### PR TITLE
Feature/sharding/parent chain initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ cd ..
 ```
 node tracker-server/index.js
 ```
+You can override default port numbering system by setting `PORT` and `P2P_PORT` environment variables.
 
 #### On Google Coud Platform (GCP)
 
@@ -96,6 +97,7 @@ NUM_VALIDATORS=4 ACCOUNT_INDEX=2 HOSTING_ENV=local DEBUG=false node client/index
 NUM_VALIDATORS=4 ACCOUNT_INDEX=3 HOSTING_ENV=local DEBUG=false node client/index.js 
 ```
 The environment variable `NUM_VALIDATORS` has default value `5`.
+You can override default port numbering system by setting `PORT` and `P2P_PORT` environment variables.
 Before starting node jobs, remove existing blockchain files and logs if necessary:
 ```
 rm -rf blockchain/blockchains logger/logs

--- a/blockchain/afan_shard/genesis_sharding.json
+++ b/blockchain/afan_shard/genesis_sharding.json
@@ -1,6 +1,6 @@
 {
   "sharding_protocol": "POA",
   "sharding_path": "/apps/afan",
-  "parent_chain_poc": "node.ainetwork.ai",
+  "parent_chain_poc": "http://127.0.0.1:8081",
   "reporting_period": 5
 }

--- a/blockchain/genesis_functions.json
+++ b/blockchain/genesis_functions.json
@@ -13,16 +13,6 @@
       }
     }
   },
-  "sharding": {
-    "shard": {
-      "$sharding_path": {
-        ".function": {
-          "function_type": "NATIVE",
-          "function_id": "_initializeShard"
-        }
-      }
-    }
-  },
   "transfer": {
     "$from": {
       "$to": {

--- a/blockchain/genesis_functions.json
+++ b/blockchain/genesis_functions.json
@@ -13,6 +13,16 @@
       }
     }
   },
+  "sharding": {
+    "shard": {
+      "$sharding_path": {
+        ".function": {
+          "function_type": "NATIVE",
+          "function_id": "_initializeShard"
+        }
+      }
+    }
+  },
   "transfer": {
     "$from": {
       "$to": {

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -56,6 +56,14 @@
       }
     }
   },
+  "sharding": {
+    "shard": {
+      ".write": false,
+      "$sharding_path": {
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardingProtocol(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
+      }
+    }
+  },
   "transfer": {
     "$from": {
       "$to": {

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardingProtocol(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'branch_owner', auth) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth) && evalRule(newData.sharding_path, null, newData.shard_reporter, currentTime)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth) && evalRule(newData.sharding_path, null, newData.shard_reporter, currentTime)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'branch_owner', auth) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth) && evalRule(newData.sharding_path, null, auth, currentTime)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'branch_owner', auth) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth) && evalRule(newData.sharding_path, null, newData.shard_reporter, currentTime)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && evalOwner(data.sharding_path, 'write_owner', auth) && evalOwner(data.sharding_path, 'write_rule', auth) && evalOwner(data.sharding_path, 'write_function', auth) && evalRule(data.sharding_path, null, data.shard_reporter, currentTime) && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'branch_owner', auth) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth) && evalRule(newData.sharding_path, null, auth, currentTime)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && evalOwner(data.sharding_path, 'write_owner', auth) && evalOwner(data.sharding_path, 'write_rule', auth) && evalOwner(data.sharding_path, 'write_function', auth) && evalRule(data.sharding_path, null, data.shard_reporter, currentTime) && newData === null)"
       }
     }
   },

--- a/chain-util.js
+++ b/chain-util.js
@@ -57,8 +57,8 @@ class ChainUtil {
     return ruleUtil.isValAddr(value);
   }
 
-  static isValShardingProtocol(value) {
-    return ruleUtil.isValShardingProtocol(value);
+  static isValShardProto(value) {
+    return ruleUtil.isValShardProto(value);
   }
 
   static numberOrZero(num) {

--- a/chain-util.js
+++ b/chain-util.js
@@ -57,6 +57,7 @@ class ChainUtil {
     return ruleUtil.isValAddr(value);
   }
 
+  // TODO(lia): normalize addresses in user inputs using this function.
   static toCksumAddr(value) {
     return ruleUtil.toCksumAddr(value);
   }

--- a/chain-util.js
+++ b/chain-util.js
@@ -57,6 +57,10 @@ class ChainUtil {
     return ruleUtil.isValAddr(value);
   }
 
+  static toCksumAddr(value) {
+    return ruleUtil.toCksumAddr(value);
+  }
+
   static isValShardProto(value) {
     return ruleUtil.isValShardProto(value);
   }

--- a/chain-util.js
+++ b/chain-util.js
@@ -53,6 +53,14 @@ class ChainUtil {
     return ruleUtil.isEmptyNode(value);
   }
 
+  static isValAddr(value) {
+    return ruleUtil.isValAddr(value);
+  }
+
+  static isValShardingProtocol(value) {
+    return ruleUtil.isValShardingProtocol(value);
+  }
+
   static numberOrZero(num) {
     return ChainUtil.isNumber(num) ? num : 0;
   }

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -647,6 +647,9 @@ class Consensus {
 
   getCatchUpInfo() {
     let res = [];
+    if (!this.blockPool) {
+      return res;
+    }
     this.blockPool.longestNotarizedChainTips.forEach(chainTip => {
       const chain = this.blockPool.getExtendingChain(chainTip, true);
       res = _.unionWith(res, chain, (a, b) => _.get(a, 'block.hash') === _.get(b, 'block.hash'));

--- a/constants.js
+++ b/constants.js
@@ -23,8 +23,8 @@ const NETWORK_ID = process.env.NETWORK_ID || 'Testnet';
 const HOSTING_ENV = process.env.HOSTING_ENV || 'default';
 const ACCOUNT_INDEX = process.env.ACCOUNT_INDEX || null;
 const TRACKER_WS_ADDR = process.env.TRACKER_WS_ADDR || 'ws://localhost:5000';
-const PORT = getPortNumber(8080, process.env.PORT_BASE || 8081);
-const P2P_PORT = getPortNumber(5000, process.env.P2P_PORT_BASE || 5001);
+const PORT = process.env.PORT || getPortNumber(8080, 8081);
+const P2P_PORT = process.env.P2P_PORT || getPortNumber(5000, 5001);
 const HASH_DELIMITER = '#';
 
 function getPortNumber(defaultValue, baseValue) {

--- a/constants.js
+++ b/constants.js
@@ -169,8 +169,8 @@ const NativeFunctionIds = {
   DEPOSIT: '_deposit',
   TRANSFER: '_transfer',
   WITHDRAW: '_withdraw',
-  SHARD_INIT: '_initializeShard',
-  SHARD_REPORT: '_reportShardProofHash',
+  INIT_SHARD: '_initializeShard',
+  REPORT_SHARD: '_reportShardProofHash',
 };
 
 /**

--- a/constants.js
+++ b/constants.js
@@ -169,7 +169,6 @@ const NativeFunctionIds = {
   DEPOSIT: '_deposit',
   TRANSFER: '_transfer',
   WITHDRAW: '_withdraw',
-  INIT_SHARD: '_initializeShard',
   UPDATE_LATEST_SHARD_REPORT: '_updateLatestShardReport',
 };
 

--- a/constants.js
+++ b/constants.js
@@ -170,7 +170,7 @@ const NativeFunctionIds = {
   TRANSFER: '_transfer',
   WITHDRAW: '_withdraw',
   INIT_SHARD: '_initializeShard',
-  REPORT_SHARD: '_reportShardProofHash',
+  UPDATE_LATEST_SHARD_REPORT: '_updateLatestShardReport',
 };
 
 /**

--- a/constants.js
+++ b/constants.js
@@ -23,13 +23,13 @@ const NETWORK_ID = process.env.NETWORK_ID || 'Testnet';
 const HOSTING_ENV = process.env.HOSTING_ENV || 'default';
 const ACCOUNT_INDEX = process.env.ACCOUNT_INDEX || null;
 const TRACKER_WS_ADDR = process.env.TRACKER_WS_ADDR || 'ws://localhost:5000';
-const PORT = getPortNumber(8080, 8081);
-const P2P_PORT = getPortNumber(5000, 5001);
+const PORT = getPortNumber(8080, process.env.PORT_BASE || 8081);
+const P2P_PORT = getPortNumber(5000, process.env.P2P_PORT_BASE || 5001);
 const HASH_DELIMITER = '#';
 
 function getPortNumber(defaultValue, baseValue) {
   if (HOSTING_ENV == 'local') {
-    return baseValue + (ACCOUNT_INDEX !== null ? Number(ACCOUNT_INDEX) : 0);
+    return Number(baseValue) + (ACCOUNT_INDEX !== null ? Number(ACCOUNT_INDEX) : 0);
   }
   return defaultValue;
 }
@@ -89,6 +89,9 @@ const PredefinedDbPaths = {
   // Sharding
   SHARDING: 'sharding',
   SHARDING_CONFIG: 'config',
+  SHARDING_SHARD: 'shard',
+  SHARDING_PROOF_HASH: 'proof_hash',
+  SHARDING_LATEST: 'latest'
 };
 
 /**
@@ -166,6 +169,8 @@ const NativeFunctionIds = {
   DEPOSIT: '_deposit',
   TRANSFER: '_transfer',
   WITHDRAW: '_withdraw',
+  SHARD_INIT: '_initializeShard',
+  SHARD_REPORT: '_reportShardProofHash',
 };
 
 /**

--- a/db/functions.js
+++ b/db/functions.js
@@ -159,48 +159,6 @@ class Functions {
     }
   }
 
-  // _initializeShard(value, context) {
-  //   if (!Functions.isValidShardingConfig(value)) {
-  //     // Shard owner trying to remove the shard
-  //     // TODO(lia): support modification of the shard config (update owners, rules, functions, values)
-  //     return;
-  //   }
-  //   const shardingPath = ChainUtil.parsePath(ainUtil.decode(context.params.sharding_path));
-  //   if (ChainUtil.formatPath(shardingPath) !== value[ShardingProperties.SHARDING_PATH]) {
-  //     return;
-  //   }
-  //   const shardOwner = value[ShardingProperties.SHARD_OWNER];
-  //   const shardReporter = value[ShardingProperties.SHARD_REPORTER];
-  //   // Set owners
-  //   this.db.writeDatabase(this._getFullOwnerPath(shardingPath), {
-  //     [OwnerProperties.OWNER]: {
-  //       [OwnerProperties.OWNERS]: {
-  //         [shardOwner]: buildOwnerPermissions(false, true, true, true),
-  //         [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
-  //       }
-  //     }
-  //   });
-  //   // Set rules
-  //   // TODO(lia): make this rule tighter (e.g. only allow writing at /$sharding_path/$block_number, values should be strings prefixed with '0x', and cannot write at /$sharding_path/latest)
-  //   this.db.writeDatabase(this._getFullRulePath(shardingPath), {
-  //     [RuleProperties.WRITE]: `auth === '${shardReporter}'`,
-  //   });
-  //   // Reset functions
-  //   this.db.writeDatabase(this._getFullFunctionPath(shardingPath), null);
-  //   // Reset values
-  //   this.db.writeDatabase(this._getFullValuePath(shardingPath), null);
-  //   // Add a native function for shard proof hash reporting
-  //   this.db.writeDatabase(
-  //     this._getFullFunctionPath([...shardingPath, '$block_number', PredefinedDbPaths.SHARDING_PROOF_HASH]),
-  //     {
-  //       [FunctionProperties.FUNCTION]: {
-  //         [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
-  //         [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
-  //       }
-  //     }
-  //   );
-  // }
-
   static isValidShardingConfig(shardingConfig) {
     return ChainUtil.isDict(shardingConfig) &&
       ChainUtil.isString(shardingConfig[ShardingProperties.SHARDING_PATH]) &&

--- a/db/functions.js
+++ b/db/functions.js
@@ -215,15 +215,15 @@ class Functions {
   _updateLatestShardReport(value, context) {
     const blockNumber = Number(context.params.block_number);
     if (!ChainUtil.isArray(context.functionPath)) {
-      return null;
-    }
-    const index = context.functionPath.findIndex((el) => el === '$block_number');
-    if (index < 0) {
-      // Invalid function path
       return;
     }
     if (!ChainUtil.isString(value)) {
       // Invalid hash reporting
+      return;
+    }
+    const index = context.functionPath.findIndex((el) => el === '$block_number');
+    if (index < 0) {
+      // Invalid function path
       return;
     }
     const shardingPath = ChainUtil.formatPath(context.functionPath.slice(0, index));

--- a/db/functions.js
+++ b/db/functions.js
@@ -22,8 +22,8 @@ class Functions {
       [NativeFunctionIds.TRANSFER]: this._transfer.bind(this),
       [NativeFunctionIds.DEPOSIT]: this._deposit.bind(this),
       [NativeFunctionIds.WITHDRAW]: this._withdraw.bind(this),
-      [NativeFunctionIds.SHARD_INIT]: this._initializeShard.bind(this),
-      [NativeFunctionIds.SHARD_REPORT]: this._reportShardProofHash.bind(this),
+      [NativeFunctionIds.INIT_SHARD]: this._initializeShard.bind(this),
+      [NativeFunctionIds.REPORT_SHARD]: this._reportShardProofHash.bind(this),
     };
   }
 
@@ -195,7 +195,7 @@ class Functions {
       {
         [FunctionProperties.FUNCTION]: {
           [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
-          [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.SHARD_REPORT
+          [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.REPORT_SHARD
         }
       }
     );
@@ -208,7 +208,7 @@ class Functions {
       ChainUtil.isNumber(shardingConfig[ShardingProperties.REPORTING_PERIOD]) &&
       ChainUtil.isValAddr(shardingConfig[ShardingProperties.SHARD_OWNER]) &&
       ChainUtil.isValAddr(shardingConfig[ShardingProperties.SHARD_REPORTER]) &&
-      ChainUtil.isValShardingProtocol(shardingConfig[ShardingProperties.SHARDING_PROTOCOL]);
+      ChainUtil.isValShardProto(shardingConfig[ShardingProperties.SHARDING_PROTOCOL]);
   }
 
   _reportShardProofHash(value, context) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -170,12 +170,13 @@ class Functions {
     if (ChainUtil.formatPath(shardingPath) !== value[ShardingProperties.SHARDING_PATH]) {
       return;
     }
-    const { shard_owner, shard_reporter } = value;
+    const shardOwner = value[ShardingProperties.SHARD_OWNER];
+    const shardReporter = value[ShardingProperties.SHARD_REPORTER];
     // Set owners
     this.db.writeDatabase(this._getFullOwnerPath(shardingPath), {
       [OwnerProperties.OWNER]: {
         [OwnerProperties.OWNERS]: {
-          [shard_owner]: buildOwnerPermissions(false, true, true, true),
+          [shardOwner]: buildOwnerPermissions(false, true, true, true),
           [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
         }
       }
@@ -183,7 +184,7 @@ class Functions {
     // Set rules
     // TODO(lia): make this rule tighter (e.g. only allow writing at /$sharding_path/$block_number, values should be strings prefixed with '0x', and cannot write at /$sharding_path/latest)
     this.db.writeDatabase(this._getFullRulePath(shardingPath), {
-      [RuleProperties.WRITE]: `auth === '${shard_reporter}'`,
+      [RuleProperties.WRITE]: `auth === '${shardReporter}'`,
     });
     // Reset functions
     this.db.writeDatabase(this._getFullFunctionPath(shardingPath), null);

--- a/db/functions.js
+++ b/db/functions.js
@@ -22,7 +22,6 @@ class Functions {
       [NativeFunctionIds.TRANSFER]: this._transfer.bind(this),
       [NativeFunctionIds.DEPOSIT]: this._deposit.bind(this),
       [NativeFunctionIds.WITHDRAW]: this._withdraw.bind(this),
-      [NativeFunctionIds.INIT_SHARD]: this._initializeShard.bind(this),
       [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: this._updateLatestShardReport.bind(this),
     };
   }
@@ -160,47 +159,47 @@ class Functions {
     }
   }
 
-  _initializeShard(value, context) {
-    if (!Functions.isValidShardingConfig(value)) {
-      // Shard owner trying to remove the shard
-      // TODO(lia): support modification of the shard config (update owners, rules, functions, values)
-      return;
-    }
-    const shardingPath = ChainUtil.parsePath(ainUtil.decode(context.params.sharding_path));
-    if (ChainUtil.formatPath(shardingPath) !== value[ShardingProperties.SHARDING_PATH]) {
-      return;
-    }
-    const shardOwner = value[ShardingProperties.SHARD_OWNER];
-    const shardReporter = value[ShardingProperties.SHARD_REPORTER];
-    // Set owners
-    this.db.writeDatabase(this._getFullOwnerPath(shardingPath), {
-      [OwnerProperties.OWNER]: {
-        [OwnerProperties.OWNERS]: {
-          [shardOwner]: buildOwnerPermissions(false, true, true, true),
-          [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
-        }
-      }
-    });
-    // Set rules
-    // TODO(lia): make this rule tighter (e.g. only allow writing at /$sharding_path/$block_number, values should be strings prefixed with '0x', and cannot write at /$sharding_path/latest)
-    this.db.writeDatabase(this._getFullRulePath(shardingPath), {
-      [RuleProperties.WRITE]: `auth === '${shardReporter}'`,
-    });
-    // Reset functions
-    this.db.writeDatabase(this._getFullFunctionPath(shardingPath), null);
-    // Reset values
-    this.db.writeDatabase(this._getFullValuePath(shardingPath), null);
-    // Add a native function for shard proof hash reporting
-    this.db.writeDatabase(
-      this._getFullFunctionPath([...shardingPath, '$block_number', PredefinedDbPaths.SHARDING_PROOF_HASH]),
-      {
-        [FunctionProperties.FUNCTION]: {
-          [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
-          [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
-        }
-      }
-    );
-  }
+  // _initializeShard(value, context) {
+  //   if (!Functions.isValidShardingConfig(value)) {
+  //     // Shard owner trying to remove the shard
+  //     // TODO(lia): support modification of the shard config (update owners, rules, functions, values)
+  //     return;
+  //   }
+  //   const shardingPath = ChainUtil.parsePath(ainUtil.decode(context.params.sharding_path));
+  //   if (ChainUtil.formatPath(shardingPath) !== value[ShardingProperties.SHARDING_PATH]) {
+  //     return;
+  //   }
+  //   const shardOwner = value[ShardingProperties.SHARD_OWNER];
+  //   const shardReporter = value[ShardingProperties.SHARD_REPORTER];
+  //   // Set owners
+  //   this.db.writeDatabase(this._getFullOwnerPath(shardingPath), {
+  //     [OwnerProperties.OWNER]: {
+  //       [OwnerProperties.OWNERS]: {
+  //         [shardOwner]: buildOwnerPermissions(false, true, true, true),
+  //         [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
+  //       }
+  //     }
+  //   });
+  //   // Set rules
+  //   // TODO(lia): make this rule tighter (e.g. only allow writing at /$sharding_path/$block_number, values should be strings prefixed with '0x', and cannot write at /$sharding_path/latest)
+  //   this.db.writeDatabase(this._getFullRulePath(shardingPath), {
+  //     [RuleProperties.WRITE]: `auth === '${shardReporter}'`,
+  //   });
+  //   // Reset functions
+  //   this.db.writeDatabase(this._getFullFunctionPath(shardingPath), null);
+  //   // Reset values
+  //   this.db.writeDatabase(this._getFullValuePath(shardingPath), null);
+  //   // Add a native function for shard proof hash reporting
+  //   this.db.writeDatabase(
+  //     this._getFullFunctionPath([...shardingPath, '$block_number', PredefinedDbPaths.SHARDING_PROOF_HASH]),
+  //     {
+  //       [FunctionProperties.FUNCTION]: {
+  //         [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
+  //         [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
+  //       }
+  //     }
+  //   );
+  // }
 
   static isValidShardingConfig(shardingConfig) {
     return ChainUtil.isDict(shardingConfig) &&

--- a/db/functions.js
+++ b/db/functions.js
@@ -1,7 +1,7 @@
 const logger = require('../logger');
 const {
-  PredefinedDbPaths, FunctionTypes, FunctionResultCode, FunctionProperties, NativeFunctionIds,
-  DefaultValues, ShardingProperties, OwnerProperties, buildOwnerPermissions, RuleProperties
+  PredefinedDbPaths, FunctionTypes, FunctionResultCode, NativeFunctionIds,
+  DefaultValues, ShardingProperties
 } = require('../constants');
 const ChainUtil = require('../chain-util');
 const axios = require('axios');
@@ -159,16 +159,6 @@ class Functions {
     }
   }
 
-  static isValidShardingConfig(shardingConfig) {
-    return ChainUtil.isDict(shardingConfig) &&
-      ChainUtil.isString(shardingConfig[ShardingProperties.SHARDING_PATH]) &&
-      ChainUtil.isString(shardingConfig[ShardingProperties.PARENT_CHAIN_POC]) &&
-      ChainUtil.isNumber(shardingConfig[ShardingProperties.REPORTING_PERIOD]) &&
-      ChainUtil.isValAddr(shardingConfig[ShardingProperties.SHARD_OWNER]) &&
-      ChainUtil.isValAddr(shardingConfig[ShardingProperties.SHARD_REPORTER]) &&
-      ChainUtil.isValShardProto(shardingConfig[ShardingProperties.SHARDING_PROTOCOL]);
-  }
-
   _updateLatestShardReport(value, context) {
     const blockNumber = Number(context.params.block_number);
     if (!ChainUtil.isArray(context.functionPath)) {
@@ -242,18 +232,6 @@ class Functions {
 
   _getLatestShardReportPath(shardingPath) {
     return `${shardingPath}/${PredefinedDbPaths.SHARDING_LATEST}`;
-  }
-
-  _getFullOwnerPath(parsedPath) {
-    return this.db.getFullPath(parsedPath, PredefinedDbPaths.OWNERS_ROOT);
-  }
-
-  _getFullFunctionPath(parsedPath) {
-    return this.db.getFullPath(parsedPath, PredefinedDbPaths.FUNCTIONS_ROOT);
-  }
-
-  _getFullRulePath(parsedPath) {
-    return this.db.getFullPath(parsedPath, PredefinedDbPaths.RULES_ROOT);
   }
 
   _getFullValuePath(parsedPath) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -23,7 +23,7 @@ class Functions {
       [NativeFunctionIds.DEPOSIT]: this._deposit.bind(this),
       [NativeFunctionIds.WITHDRAW]: this._withdraw.bind(this),
       [NativeFunctionIds.INIT_SHARD]: this._initializeShard.bind(this),
-      [NativeFunctionIds.REPORT_SHARD]: this._reportShardProofHash.bind(this),
+      [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: this._updateLatestShardReport.bind(this),
     };
   }
 
@@ -196,7 +196,7 @@ class Functions {
       {
         [FunctionProperties.FUNCTION]: {
           [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
-          [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.REPORT_SHARD
+          [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
         }
       }
     );
@@ -212,7 +212,7 @@ class Functions {
       ChainUtil.isValShardProto(shardingConfig[ShardingProperties.SHARDING_PROTOCOL]);
   }
 
-  _reportShardProofHash(value, context) {
+  _updateLatestShardReport(value, context) {
     const blockNumber = Number(context.params.block_number);
     if (!ChainUtil.isArray(context.functionPath)) {
       return null;

--- a/db/functions.js
+++ b/db/functions.js
@@ -213,7 +213,9 @@ class Functions {
 
   _reportShardProofHash(value, context) {
     const blockNumber = Number(context.params.block_number);
-    if (!ChainUtil.isArray(context.functionPath)) return null;
+    if (!ChainUtil.isArray(context.functionPath)) {
+      return null;
+    }
     const index = context.functionPath.findIndex((el) => el === '$block_number');
     if (index < 0) {
       // Invalid function path

--- a/db/index.js
+++ b/db/index.js
@@ -823,8 +823,9 @@ class DB {
   }
 
   makeEvalFunction(ruleString, pathVars) {
-    return new Function('auth', 'data', 'newData', 'currentTime', 'getValue', 'getRule',
-                        'getFunction', 'getOwner', 'util', 'lastBlockNumber', ...Object.keys(pathVars),
+    return new Function('auth', 'data', 'newData', 'currentTime',
+                        'getValue', 'getRule', 'getFunction', 'getOwner',
+                        'evalRule', 'evalOwner', 'util','lastBlockNumber', ...Object.keys(pathVars),
                         '"use strict"; return ' + ruleString);
   }
 
@@ -837,6 +838,7 @@ class DB {
     const evalFunc = this.makeEvalFunction(ruleString, pathVars);
     return evalFunc(address, data, newData, timestamp, this.getValue.bind(this),
                     this.getRule.bind(this), this.getFunction.bind(this), this.getOwner.bind(this),
+                    this.evalRule.bind(this), this.evalOwner.bind(this),
                     new RuleUtil(), this.lastBlockNumber(), ...Object.values(pathVars));
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -825,7 +825,7 @@ class DB {
   makeEvalFunction(ruleString, pathVars) {
     return new Function('auth', 'data', 'newData', 'currentTime',
                         'getValue', 'getRule', 'getFunction', 'getOwner',
-                        'evalRule', 'evalOwner', 'util','lastBlockNumber', ...Object.keys(pathVars),
+                        'evalRule', 'evalOwner', 'util', 'lastBlockNumber', ...Object.keys(pathVars),
                         '"use strict"; return ' + ruleString);
   }
 

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -52,6 +52,10 @@ class RuleUtil {
   isCksumAddr(addr) {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
+
+  isValShardingProtocol(value) {
+    return value === 'NONE' || value === 'POA';
+  }
 }
 
 module.exports = RuleUtil;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -53,6 +53,14 @@ class RuleUtil {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
 
+  toCksumAddr(addr) {
+    try {
+      return ainUtil.toChecksumAddress(addr);
+    } catch (e) {
+      return '';
+    }
+  }
+
   isValShardProto(value) {
     const { ShardingProtocols } = require('../constants');
     return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -1,4 +1,5 @@
 const ainUtil = require('@ainblockchain/ain-util');
+const { ShardingProtocols } = require('../constants');
 
 // NOTE(seo): To keep the blockchain deterministic as much as possibble over time,
 // we keep util functions here self-contained as much as possible.
@@ -54,7 +55,7 @@ class RuleUtil {
   }
 
   isValShardProto(value) {
-    return value === 'NONE' || value === 'POA';
+    return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;
   }
 }
 

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -53,7 +53,7 @@ class RuleUtil {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
 
-  isValShardingProtocol(value) {
+  isValShardProto(value) {
     return value === 'NONE' || value === 'POA';
   }
 }

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -53,6 +53,7 @@ class RuleUtil {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
 
+  // TODO(lia): normalize addresses in rule strings using this function.
   toCksumAddr(addr) {
     try {
       return ainUtil.toChecksumAddress(addr);

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -1,5 +1,4 @@
 const ainUtil = require('@ainblockchain/ain-util');
-const { ShardingProtocols } = require('../constants');
 
 // NOTE(seo): To keep the blockchain deterministic as much as possibble over time,
 // we keep util functions here self-contained as much as possible.
@@ -55,6 +54,7 @@ class RuleUtil {
   }
 
   isValShardProto(value) {
+    const { ShardingProtocols } = require('../constants');
     return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;
   }
 }

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -1338,7 +1338,7 @@ describe('API Tests', () => {
               "proof_hash": {
                 ".function": {
                   "function_type": "NATIVE",
-                  "function_id": "_reportShardProofHash"
+                  "function_id": "_updateLatestShardReport"
                 }
               }
             }
@@ -1387,7 +1387,7 @@ describe('API Tests', () => {
       });
     });
 
-    describe('_reportShardProofHash', () => {
+    describe('_updateLatestShardReport', () => {
       before(() => {
         const shardInitRes = JSON.parse(
           syncRequest(

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -1384,22 +1384,6 @@ describe('API Tests', () => {
           syncRequest('GET', server1 + `/get_value?ref=/sharding/shard/${encodedShardingPath}`).body.toString('utf-8')
         ).result;
         expect(shardingConfigRes).to.equal(null);
-        // const ownerRes = JSON.parse(
-        //   syncRequest('GET', server1 + `/get_owner?ref=${shardingPath}`).body.toString('utf-8')
-        // ).result;
-        // const ruleRes = JSON.parse(
-        //   syncRequest('GET', server1 + `/get_rule?ref=${shardingPath}`).body.toString('utf-8')
-        // ).result;
-        // const functionRes = JSON.parse(
-        //   syncRequest('GET', server1 + `/get_function?ref=${shardingPath}`).body.toString('utf-8')
-        // ).result;
-        // const valueRes = JSON.parse(
-        //   syncRequest('GET', server1 + `/get_value?ref=${shardingPath}`).body.toString('utf-8')
-        // ).result;
-        // expect(ownerRes).to.equal(null);
-        // expect(ruleRes).to.equal(null);
-        // expect(functionRes).to.equal(null);
-        // expect(valueRes).to.equal(null);
       });
     });
 

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -3,6 +3,7 @@ const chai = require('chai');
 const assert = chai.assert;
 const expect = chai.expect;
 const spawn = require("child_process").spawn;
+const ainUtil = require('@ainblockchain/ain-util');
 const PROJECT_ROOT = require('path').dirname(__filename) + "/../"
 const TRACKER_SERVER = PROJECT_ROOT + "tracker-server/index.js"
 const APP_SERVER = PROJECT_ROOT + "client/index.js"
@@ -18,35 +19,48 @@ const {
 
 const ENV_VARIABLES = [
   {
+    // For parent chain poc node
+    NUM_VALIDATORS: 1, ACCOUNT_INDEX: 0, HOSTING_ENV: 'local', DEBUG: true
+  },
+  {
+    // For child chain tracker
+    PORT: 9090, P2P_PORT: 6000
+  },
+  {
     GENESIS_CONFIGS_DIR: 'blockchain/afan_shard',
+    PORT: 9091, P2P_PORT: 6001, TRACKER_WS_ADDR: 'ws://localhost:6000',
     NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0, HOSTING_ENV: 'local', DEBUG: true,
     ADDITIONAL_OWNERS: 'test:./test/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:./test/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'blockchain/afan_shard',
+    PORT: 9092, P2P_PORT: 6002, TRACKER_WS_ADDR: 'ws://localhost:6000',
     NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1, HOSTING_ENV: 'local', DEBUG: true,
     ADDITIONAL_OWNERS: 'test:./test/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:./test/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'blockchain/afan_shard',
+    PORT: 9093, P2P_PORT: 6003, TRACKER_WS_ADDR: 'ws://localhost:6000',
     NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2, HOSTING_ENV: 'local', DEBUG: true,
     ADDITIONAL_OWNERS: 'test:./test/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:./test/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'blockchain/afan_shard',
+    PORT: 9094, P2P_PORT: 6004, TRACKER_WS_ADDR: 'ws://localhost:6000',
     NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3, HOSTING_ENV: 'local', DEBUG: true,
     ADDITIONAL_OWNERS: 'test:./test/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:./test/data/rules_for_testing.json'
   },
 ];
 
-const server1 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[0].ACCOUNT_INDEX))
-const server2 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[1].ACCOUNT_INDEX))
-const server3 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[2].ACCOUNT_INDEX))
-const server4 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[3].ACCOUNT_INDEX))
+const parentServer = 'http://127.0.0.1:8081';
+const server1 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[2].ACCOUNT_INDEX))
+const server2 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[3].ACCOUNT_INDEX))
+const server3 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[4].ACCOUNT_INDEX))
+const server4 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[5].ACCOUNT_INDEX))
 
 function startServer(application, serverName, envVars, stdioInherit = false) {
   const options = {
@@ -72,24 +86,31 @@ describe('Sharding initialization', () => {
   const sharding =
       readConfigFile(path.resolve(__dirname, '../blockchain/afan_shard', 'genesis_sharding.json'));
 
-  let tracker_proc, server1_proc, server2_proc, server3_proc, server4_proc
+  let parent_chain_tracker_proc, parent_chain_server_proc,
+      tracker_proc, server1_proc, server2_proc, server3_proc, server4_proc;
 
   before(() => {
     rimraf.sync(BLOCKCHAINS_DIR)
 
-    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', {}, false);
+    parent_chain_tracker_proc = startServer(TRACKER_SERVER, 'parent tracker server', {}, false);
     sleep(2000);
-    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[0]);
+    parent_chain_server_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[0]);
     sleep(2000);
-    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[1]);
+    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', ENV_VARIABLES[1], false);
     sleep(2000);
-    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[2]);
+    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2]);
     sleep(2000);
-    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[3]);
+    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[3]);
+    sleep(2000);
+    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[4]);
+    sleep(2000);
+    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[5]);
     sleep(2000);
   });
 
   after(() => {
+    parent_chain_tracker_proc.kill()
+    parent_chain_server_proc.kill()
     tracker_proc.kill()
     server1_proc.kill()
     server2_proc.kill()
@@ -99,7 +120,65 @@ describe('Sharding initialization', () => {
     rimraf.sync(BLOCKCHAINS_DIR)
   });
 
-  describe('DB initialization', () => {
+
+  describe('Parent chain initialization', () => {
+    describe('DB values', () => {
+      it('sharding', () => {
+        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=/sharding/shard/${ainUtil.encode(sharding.sharding_path)}`)
+        .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: Object.assign(
+            {},
+            sharding,
+            {
+              shard_owner: accounts.owner.address,
+              shard_reporter: accounts.others[0].address
+            }
+          )
+        });
+      });
+    });
+
+    describe('DB functions', () => {
+      it('sharding path', () => {
+        const body = JSON.parse(syncRequest('GET', parentServer + `/get_function?ref=${sharding.sharding_path}`)
+        .body.toString('utf-8'));
+        expect(body.code).to.equal(0);
+        expect(body.result).to.not.be.null;
+        assert.deepEqual(body.result, {
+          "$block_number": {
+            "proof_hash": {
+              ".function": {
+                "function_type": "NATIVE",
+                "function_id": "_reportShardProofHash"
+              }
+            }
+          }
+        })
+      });
+    });
+
+    describe('DB rules', () => {
+      it('sharding path', () => {
+        const body = JSON.parse(syncRequest('GET', parentServer + `/get_rule?ref=${sharding.sharding_path}`)
+        .body.toString('utf-8'));
+        expect(body.code).to.equal(0);
+        expect(body.result['.write']).to.have.string(accounts.others[0].address);
+      });
+    });
+
+    describe('DB owners', () => {
+      it('sharding path', () => {
+        const body = JSON.parse(syncRequest('GET', parentServer + `/get_owner?ref=${sharding.sharding_path}`)
+        .body.toString('utf-8'));
+        expect(body.code).to.equal(0);
+        expect(body.result['.owner'].owners[accounts.owner.address]).to.not.be.null;
+      });
+    });
+  });
+
+  describe('Child chain initialization', () => {
     describe('DB values', () => {
       it('token', () => {
         const body = JSON.parse(syncRequest('GET', server1 + '/get_value?ref=/token')

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -151,7 +151,7 @@ describe('Sharding initialization', () => {
             "proof_hash": {
               ".function": {
                 "function_type": "NATIVE",
-                "function_id": "_reportShardProofHash"
+                "function_id": "_updateLatestShardReport"
               }
             }
           }

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -78,6 +78,18 @@ function startServer(application, serverName, envVars, stdioInherit = false) {
   });
 }
 
+// Needed to make sure the shard initialization is finished
+// before other shard nodes start
+function waitUntilShardReporterStarts() {
+  let consensusState;
+  while (true) {
+    consensusState = JSON.parse(syncRequest('GET', server1 + '/get_consensus_state')
+      .body.toString('utf-8')).result;
+    if (consensusState && consensusState.status === 1) return;
+    sleep(1000);
+  }
+}
+
 describe('Sharding initialization', () => {
   const token =
       readConfigFile(path.resolve(__dirname, '../blockchain/afan_shard', 'genesis_token.json'));
@@ -100,6 +112,7 @@ describe('Sharding initialization', () => {
     sleep(2000);
     server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2]);
     sleep(2000);
+    waitUntilShardReporterStarts();
     server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[3]);
     sleep(2000);
     server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[4]);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test_state_util": "mocha ./test/state-util.test.js"
   },
   "dependencies": {
-    "@ainblockchain/ain-util": "^1.1.5",
+    "@ainblockchain/ain-util": "^1.1.6",
     "@google-cloud/logging-winston": "^3.0.5",
     "ajv": "^5.5.2",
     "axios": "^0.19.2",

--- a/server/index.js
+++ b/server/index.js
@@ -644,7 +644,7 @@ class P2pServer {
             value: {
               [OwnerProperties.OWNER]: {
                 [OwnerProperties.OWNERS]: {
-                  [shardOwner]: buildOwnerPermissions(true, true, true, true),
+                  [shardOwner]: buildOwnerPermissions(false, true, true, true),
                   [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
                 }
               }

--- a/server/index.js
+++ b/server/index.js
@@ -673,6 +673,7 @@ class P2pServer {
         }
       );
       if (_.get(response, 'data.result.result.is_confirmed')) {
+        logger.info(`[${P2P_PREFIX}] Shard init success`);
         return;
       }
       sleep(1);

--- a/server/util.js
+++ b/server/util.js
@@ -1,0 +1,87 @@
+/**
+ * This file contains utility functions for shard reporters to communicate with
+ * the parent_chain_poc through API calls. In the future, these should be refactored
+ * into a module, or replaced with another protocol for cross-shard communication.
+ */
+
+const { sleep } = require('sleep');
+const axios = require('axios');
+const ainUtil = require('@ainblockchain/ain-util');
+const _ = require('lodash');
+const logger = require('../logger');
+const ChainUtil = require('../chain-util');
+
+const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
+const MAX_NUM_CONF_CHECK = 10;
+
+async function sendTxAndWaitForConfirmation(endpoint, tx, keyBuffer) {
+  const res = await signAndSendTx(endpoint, tx, keyBuffer);
+  if (res.errMsg || !res.txHash) {
+    throw Error(`Failed to sign and send tx: ${res.errMsg}`);
+  }
+  if (!(await waitUntilTxFinalize(endpoint, res.txHash))) {
+    throw Error('Transaction did not finalize in time. Try selecting a different parent_chain_poc.');
+  }
+}
+
+async function signAndSendTx(endpoint, tx, keyBuffer) {
+  try {
+    const sig = ainUtil.ecSignTransaction(tx, keyBuffer);
+    const sigBuffer = ainUtil.toBuffer(sig);
+    const lenHash = sigBuffer.length - 65;
+    const hashedData = sigBuffer.slice(0, lenHash);
+    const txHash = '0x' + hashedData.toString('hex');
+    const response = await axios.post(
+      endpoint,
+      {
+        method: "ain_sendSignedTransaction",
+        params: {
+          protoVer: CURRENT_PROTOCOL_VERSION,
+          signature: sig,
+          transaction: tx
+        },
+        jsonrpc: "2.0",
+        id: 0
+      }
+    );
+    if (ChainUtil.transactionFailed(response.data.result)) {
+      throw Error(`Transaction failed: ${JSON.stringify(response.data.result)}`);
+    }
+    return { txHash };
+  } catch (e) {
+    return { errMsg: e.message };
+  }
+}
+
+async function waitUntilTxFinalize(endpoint, txHash) {
+  let numTries = 0;
+  while (numTries < MAX_NUM_CONF_CHECK) {
+    try {
+      const response = await axios.post(
+        endpoint,
+        {
+          method: "ain_getTransactionByHash",
+          params: {
+            protoVer: CURRENT_PROTOCOL_VERSION,
+            hash: txHash
+          },
+          jsonrpc: "2.0",
+          id: 0
+        }
+      );
+      if (_.get(response, 'data.result.result.is_confirmed')) {
+        return true;
+      }
+    } catch (e) {
+      logger.error(`Failed to confirm transaction: ${e}`);
+      return false;
+    }
+    sleep(1);
+    numTries++;
+  }
+  return false;
+}
+
+module.exports = {
+  sendTxAndWaitForConfirmation
+}

--- a/tracker-server/index.js
+++ b/tracker-server/index.js
@@ -5,7 +5,7 @@ const jayson = require('jayson');
 const _ = require('lodash');
 const logger = require('./logger');
 
-const P2P_PORT = 5000;
+const P2P_PORT = process.env.P2P_PORT || 5000;
 const PORT = process.env.PORT || 8080;
 const MAX_NUM_PEERS = 2;
 const PEER_NODES = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,14 @@
 # yarn lockfile v1
 
 
-"@ainblockchain/ain-util@^1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-util/-/ain-util-1.1.5.tgz#0e63bcd46dfbc5cc3fa5e8a09b73774fa76b8b9a"
+"@ainblockchain/ain-util@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-util/-/ain-util-1.1.6.tgz#f8dc8506e5f4560ab4f81bd0664e3b6606ba70b4"
+  integrity sha512-1QbPfHGE5PV/AmWPZ5VD2gW5t2bagFCn1xZPpVnpfPiNCc45RnNS0D6scRzMwBsTo1kJpNciJXIyUpCabaEplA==
   dependencies:
     bn.js "^4.11.8"
     browserify-cipher "^1.0.1"
-    eccrypto "^1.1.3"
+    eccrypto "^1.1.5"
     fast-json-stable-stringify "^2.0.0"
     keccak "^2.0.0"
     pbkdf2 "^3.0.17"
@@ -319,9 +320,10 @@ acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
 
-acorn@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+acorn@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 acorn@^3.0.4:
   version "3.3.0"
@@ -1134,12 +1136,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-eccrypto@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/eccrypto/-/eccrypto-1.1.3.tgz#010cb4e9d239ce9752b82c0ac6d8af207fffaf3e"
+eccrypto@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/eccrypto/-/eccrypto-1.1.5.tgz#8e97a82009bd4a37a8ebf919e47590edc1e121b3"
+  integrity sha512-iGu2lqaSFEX7jmYQayOzSIB52PdXguUeR17V7ilfmd5nVdt683HvYB0DwuGK1Y3srNp/zl6D05JfEdFY+SC5MQ==
   dependencies:
-    acorn "7.1.0"
-    elliptic "6.5.1"
+    acorn "7.1.1"
+    elliptic "6.5.3"
     es6-promise "4.2.8"
     nan "2.14.0"
   optionalDependencies:
@@ -1155,19 +1158,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-elliptic@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
-
-elliptic@^6.4.1, elliptic@^6.5.2:
+elliptic@6.5.3, elliptic@^6.4.1, elliptic@^6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   dependencies:


### PR DESCRIPTION
- Implemented parent chain initialization for sharding (#62) 
- Added _initializeShard native function
- Added _reportShardProofHash native function (shard reporting PR is on its way!)
- Added test cases in dev.test.js and sharding.test.js
- Enabled PORT and P2P_PORT setting by env vars (so that we can run both parent and child networks on one machine for testing)
- Changed parent_chain_poc in blockchain/afan_shard/genesis_sharding.json to 'http://127.0.0.1:8081'. This makes developing and testing much easier, but I'm open to other ideas (maybe another env var?)
- Also, current implementation doesn't reset values, rules, functions, owners at /\<Sharding Path> when the shard owner sets the value at /sharding/shard/\<Sharding Path> to null. It only removes the shard config at that specific location. Wanted to hear your opinion on the resetting of other values.
- Fixed #64 