### PR TITLE
Feature/platfowner/valid path

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -92,17 +92,17 @@ class DB {
     return node;
   }
 
-  writeDatabase(fullPath, value) {
-    const valueTree = jsObjectToStateTree(value);
+  writeDatabase(fullPath, stateObj) {
+    const stateTree = jsObjectToStateTree(stateObj);
     if (fullPath.length === 0) {
-      this.dbRoot = valueTree;
+      this.dbRoot = stateTree;
     } else {
       const pathToParent = fullPath.slice().splice(0, fullPath.length - 1);
       const label = fullPath[fullPath.length - 1];
       const parent = this.getRefForWriting(pathToParent);
-      parent.setChild(label, valueTree);
+      parent.setChild(label, stateTree);
     }
-    if (DB.isEmptyNode(valueTree)) {
+    if (DB.isEmptyNode(stateTree)) {
       this.removeEmptyNodes(fullPath);
     }
   }
@@ -133,8 +133,8 @@ class DB {
   }
 
   readDatabase(fullPath) {
-    const node = this.getRefForReading(fullPath);
-    return stateTreeToJsObject(node);
+    const stateNode = this.getRefForReading(fullPath);
+    return stateTreeToJsObject(stateNode);
   }
 
   getValue(valuePath) {
@@ -214,7 +214,6 @@ class DB {
     return resultList;
   }
 
-  // TODO(seo): Add dbPath validity check (e.g. '$', '.', etc).
   // TODO(seo): Define error code explicitly.
   // TODO(seo): Consider making set operation and native function run tightly bound, i.e., revert
   //            the former if the latter fails.

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -14,8 +14,9 @@ function hasAllowedPattern(label) {
 }
 
 function isValidStateLabel(label) {
-  if (!ChainUtil.isString(label) || label === '' ||
-      hasReservedChar(label) && !hasAllowedPattern(label)) {
+  if (!ChainUtil.isString(label) ||
+      label === '' ||
+      (hasReservedChar(label) && !hasAllowedPattern(label))) {
     return false;
   }
   return true;

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -925,6 +925,30 @@ describe("DB operations", () => {
         "error_message": "Invalid object for states: /array"
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'.': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /."
+      });
+      expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'$': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /$"
+      });
+      expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'*a': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /*a"
+      });
+      expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'a*': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /a*"
+      });
+      expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
     })
 
     it("when writing with invalid path", () => {
@@ -932,13 +956,17 @@ describe("DB operations", () => {
         "code": 7,
         "error_message": "Invalid path: /test/new/unchartered/nested/."
       });
-      assert.deepEqual(node.db.setValue("test/new/unchartered/nested/*", 12345), {
-        "code": 7,
-        "error_message": "Invalid path: /test/new/unchartered/nested/*"
-      });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/$", 12345), {
         "code": 7,
         "error_message": "Invalid path: /test/new/unchartered/nested/$"
+      });
+      assert.deepEqual(node.db.setValue("test/new/unchartered/nested/a*", 12345), {
+        "code": 7,
+        "error_message": "Invalid path: /test/new/unchartered/nested/a*"
+      });
+      assert.deepEqual(node.db.setValue("test/new/unchartered/nested/*a", 12345), {
+        "code": 7,
+        "error_message": "Invalid path: /test/new/unchartered/nested/*a"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/#", 12345), {
         "code": 7,
@@ -1020,16 +1048,30 @@ describe("DB operations", () => {
   })
 
   describe("setFunction operations", () => {
-    it("when overwriting existing function config", () => {
+    it("when overwriting existing function config with simple path", () => {
       const functionConfig = {".function": "other function config"};
       expect(node.db.setFunction("/test/test_function/some/path", functionConfig)).to.equal(true)
       assert.deepEqual(node.db.getFunction("/test/test_function/some/path"), functionConfig)
+    })
+
+    it("when writing with variable path", () => {
+      const functionConfig = {".function": "other function config"};
+      expect(node.db.setFunction("/test/test_function/some/$variable/path", functionConfig))
+          .to.equal(true)
+      assert.deepEqual(
+          node.db.getFunction("/test/test_function/some/$variable/path"), functionConfig)
     })
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setFunction("/test/test_function/some/path2", {array: []}), {
         "code": 6,
         "error_message": "Invalid object for states: /array"
+      });
+      expect(node.db.getFunction("test/new2/unchartered/nested/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setFunction("/test/test_function/some/path2", {'.': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /."
       });
       expect(node.db.getFunction("test/new2/unchartered/nested/path2")).to.equal(null)
     })
@@ -1043,16 +1085,28 @@ describe("DB operations", () => {
   })
 
   describe("setRule operations", () => {
-    it("when overwriting existing rule config", () => {
+    it("when overwriting existing rule config with simple path", () => {
       const ruleConfig = {".write": "other rule config"};
       expect(node.db.setRule("/test/test_rule/some/path", ruleConfig)).to.equal(true)
       assert.deepEqual(node.db.getRule("/test/test_rule/some/path"), ruleConfig)
+    })
+
+    it("when writing with variable path", () => {
+      const ruleConfig = {".write": "other rule config"};
+      expect(node.db.setRule("/test/test_rule/some/$variable/path", ruleConfig)).to.equal(true)
+      assert.deepEqual(node.db.getRule("/test/test_rule/some/$variable/path"), ruleConfig)
     })
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setRule("/test/test_rule/some/path2", {array: []}), {
         "code": 6,
         "error_message": "Invalid object for states: /array"
+      });
+      expect(node.db.getRule("/test/test_rule/some/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setRule("/test/test_rule/some/path2", {'.': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /."
       });
       expect(node.db.getRule("/test/test_rule/some/path2")).to.equal(null)
     })
@@ -1076,6 +1130,12 @@ describe("DB operations", () => {
       assert.deepEqual(node.db.setOwner("/test/test_owner/some/path2", {array: []}), {
         "code": 6,
         "error_message": "Invalid object for states: /array"
+      });
+      expect(node.db.getOwner("/test/test_owner/some/path2")).to.equal(null)
+
+      assert.deepEqual(node.db.setOwner("/test/test_owner/some/path2", {'.': 'x'}), {
+        "code": 6,
+        "error_message": "Invalid object for states: /."
       });
       expect(node.db.getOwner("/test/test_owner/some/path2")).to.equal(null)
     })
@@ -1590,6 +1650,8 @@ describe("DB rule config", () => {
   let node1, node2, dbValues;
 
   beforeEach(() => {
+    let result;
+
     rimraf.sync(BLOCKCHAINS_DIR);
 
     node1 = new Node();
@@ -1599,7 +1661,9 @@ describe("DB rule config", () => {
     dbValues = {
       "comcom": "unreadable value",
       "unspecified": {
-        "test/nested": "readable"
+        "test": {
+          "nested": "readable"
+        }
       },
       "ai" : "readable",
       "billing_keys": {
@@ -1623,8 +1687,10 @@ describe("DB rule config", () => {
     dbValues["second_users"][node2.account.address][node2.account.address] = "i can write";
     dbValues["second_users"][node1.account.address]["something_else"] = "i can write";
 
-    node1.db.setValue("test", dbValues);
-    node2.db.setValue("test", dbValues);
+    result = node1.db.setValue("test", dbValues);
+    console.log(`Result of setValue(): ${JSON.stringify(result, null, 2)}`);
+    result = node2.db.setValue("test", dbValues);
+    console.log(`Result of setValue(): ${JSON.stringify(result, null, 2)}`);
   })
 
   afterEach(() => {


### PR DESCRIPTION
Summary:
- Apply more precise path validation logic (Allow: '.abc', '$abc', '*', Not allow: '.', '$', '*abc', 'abc*').
- Apply path validation to object-to-write.

#50 #51 