### PR TITLE
Make consensusStatus more concise.

### DIFF
--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -125,6 +125,14 @@ class Blockchain {
     return lastBlock.number;
   }
 
+  lastBlockEpoch() {
+    const lastBlock = this.lastBlock();
+    if (!lastBlock) {
+      return -1;
+    }
+    return lastBlock.epoch;
+  }
+
   lastBlockTimestamp() {
     const lastBlock = this.lastBlock();
     if (!lastBlock) {

--- a/server/index.js
+++ b/server/index.js
@@ -225,11 +225,12 @@ class P2pServer {
         number: this.node.bc.lastBlockNumber(),
         timestamp: this.node.bc.lastBlockTimestamp(),
       },
-      consensusStatus: {
-        consensus: this.consensus.getState(),
-        blockPool: this.consensus.blockPool ? this.consensus.blockPool.hashToBlockInfo : {},
-        longestNotarizedChainTips: this.consensus.blockPool ? this.consensus.blockPool.longestNotarizedChainTips : []
-      },
+      consensusStatus: Object.assign(
+        {},
+        this.consensus.getState(),
+        { longestNotarizedChainTipsSize: this.consensus.blockPool ?
+            this.consensus.blockPool.longestNotarizedChainTips.length : 0 }
+      ),
       txStatus: {
         txPoolSize: this.node.tp.getPoolSize(),
         txTrackerSize: Object.keys(this.node.tp.transactionTracker).length,

--- a/server/index.js
+++ b/server/index.js
@@ -223,6 +223,7 @@ class P2pServer {
       updatedAt: Date.now(),
       lastBlock: {
         number: this.node.bc.lastBlockNumber(),
+        epoch: this.node.bc.lastBlockEpoch(),
         timestamp: this.node.bc.lastBlockTimestamp(),
       },
       consensusStatus: Object.assign(

--- a/tracker-server/index.js
+++ b/tracker-server/index.js
@@ -81,11 +81,6 @@ function setTimer(ws, timeSec) {
   }, timeSec * 1000);
 }
 
-function jsonReplacer(key, val) {
-  if (key === 'blockPool') return undefined;
-  else return val;
-}
-
 // A tracker server that tracks the peer-to-peer network status of the blockchain nodes.
 // TODO(seo): Sign messages to nodes.
 const server = new WebSocketServer({
@@ -122,7 +117,7 @@ server.on('connection', (ws) => {
         node = PEER_NODES[nodeInfo.address].reconstruct(nodeInfo);
         node.assignRandomPeers();
         logger.info(`\n<< Update from node [${abbrAddr(nodeInfo.address)}]: ` +
-            `${JSON.stringify(nodeInfo, jsonReplacer, 2)}`)
+            `${JSON.stringify(nodeInfo, null, 2)}`)
       } else {
         node = new PeerNode(nodeInfo);
         node.assignRandomPeers();


### PR DESCRIPTION
For smaller peer node info in tracker server.

Before:
```
{
  ...
  consensusStatus: {
    consensus; { health, status, epoch },
    blockPool: { ... },
    longestNotarizedChainTips: [ ... ]
  },
  ...
}
```
After:
```
{
  ...
  consensusStatus: {
    health: true,
    status: 1,
    epoch: 123,
    longestNotarizedChainTipsSize: 2
  },
  ...
}
```