### PR TITLE
Feature/consensus/add status apis

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -285,19 +285,15 @@ app.get('/get_address', (req, res, next) => {
 });
 
 app.get('/get_raw_consensus_state', (req, res) => {
-  const result = {};
-  result['consensus'] = p2pServer.consensus.state;
-  if (p2pServer.consensus.blockPool) {
-    const blockPool = p2pServer.consensus.blockPool;
-    result['block_pool'] = {
-      hashToBlockInfo: blockPool.hashToBlockInfo,
-      hashToState: Array.from(blockPool.hashToState.keys()),
-      hashToNextBlockSet: Object.keys(blockPool.hashToNextBlockSet),
-      epochToBlock: Object.keys(blockPool.epochToBlock),
-      numberToBlock: Object.keys(blockPool.numberToBlock),
-      longestNotarizedChainTips: blockPool.longestNotarizedChainTips
-    }
-  }
+  const result = p2pServer.consensus.getRawState();
+  res.status(200)
+    .set('Content-Type', 'application/json')
+    .send({code: 0, result})
+    .end();
+});
+
+app.get('/get_consensus_state', (req, res) => {
+  const result = p2pServer.consensus.getState();
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/consensus/constants.js
+++ b/consensus/constants.js
@@ -4,7 +4,8 @@ const ConsensusConsts = {
   EPOCH_MS: 1000,
   MAX_CONSENSUS_STATE_DB: 1000,
   INITIAL_NUM_VALIDATORS: 5,
-  INITIAL_STAKE: 250
+  INITIAL_STAKE: 250,
+  HEALTH_THRESHOLD_EPOCH: 600 // 600 epochs = 10 minutes
 }
 
 const ConsensusMessageTypes = {

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -768,6 +768,58 @@ class Consensus {
     this.setter = setter;
   }
 
+  /**
+   * Dumps the raw consensus and block pool's states
+   * {
+   *   consensus: {
+   *     epoch,
+   *     proposer
+   *   },
+   *   block_pool: {
+   *     hashToBlockInfo, 
+   *     hashToState,
+   *     hashToNextBlockSet,
+   *     epochToBlock,
+   *     numberToBlock,
+   *     longestNotarizedChainTips
+   *   }
+   * }
+   */
+  getRawState() {
+    const result = {};
+    result['consensus'] = this.state;
+    if (this.blockPool) {
+      result['block_pool'] = {
+        hashToBlockInfo: this.blockPool.hashToBlockInfo,
+        hashToState: Array.from(this.blockPool.hashToState.keys()),
+        hashToNextBlockSet: Object.keys(this.blockPool.hashToNextBlockSet),
+        epochToBlock: Object.keys(this.blockPool.epochToBlock),
+        numberToBlock: Object.keys(this.blockPool.numberToBlock),
+        longestNotarizedChainTips: this.blockPool.longestNotarizedChainTips
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns the basic status of consensus to see if block is being produced
+   * {
+   *   health
+   *   status
+   *   epoch
+   * }
+   */
+  getState() {
+    const lastFinalizedBlock = this.node.bc.lastBlock();
+    let health;
+    if (!lastFinalizedBlock) {
+      health = false;
+    } else {
+      health = (this.state.epoch - lastFinalizedBlock.epoch) < ConsensusConsts.HEALTH_THRESHOLD_EPOCH;
+    }
+    return { health, status: this.status, epoch: this.state.epoch };
+  }
+
   static selectProposer(seed, validators) {
     const LOG_SUFFIX = 'selectProposer';
     if (DEBUG) {

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -787,7 +787,7 @@ class Consensus {
    */
   getRawState() {
     const result = {};
-    result['consensus'] = this.state;
+    result['consensus'] = Object.assign({}, this.state, { status: this.status });
     if (this.blockPool) {
       result['block_pool'] = {
         hashToBlockInfo: this.blockPool.hashToBlockInfo,
@@ -802,7 +802,7 @@ class Consensus {
   }
 
   /**
-   * Returns the basic status of consensus to see if block is being produced
+   * Returns the basic status of consensus to see if blocks are being produced
    * {
    *   health
    *   status

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -286,12 +286,12 @@ module.exports = function getMethods(
 
     net_consensusState: function(args, done) {
       const result = p2pServer.consensus.getState();
-      done(null, addProtocolVersion( result ));
+      done(null, addProtocolVersion({ result }));
     },
 
     net_rawConsensusState: function(args, done) {
       const result = p2pServer.consensus.getRawState();
-      done(null, addProtocolVersion( result ));
+      done(null, addProtocolVersion({ result }));
     }
   };
 };

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -282,6 +282,16 @@ module.exports = function getMethods(
 
     net_getNetworkId: function(args, done) {
       done(null, addProtocolVersion({ result: NETWORK_ID }));
+    },
+
+    net_consensusState: function(args, done) {
+      const result = p2pServer.consensus.getState();
+      done(null, addProtocolVersion( result ));
+    },
+
+    net_rawConsensusState: function(args, done) {
+      const result = p2pServer.consensus.getRawState();
+      done(null, addProtocolVersion( result ));
     }
   };
 };

--- a/server/index.js
+++ b/server/index.js
@@ -204,7 +204,7 @@ class P2pServer {
         timestamp: this.node.bc.lastBlockTimestamp(),
       },
       consensusStatus: {
-        status: this.consensus.state,
+        consensus: this.consensus.getState(),
         blockPool: this.consensus.blockPool ? this.consensus.blockPool.hashToBlockInfo : {},
         longestNotarizedChainTips: this.consensus.blockPool ? this.consensus.blockPool.longestNotarizedChainTips : []
       },


### PR DESCRIPTION
Added JSON RPC APIs for consensus states
- net_consensusState
    - Returns minimal consensus state information to determine whether the blockchain is healthy (is creating and finalizing blocks) 
- net_rawConsensusState
    - Dumps the whole consensus state as well as its block pool's state

Also added the identical APIs for testing purposes in client. (/get_raw_consensus_state, /get_consensus_state)