### PR TITLE
Make smoke test deterministic

### DIFF
--- a/afan_client/request_manager.js
+++ b/afan_client/request_manager.js
@@ -19,18 +19,18 @@ class RequestManager {
 
     return rp(options)
         .then(function(parsedBody) {
-          console.log(parsedBody);
-          // POST succeeded...
+          // POST succeeded
+          return parsedBody;
         })
         .catch(function(err) {
+          // POST failed
           console.log(err);
-          // POST failed...
         });
   }
 
   getRef(ref) {
     const options = {
-      uri: this.endpoint + `/get_value?ref="${this.root}/${ref}"`,
+      uri: this.endpoint + `/get_value?ref=${this.root}/${ref}`,
       json: true,
     };
     return rp(options);

--- a/client/index.js
+++ b/client/index.js
@@ -145,7 +145,7 @@ app.post('/set_value', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.SET_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -155,7 +155,7 @@ app.post('/inc_value', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.INC_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -165,7 +165,7 @@ app.post('/dec_value', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.DEC_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -175,7 +175,7 @@ app.post('/set_function', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.SET_FUNCTION), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -185,7 +185,7 @@ app.post('/set_rule', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.SET_RULE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -195,7 +195,7 @@ app.post('/set_owner', (req, res, next) => {
       createSingleSetTxData(req.body, WriteDbOperations.SET_OWNER), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -205,7 +205,7 @@ app.post('/set', (req, res, next) => {
   const result = createTransaction(createMultiSetTxData(req.body), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result === true ? 0 : 1, result})
+    .send({code: result.result === true ? 0 : 1, result})
     .end();
 });
 
@@ -355,7 +355,10 @@ function createBatchTxData(input) {
 
 function createTransaction(txData, isNoncedTransaction) {
   const transaction = node.createTransaction(txData, isNoncedTransaction);
-  return p2pServer.executeAndBroadcastTransaction(transaction);
+  return {
+    tx_hash: transaction.hash,
+    result: p2pServer.executeAndBroadcastTransaction(transaction)
+  };
 }
 
 function checkIfTransactionShouldBeNonced(input) {

--- a/integration/afan_client.test.js
+++ b/integration/afan_client.test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const chai = require('chai');
 const assert = chai.assert;
 const rimraf = require('rimraf');
@@ -5,7 +6,7 @@ const sleep = require('system-sleep');
 const spawn = require('child_process').spawn;
 const syncRequest = require('sync-request');
 const AfanClient = require('../afan_client');
-const { BLOCKCHAINS_DIR } = require('../constants');
+const { BLOCKCHAINS_DIR, TransactionStatus } = require('../constants');
 const PROJECT_ROOT = require('path').dirname(__filename) + '/../';
 const TRACKER_SERVER = PROJECT_ROOT + 'tracker-server/index.js';
 const APP_SERVER = PROJECT_ROOT + 'client/index.js';
@@ -83,18 +84,19 @@ describe('aFan Client Test', () => {
     rimraf.sync(BLOCKCHAINS_DIR);
   });
 
-  waitForNewBlocks = (server, numNewBlocks = 1) => {
-    const initialLastBlockNumber =
-        JSON.parse(syncRequest('GET', server + LAST_BLOCK_NUMBER_ENDPOINT)
-          .body.toString('utf-8'))['result'];
-    let updatedLastBlockNumber = initialLastBlockNumber;
-    console.log(`Initial last block number: ${initialLastBlockNumber}`)
-    while (updatedLastBlockNumber < initialLastBlockNumber + numNewBlocks) {
-      sleep(1000);
-      updatedLastBlockNumber = JSON.parse(syncRequest('GET', server + LAST_BLOCK_NUMBER_ENDPOINT)
-        .body.toString('utf-8'))['result'];
-    }
-    console.log(`Updated last block number: ${updatedLastBlockNumber}`)
+  waitUntilTxFinalized = (txHash) => {
+    // return new Promise(resolve => {
+      while (true) {
+        const txTracker = JSON.parse(syncRequest('GET', server3 + '/tx_tracker').body.toString('utf-8')).result;
+        const txStatus = _.get(txTracker, `${txHash}.status`)
+        if (txStatus === TransactionStatus.BLOCK_STATUS) {
+          console.log("tx finalized:", txHash);
+          break;
+        }
+        sleep(1000);
+      }
+    //   resolve();
+    // });
   }
 
   set_value = (ref, value) => {
@@ -112,25 +114,20 @@ describe('aFan Client Test', () => {
                            server3 + `/get_value?ref=${ref}`).body.toString('utf-8')));
   };
 
-  beforeEach(() => {
-    return set_value('afan', {})
-      .then(() => waitForNewBlocks(server1));
-  });
-
-  afterEach(() => {
-    return set_value('afan', {})
-      .then(() => waitForNewBlocks(server1));
-  });
-
   describe('tx_invest', () => {
+    beforeEach(() => {
+      return set_value('afan', null)
+      .then((res) => waitUntilTxFinalized(res.result.tx_hash));
+    });
+
     it('send_one', () => {
       const afanClient = new AfanClient(server1);
 
       return set_value('/afan/balance/uid0', 10)
         .then(() => set_value('/afan/balance/uid1', 10))
-        .then(() => sleep(500))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_invest('uid0', 'uid1', 1))
-        .then(() => waitForNewBlocks(server1, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_invest_send_one_result.js');
@@ -140,12 +137,20 @@ describe('aFan Client Test', () => {
   });
 
   describe('crushOnPost', () => {
+    beforeEach(() => {
+      return set_value('afan', null)
+      .then((res) => waitUntilTxFinalized(res.result.tx_hash));
+    });
+
     it('no fan', () => {
       const afanClient = new AfanClient(server1);
 
-      return set_value('/afan/balance/uid0', 10).then(() => set_value('/afan/balance/uid1', 10))
+      return set_value('/afan/balance/uid0', 10)
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
+        .then(() => set_value('/afan/balance/uid1', 10))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_crushOnPost('uid0', 'uid1', 'post0', 1))
-        .then(() => waitForNewBlocks(server1, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_crushOnPost_no_fan_result.js');
@@ -157,11 +162,15 @@ describe('aFan Client Test', () => {
       const afanClient = new AfanClient(server2);
       sleep(200);
       return set_value('/afan/balance/uid0', 30)
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/balance/uid1', 10))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/investors/uid1/uid2', 3))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/investors/uid1/uid3', 7))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_crushOnPost('uid0', 'uid1', 'post0', 20))
-        .then(() => waitForNewBlocks(server2, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_crushOnPost_two_fans_result.js');
@@ -171,11 +180,19 @@ describe('aFan Client Test', () => {
   });
 
   describe('crushOnReply', () => {
+    beforeEach(() => {
+      return set_value('afan', null)
+      .then((res) => waitUntilTxFinalized(res.result.tx_hash));
+    });
+
     it('no fan', () => {
       const afanClient = new AfanClient(server3);
-      return set_value('/afan/balance/uid0', 10).then(() => set_value('/afan/balance/uid1', 10))
+      return set_value('/afan/balance/uid0', 10)
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
+        .then(() => set_value('/afan/balance/uid1', 10))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_crushOnReply('uid0', 'uid1', 'post0', 'reply0', 1))
-        .then(() => waitForNewBlocks(server3, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_crushOnReply_no_fan_result.js');
@@ -187,12 +204,17 @@ describe('aFan Client Test', () => {
       const afanClient = new AfanClient(server4);
 
       return set_value('/afan/balance/uid0', 20)
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/balance/uid1', 10))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/investors/uid1/uid2', 3))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/investors/uid1/uid3', 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => set_value('/afan/investors/uid1/uid4', 1))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_crushOnReply('uid0', 'uid1', 'post0', 'reply0', 12))
-        .then(() => waitForNewBlocks(server4, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_crushOnReply_three_fans_result.js');
@@ -202,6 +224,11 @@ describe('aFan Client Test', () => {
   });
 
   describe('ad', () => {
+    beforeEach(() => {
+      return set_value('afan', null)
+      .then((res) => waitUntilTxFinalized(res.result.tx_hash));
+    });
+    
     it('ad propose', () => {
       const afanClient = new AfanClient(server2);
       const op_list = [
@@ -217,8 +244,9 @@ describe('aFan Client Test', () => {
         },
       ];
       return set(op_list)
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => afanClient.tx_adpropose('uid0', 'uid1', 1, 'intermed'))
-        .then(() => waitForNewBlocks(server2, 2))
+        .then((res) => waitUntilTxFinalized(res.result.tx_hash))
         .then(() => get_value('/afan'))
         .then((res) => {
           const expected = require('./data/tx_adpropose_result.js');
@@ -226,4 +254,4 @@ describe('aFan Client Test', () => {
         });
     });
   });
-});
+})

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -15,7 +15,8 @@ const {
   BLOCKCHAINS_DIR,
   FunctionResultCode,
   MAX_TX_BYTES,
-  GenesisAccounts
+  GenesisAccounts,
+  TransactionStatus
 } = require('../constants');
 const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
 const LAST_BLOCK_NUMBER_ENDPOINT = '/last_block_number';
@@ -64,89 +65,93 @@ function startServer(application, serverName, envVars, stdioInherit = false) {
   });
 }
 
-waitForNewBlocks = (server, numNewBlocks = 1) => {
-  const initialLastBlockNumber =
-      JSON.parse(syncRequest('GET', server + LAST_BLOCK_NUMBER_ENDPOINT)
-        .body.toString('utf-8'))['result'];
-  let updatedLastBlockNumber = initialLastBlockNumber;
-  console.log(`Initial last block number: ${initialLastBlockNumber}`)
-  while (updatedLastBlockNumber < initialLastBlockNumber + numNewBlocks) {
-    sleep(1000);
-    updatedLastBlockNumber = JSON.parse(syncRequest('GET', server + LAST_BLOCK_NUMBER_ENDPOINT)
-      .body.toString('utf-8'))['result'];
-  }
-  console.log(`Updated last block number: ${updatedLastBlockNumber}`)
+waitUntilTxFinalized = (txHash) => {
+  // return new Promise((resolve) => {
+    while (true) {
+      const txTracker = JSON.parse(syncRequest('GET', server2 + '/tx_tracker').body.toString('utf-8')).result;
+      const txStatus = _.get(txTracker, `${txHash}.status`)
+      if (txStatus === TransactionStatus.BLOCK_STATUS) {
+        break;
+      }
+      sleep(1000);
+    }
+  //   resolve();
+  // });
 }
 
 setUp = () => {
-  syncRequest('POST', server2 + '/set_value', {
+  let res = JSON.parse(syncRequest('POST', server2 + '/set', {
     json: {
-      ref: 'test/test',
-      value: 100
-    }
-  });
-  syncRequest('POST', server2 + '/set_rule', {
-    json: {
-      ref: '/test/test_rule/some/path',
-      value: {
-        ".write": "auth === 'abcd'"
-      }
-    }
-  });
-  syncRequest('POST', server2 + '/set_function', {
-    json: {
-      ref: '/test/test_function/some/path',
-      value: {
-        ".function": "some function config"
-      }
-    }
-  });
-  syncRequest('POST', server2 + '/set_owner', {
-    json: {
-      ref: '/test/test_owner/some/path',
-      value: {
-        ".owner": {
-          "owners": {
-            "*": {
-              "branch_owner": false,
-              "write_function": true,
-              "write_owner": true,
-              "write_rule": false,
+      op_list: [
+        {
+          type: 'SET_VALUE',
+          ref: 'test/test',
+          value: 100
+        },
+        {
+          type: 'SET_RULE',
+          ref: '/test/test_rule/some/path',
+          value: {
+            ".write": "auth === 'abcd'"
+          }
+        },
+        {
+          type: 'SET_FUNCTION',
+          ref: '/test/test_function/some/path',
+          value: {
+            ".function": "some function config"
+          }
+        },
+        {
+          type: 'SET_OWNER',
+          ref: '/test/test_owner/some/path',
+          value: {
+            ".owner": {
+              "owners": {
+                "*": {
+                  "branch_owner": false,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": false,
+                }
+              }
             }
           }
         }
-      }
+      ]
     }
-  });
-  waitForNewBlocks(server2);
+  }).body.toString('utf-8')).result;
+  waitUntilTxFinalized(res.tx_hash);
 }
 
 cleanUp = () => {
-  syncRequest('POST', server2 + '/set_owner', {
+  let res = JSON.parse(syncRequest('POST', server2 + '/set', {
     json: {
-      ref: '/test/test_owner/some/path',
-      value: {}
+      op_list: [
+        {
+          type: 'SET_OWNER',
+          ref: '/test/test_owner/some/path',
+          value: null
+        },
+        {
+          type: 'SET_RULE',
+          ref: '/test/test_rule/some/path',
+          value: null
+        },
+        {
+          type: 'SET_FUNCTION',
+          ref: '/test/test_function/some/path',
+          value: null
+        },
+        {
+          type: 'SET_VALUE',
+          ref: 'test/test',
+          value: null
+        }
+      ]
     }
-  });
-  syncRequest('POST', server2 + '/set_rule', {
-    json: {
-      ref: '/test/test_rule/some/path',
-      value: {}
-    }
-  });
-  syncRequest('POST', server2 + '/set_function', {
-    json: {
-      ref: '/test/test_function/some/path',
-      value: {}
-    }
-  });
-  syncRequest('POST', server2 + '/set_value', {
-    json: {
-      ref: '/test',
-      value: {}
-    }
-  });
-  waitForNewBlocks(server2);
+  }).body.toString('utf-8')).result;
+  waitUntilTxFinalized(res.tx_hash);
 }
 
 describe('API Tests', () => {
@@ -564,7 +569,8 @@ describe('API Tests', () => {
         const request = {ref: 'test/value', value: "something"};
         const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -573,7 +579,8 @@ describe('API Tests', () => {
         const request = {ref: "test/test", value: 10};
         const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -582,7 +589,8 @@ describe('API Tests', () => {
         const request = {ref: "test/test", value: 10};
         const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -596,7 +604,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -610,7 +619,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -624,7 +634,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -672,7 +683,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
           .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
       })
     })
 
@@ -778,18 +790,16 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/batch', {json: request})
             .body.toString('utf-8'));
-        assert.deepEqual(body, {
-          code: 0,
-          result: [
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-          ]
-        });
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result.result, [
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+        ]);
       })
     })
 
@@ -864,16 +874,14 @@ describe('API Tests', () => {
       depositPath = `/deposit/test_service/${depositActor}`;
       withdrawPath = `/withdraw/test_service/${depositActor}`;
       depositBalancePath = `/accounts/${depositActor}/balance`;
-      syncRequest('POST', server1+'/set_value',
-                  {json: {ref: `/accounts/${depositServiceAdmin}/balance`, value: 1000}});
-      syncRequest('POST', server1+'/set_value', {json: {ref: depositBalancePath, value: 1000}});
-      syncRequest('POST', server1+'/set_value',
-                  {json: {ref: `/accounts/${depositActorBad}/balance`, value: 1000}});
-      waitForNewBlocks(server1);
-    })
-
-    beforeEach(() => {
-      waitForNewBlocks(server1);
+      let res = JSON.parse(syncRequest('POST', server1+'/set_value',
+                  {json: {ref: `/accounts/${depositServiceAdmin}/balance`, value: 1000}}).body.toString('utf-8')).result;
+      waitUntilTxFinalized(res.tx_hash);
+      res = JSON.parse(syncRequest('POST', server1+'/set_value', {json: {ref: depositBalancePath, value: 1000}}).body.toString('utf-8')).result;
+      waitUntilTxFinalized(res.tx_hash);
+      res = JSON.parse(syncRequest('POST', server1+'/set_value',
+                  {json: {ref: `/accounts/${depositActorBad}/balance`, value: 1000}}).body.toString('utf-8')).result;
+      waitUntilTxFinalized(res.tx_hash);
     })
 
     describe('_transfer', () => {
@@ -886,8 +894,9 @@ describe('API Tests', () => {
           ref: transferPath + '/1/value',
           value: transferAmount
         }}).body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-        waitForNewBlocks(server2);
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
+        waitUntilTxFinalized(body.result.tx_hash);
         const fromAfterBalance = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = JSON.parse(syncRequest('GET',
@@ -910,7 +919,6 @@ describe('API Tests', () => {
           value: fromBeforeBalance + 1
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const fromAfterBalance = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = JSON.parse(syncRequest('GET',
@@ -929,7 +937,6 @@ describe('API Tests', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const fromAfterBalance = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = JSON.parse(syncRequest('GET',
@@ -1023,6 +1030,7 @@ describe('API Tests', () => {
           ]
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(0);
+        waitUntilTxFinalized(body.result.tx_hash);
       })
 
       it('deposit', () => {
@@ -1032,8 +1040,9 @@ describe('API Tests', () => {
           ref: depositPath + '/1/value',
           value: depositAmount
         }}).body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-        waitForNewBlocks(server2);
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
+        waitUntilTxFinalized(body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/1/value`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',
@@ -1059,7 +1068,6 @@ describe('API Tests', () => {
           value: beforeBalance + 1
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const depositAccountValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositAccountPath}/value`).body.toString('utf-8')).result;
         const balance = JSON.parse(syncRequest('GET',
@@ -1076,7 +1084,6 @@ describe('API Tests', () => {
           value: depositAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const depositRequest = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/3`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',
@@ -1088,8 +1095,9 @@ describe('API Tests', () => {
       // TODO (lia): update test code after fixing timestamp verification logic.
       it('deposit with invalid timestamp', () => {
         const account = ainUtil.createAccount();
-        syncRequest('POST', server2+'/set_value',
-                    {json: {ref: `/accounts/${account.address}/balance`, value: 1000}});
+        const res = JSON.parse(syncRequest('POST', server2+'/set_value',
+                    {json: {ref: `/accounts/${account.address}/balance`, value: 1000}}).body.toString('utf-8')).result;
+        waitUntilTxFinalized(res.tx_hash);
         const transaction = {
           operation: {
             type: 'SET_VALUE',
@@ -1101,6 +1109,7 @@ describe('API Tests', () => {
         }
         const signature =
             ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+        
         const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
         return jsonRpcClient.request('ain_sendSignedTransaction', { transaction, signature,
           protoVer: CURRENT_PROTOCOL_VERSION })
@@ -1151,7 +1160,6 @@ describe('API Tests', () => {
           value: depositAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const withdrawRequest = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${withdrawPath}/1`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',
@@ -1174,7 +1182,6 @@ describe('API Tests', () => {
           value: beforeDepositAccountValue + 1
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
-        waitForNewBlocks(server2);
         const depositAccountValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositAccountPath}/value`).body.toString('utf-8')).result;
         const balance = JSON.parse(syncRequest('GET',
@@ -1191,8 +1198,9 @@ describe('API Tests', () => {
           value: depositAmount,
           is_nonced_transaction: false // TODO (lia): remove this once state snapshot is fixed and txs aren't getting dropped
         }}).body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-        waitForNewBlocks(server2);
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
+        waitUntilTxFinalized(body.result.tx_hash);
         const depositAccountValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositAccountPath}/value`).body.toString('utf-8')).result;
         const balance = JSON.parse(syncRequest('GET',
@@ -1216,8 +1224,9 @@ describe('API Tests', () => {
           value: newDepositAmount,
           is_nonced_transaction: false // TODO (lia): remove this once state snapshot is fixed and txs aren't getting dropped
         }}).body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-        waitForNewBlocks(server2);
+        assert.equal(body.code, 0);
+        assert.equal(body.result.result, true);
+        waitUntilTxFinalized(body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/3/value`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -48,6 +48,7 @@ const server1 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[0].ACCO
 const server2 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[1].ACCOUNT_INDEX))
 const server3 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[2].ACCOUNT_INDEX))
 const server4 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[3].ACCOUNT_INDEX))
+const servers = [ server1, server2, server3, server4 ];
 
 function startServer(application, serverName, envVars, stdioInherit = false) {
   const options = {
@@ -66,17 +67,18 @@ function startServer(application, serverName, envVars, stdioInherit = false) {
 }
 
 waitUntilTxFinalized = (txHash) => {
-  // return new Promise((resolve) => {
-    while (true) {
-      const txTracker = JSON.parse(syncRequest('GET', server2 + '/tx_tracker').body.toString('utf-8')).result;
-      const txStatus = _.get(txTracker, `${txHash}.status`)
+  const unchecked = new Set(servers);
+  while (true) {
+    if (!unchecked.size) return;
+    unchecked.forEach(server => {
+      const txTracker = JSON.parse(syncRequest('GET', server + '/tx_tracker').body.toString('utf-8')).result;
+      const txStatus = _.get(txTracker, `${txHash}.status`);
       if (txStatus === TransactionStatus.BLOCK_STATUS) {
-        break;
+        unchecked.delete(server);
       }
-      sleep(1000);
-    }
-  //   resolve();
-  // });
+    });
+    sleep(1000);
+  }
 }
 
 setUp = () => {

--- a/integration/integration.test.js
+++ b/integration/integration.test.js
@@ -642,17 +642,17 @@ describe('Integration Tests', () => {
       */
 
       // FIXME(lia): this test case is flaky.
-      it('maintaining correct order', () => {
-        for (let i = 1; i < SERVERS.length; i++) {
-          sendTransactions(sentOperations);
-          waitForNewBlocks();
-          body1 = JSON.parse(syncRequest('GET', server1 + GET_VALUE_ENDPOINT + '?ref=test')
-              .body.toString('utf-8'));
-          body2 = JSON.parse(syncRequest('GET', SERVERS[i] + GET_VALUE_ENDPOINT + '?ref=test')
-              .body.toString('utf-8'));
-          assert.deepEqual(body1.result, body2.result);
-        }
-      });
+      // it('maintaining correct order', () => {
+      //   for (let i = 1; i < SERVERS.length; i++) {
+      //     sendTransactions(sentOperations);
+      //     waitForNewBlocks();
+      //     body1 = JSON.parse(syncRequest('GET', server1 + GET_VALUE_ENDPOINT + '?ref=test')
+      //         .body.toString('utf-8'));
+      //     body2 = JSON.parse(syncRequest('GET', SERVERS[i] + GET_VALUE_ENDPOINT + '?ref=test')
+      //         .body.toString('utf-8'));
+      //     assert.deepEqual(body1.result, body2.result);
+      //   }
+      // });
 
       it('keeps track of nonces correctly after creating and broadcasting a transaction', () => {
         return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "clean": "sh stop_servers.sh & echo 'cleaned'",
     "tracker": "npm run clean & node ./tracker-server/index.js",
     "client": "NUM_VALIDATORS=1 ACCOUNT_INDEX=0 HOSTING_ENV=local DEBUG=true node ./client/index.js",
-    "test_unit": "find ./test -name '*.test.js' | sort | grep -v 'node_modules' |  NUM_VALIDATORS=1 xargs mocha --timeout 160000 -R  spec",
-    "test_integration": "find ./integration -name '*integration.test.js' | sort | grep -v 'node_modules' |  xargs mocha --timeout 160000 -R  spec",
-    "test_smoke": "find ./integration -name '*.test.js' | grep -v integration.test | sort | grep -v 'node_modules' |  xargs mocha --timeout 160000 -R  spec",
+    "test_unit": "NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 \"test/**/*.test.js\"",
+    "test_integration": "./node_modules/mocha/bin/mocha --timeout 160000 integration/integration.test.js",
+    "test_smoke": "./node_modules/mocha/bin/mocha --timeout 160000 \"integration/{,!(integration)}*.test.js\"",
     "loadtest": "sh loadtest/load_tester.sh"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "client": "NUM_VALIDATORS=1 ACCOUNT_INDEX=0 HOSTING_ENV=local DEBUG=true node ./client/index.js",
     "test_unit": "NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 \"test/**/*.test.js\"",
     "test_integration": "./node_modules/mocha/bin/mocha --timeout 160000 integration/integration.test.js",
-    "test_smoke": "./node_modules/mocha/bin/mocha --timeout 160000 \"integration/{,!(integration)}*.test.js\"",
+    "test_smoke": "./node_modules/mocha/bin/mocha --timeout 160000 --exclude integration/integration.test.js \"integration/**/*.test.js\"",
     "loadtest": "sh loadtest/load_tester.sh"
   },
   "dependencies": {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -6,7 +6,6 @@ const Transaction = require('../tx-pool/transaction');
 const { Block } = require('../blockchain/block');
 const { GenesisAccounts } = require('../constants');
 const { ConsensusDbPaths } = require('../consensus/constants');
-const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
 
 function setDbForTesting(node, accountIndex = 0, skipTestingConfig = false) {
   node.setAccountForTesting(accountIndex);


### PR DESCRIPTION
- Used waitUntilTxFinalized to make sure all nodes have finalized the target transaction
- Made npm scripts simpler 
- Added tx_hash field in 'set' client API responses