### PR TITLE
Feature/platfowner/global path

### DIFF
--- a/afan_client/index.js
+++ b/afan_client/index.js
@@ -60,11 +60,9 @@ class AfanClient {
   }
 
   async tx_adpropose(from, to, value, intermed) {
-    console.log('adpropose');
     const requestManager = new RequestManager(this.endpoint, APP_NAME);
     try {
       const state = await requestManager.getAdState(from, to);
-      console.log('state: ' + state.result);
       if (state.result && state.result !==3) {
         return {code: -4, message: 'Already proposed'};
       }

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_rules.json
+++ b/blockchain/genesis_rules.json
@@ -60,7 +60,7 @@
     "shard": {
       ".write": false,
       "$sharding_path": {
-        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol) && evalOwner(newData.sharding_path, 'write_owner', auth) && evalOwner(newData.sharding_path, 'write_rule', auth) && evalOwner(newData.sharding_path, 'write_function', auth)) || (auth === data.shard_owner && newData === null)"
+        ".write": "(data === null && util.isDict(newData) && util.isString(newData.sharding_path) && util.isString(newData.parent_chain_poc) && util.isNumber(newData.reporting_period) && util.isValAddr(newData.shard_owner) && util.isValAddr(newData.shard_reporter) && util.isValShardProto(newData.sharding_protocol)) || (auth === data.shard_owner && newData === null)"
       }
     }
   },

--- a/blockchain/genesis_sharding.json
+++ b/blockchain/genesis_sharding.json
@@ -1,6 +1,6 @@
 {
   "sharding_protocol": "NONE",
-  "sharding_path": "",
+  "sharding_path": "/",
   "parent_chain_poc": "",
   "reporting_period": 0
 }

--- a/chain-util.js
+++ b/chain-util.js
@@ -66,6 +66,10 @@ class ChainUtil {
     return ruleUtil.isValShardProto(value);
   }
 
+  static boolOrFalse(value) {
+    return ChainUtil.isBool(value) ? value : false;
+  }
+
   static numberOrZero(num) {
     return ChainUtil.isNumber(num) ? num : 0;
   }

--- a/chain-util.js
+++ b/chain-util.js
@@ -57,9 +57,8 @@ class ChainUtil {
     return ruleUtil.isValAddr(value);
   }
 
-  // TODO(lia): normalize addresses in user inputs using this function.
-  static toCksumAddr(value) {
-    return ruleUtil.toCksumAddr(value);
+  static isCksumAddr(addr) {
+    return ruleUtil.isCksumAddr(addr);
   }
 
   static isValShardProto(value) {
@@ -76,6 +75,15 @@ class ChainUtil {
 
   static stringOrEmpty(str) {
     return ChainUtil.isString(str) ? str : '';
+  }
+
+  static toBool(value) {
+    return ruleUtil.toBool(value);
+  }
+
+  // TODO(lia): normalize addresses in user inputs using this function.
+  static toCksumAddr(addr) {
+    return ruleUtil.toCksumAddr(addr);
   }
 
   static toString(value) {

--- a/chain-util.js
+++ b/chain-util.js
@@ -98,7 +98,7 @@ class ChainUtil {
   }
 
   static formatPath(parsedPath) {
-    if (!Array.isArray(parsedPath) || !parsedPath.length) {
+    if (!Array.isArray(parsedPath) || parsedPath.length === 0) {
       return '/';
     }
     let formatted = '';

--- a/client/index.js
+++ b/client/index.js
@@ -58,7 +58,7 @@ app.get('/', (req, res, next) => {
 });
 
 app.get('/get_value', (req, res, next) => {
-  const result = node.db.getValue(req.query.ref);
+  const result = node.db.getValue(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -66,7 +66,7 @@ app.get('/get_value', (req, res, next) => {
 });
 
 app.get('/get_function', (req, res, next) => {
-  const result = node.db.getFunction(req.query.ref);
+  const result = node.db.getFunction(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -74,7 +74,7 @@ app.get('/get_function', (req, res, next) => {
 });
 
 app.get('/get_rule', (req, res, next) => {
-  const result = node.db.getRule(req.query.ref);
+  const result = node.db.getRule(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -82,18 +82,7 @@ app.get('/get_rule', (req, res, next) => {
 });
 
 app.get('/get_owner', (req, res, next) => {
-  const result = node.db.getOwner(req.query.ref);
-  res.status(200)
-    .set('Content-Type', 'application/json')
-    .send({code: result !== null ? 0 : 1, result})
-    .end();
-});
-
-/**
- * Returns a proof of the state node in the given full database path.
- */
-app.get('/get_proof', (req, res, next) => {
-  const result = node.db.getProof(req.query.ref);
+  const result = node.db.getOwner(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -101,7 +90,7 @@ app.get('/get_proof', (req, res, next) => {
 });
 
 app.get('/match_function', (req, res, next) => {
-  const result = node.db.matchFunction(req.query.ref);
+  const result = node.db.matchFunction(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -109,7 +98,7 @@ app.get('/match_function', (req, res, next) => {
 });
 
 app.get('/match_rule', (req, res, next) => {
-  const result = node.db.matchRule(req.query.ref);
+  const result = node.db.matchRule(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -117,7 +106,7 @@ app.get('/match_rule', (req, res, next) => {
 });
 
 app.get('/match_owner', (req, res, next) => {
-  const result = node.db.matchOwner(req.query.ref);
+  const result = node.db.matchOwner(req.query.ref, req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -126,7 +115,8 @@ app.get('/match_owner', (req, res, next) => {
 
 app.post('/eval_rule', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalRule(body.ref, body.value, body.address, body.timestamp || Date.now());
+  const result = node.db.evalRule(body.ref, body.value, body.is_global, body.address,
+      body.timestamp || Date.now());
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
@@ -135,7 +125,7 @@ app.post('/eval_rule', (req, res, next) => {
 
 app.post('/eval_owner', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalOwner(body.ref, body.permission, body.address);
+  const result = node.db.evalOwner(body.ref, body.permission, body.is_global, body.address);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
@@ -147,6 +137,17 @@ app.post('/get', (req, res, next) => {
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
+    .end();
+});
+
+/**
+ * Returns a proof of the state node in the given full database path.
+ */
+app.get('/get_proof', (req, res, next) => {
+  const result = node.db.getProof(req.query.ref);
+  res.status(200)
+    .set('Content-Type', 'application/json')
+    .send({code: result !== null ? 0 : 1, result})
     .end();
 });
 

--- a/client/index.js
+++ b/client/index.js
@@ -354,6 +354,7 @@ function createSingleSetTxData(input, opType) {
       type: opType,
       ref: input.ref,
       value: input.value,
+      is_global: input.is_global,
     }
   };
   if (input.address !== undefined) {

--- a/client/index.js
+++ b/client/index.js
@@ -126,8 +126,8 @@ app.get('/match_owner', (req, res, next) => {
 
 app.post('/eval_rule', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalRule(body.ref, body.value, body.address, !!body.is_global,
-      body.timestamp || Date.now());
+  const result = node.db.evalRule(
+      body.ref, body.value, body.address, body.timestamp || Date.now(), !!body.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/client/index.js
+++ b/client/index.js
@@ -8,6 +8,7 @@ const jayson = require('jayson');
 const logger = require('../logger');
 const Node = require('../node');
 const P2pServer = require('../server');
+const ChainUtil = require('../chain-util');
 const { PORT, PROTOCOL_VERSIONS, WriteDbOperations, TransactionStatus } = require('../constants');
 const { ConsensusStatus } = require('../consensus/constants');
 const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
@@ -58,7 +59,7 @@ app.get('/', (req, res, next) => {
 });
 
 app.get('/get_value', (req, res, next) => {
-  const result = node.db.getValue(req.query.ref, !!req.query.is_global);
+  const result = node.db.getValue(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -66,7 +67,7 @@ app.get('/get_value', (req, res, next) => {
 });
 
 app.get('/get_function', (req, res, next) => {
-  const result = node.db.getFunction(req.query.ref, !!req.query.is_global);
+  const result = node.db.getFunction(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -74,7 +75,7 @@ app.get('/get_function', (req, res, next) => {
 });
 
 app.get('/get_rule', (req, res, next) => {
-  const result = node.db.getRule(req.query.ref, !!req.query.is_global);
+  const result = node.db.getRule(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -82,7 +83,7 @@ app.get('/get_rule', (req, res, next) => {
 });
 
 app.get('/get_owner', (req, res, next) => {
-  const result = node.db.getOwner(req.query.ref, !!req.query.is_global);
+  const result = node.db.getOwner(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -101,7 +102,7 @@ app.get('/get_proof', (req, res, next) => {
 });
 
 app.get('/match_function', (req, res, next) => {
-  const result = node.db.matchFunction(req.query.ref, !!req.query.is_global);
+  const result = node.db.matchFunction(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -109,7 +110,7 @@ app.get('/match_function', (req, res, next) => {
 });
 
 app.get('/match_rule', (req, res, next) => {
-  const result = node.db.matchRule(req.query.ref, !!req.query.is_global);
+  const result = node.db.matchRule(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -117,7 +118,7 @@ app.get('/match_rule', (req, res, next) => {
 });
 
 app.get('/match_owner', (req, res, next) => {
-  const result = node.db.matchOwner(req.query.ref, !!req.query.is_global);
+  const result = node.db.matchOwner(req.query.ref, ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -127,7 +128,8 @@ app.get('/match_owner', (req, res, next) => {
 app.post('/eval_rule', (req, res, next) => {
   const body = req.body;
   const result = node.db.evalRule(
-      body.ref, body.value, body.address, body.timestamp || Date.now(), !!body.is_global);
+      body.ref, body.value, body.address, body.timestamp || Date.now(),
+      ChainUtil.toBool(body.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
@@ -136,7 +138,8 @@ app.post('/eval_rule', (req, res, next) => {
 
 app.post('/eval_owner', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalOwner(body.ref, body.permission, body.address, !!body.is_global);
+  const result = node.db.evalOwner(
+      body.ref, body.permission, body.address, ChainUtil.toBool(body.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/client/index.js
+++ b/client/index.js
@@ -115,7 +115,7 @@ app.get('/match_owner', (req, res, next) => {
 
 app.post('/eval_rule', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalRule(body.ref, body.value, body.is_global, body.address,
+  const result = node.db.evalRule(body.ref, body.value, body.address, body.is_global,
       body.timestamp || Date.now());
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -125,7 +125,7 @@ app.post('/eval_rule', (req, res, next) => {
 
 app.post('/eval_owner', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalOwner(body.ref, body.permission, body.is_global, body.address);
+  const result = node.db.evalOwner(body.ref, body.permission, body.address, body.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/client/index.js
+++ b/client/index.js
@@ -58,7 +58,7 @@ app.get('/', (req, res, next) => {
 });
 
 app.get('/get_value', (req, res, next) => {
-  const result = node.db.getValue(req.query.ref, req.query.is_global);
+  const result = node.db.getValue(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -66,7 +66,7 @@ app.get('/get_value', (req, res, next) => {
 });
 
 app.get('/get_function', (req, res, next) => {
-  const result = node.db.getFunction(req.query.ref, req.query.is_global);
+  const result = node.db.getFunction(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -74,7 +74,7 @@ app.get('/get_function', (req, res, next) => {
 });
 
 app.get('/get_rule', (req, res, next) => {
-  const result = node.db.getRule(req.query.ref, req.query.is_global);
+  const result = node.db.getRule(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -82,7 +82,7 @@ app.get('/get_rule', (req, res, next) => {
 });
 
 app.get('/get_owner', (req, res, next) => {
-  const result = node.db.getOwner(req.query.ref, req.query.is_global);
+  const result = node.db.getOwner(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -101,7 +101,7 @@ app.get('/get_proof', (req, res, next) => {
 });
 
 app.get('/match_function', (req, res, next) => {
-  const result = node.db.matchFunction(req.query.ref, req.query.is_global);
+  const result = node.db.matchFunction(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -109,7 +109,7 @@ app.get('/match_function', (req, res, next) => {
 });
 
 app.get('/match_rule', (req, res, next) => {
-  const result = node.db.matchRule(req.query.ref, req.query.is_global);
+  const result = node.db.matchRule(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -117,7 +117,7 @@ app.get('/match_rule', (req, res, next) => {
 });
 
 app.get('/match_owner', (req, res, next) => {
-  const result = node.db.matchOwner(req.query.ref, req.query.is_global);
+  const result = node.db.matchOwner(req.query.ref, !!req.query.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -126,7 +126,7 @@ app.get('/match_owner', (req, res, next) => {
 
 app.post('/eval_rule', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalRule(body.ref, body.value, body.address, body.is_global,
+  const result = node.db.evalRule(body.ref, body.value, body.address, !!body.is_global,
       body.timestamp || Date.now());
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -136,7 +136,7 @@ app.post('/eval_rule', (req, res, next) => {
 
 app.post('/eval_owner', (req, res, next) => {
   const body = req.body;
-  const result = node.db.evalOwner(body.ref, body.permission, body.address, body.is_global);
+  const result = node.db.evalOwner(body.ref, body.permission, body.address, !!body.is_global);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
@@ -153,7 +153,7 @@ app.post('/get', (req, res, next) => {
 
 app.post('/set_value', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.SET_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -163,7 +163,7 @@ app.post('/set_value', (req, res, next) => {
 
 app.post('/inc_value', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.INC_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -173,7 +173,7 @@ app.post('/inc_value', (req, res, next) => {
 
 app.post('/dec_value', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.DEC_VALUE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -183,7 +183,7 @@ app.post('/dec_value', (req, res, next) => {
 
 app.post('/set_function', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.SET_FUNCTION), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -193,7 +193,7 @@ app.post('/set_function', (req, res, next) => {
 
 app.post('/set_rule', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.SET_RULE), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -203,7 +203,7 @@ app.post('/set_rule', (req, res, next) => {
 
 app.post('/set_owner', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(
+  const result = createAndExecuteTransaction(
       createSingleSetTxData(req.body, WriteDbOperations.SET_OWNER), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
@@ -214,7 +214,7 @@ app.post('/set_owner', (req, res, next) => {
 // TODO(seo): Replace skip_verif with real signature.
 app.post('/set', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(createMultiSetTxData(req.body), isNoncedTransaction);
+  const result = createAndExecuteTransaction(createMultiSetTxData(req.body), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result.result === true ? 0 : 1, result})
@@ -223,7 +223,7 @@ app.post('/set', (req, res, next) => {
 
 app.post('/batch', (req, res, next) => {
   const isNoncedTransaction = checkIfTransactionShouldBeNonced(req.body);
-  const result = createTransaction(createBatchTxData(req.body), isNoncedTransaction);
+  const result = createAndExecuteTransaction(createBatchTxData(req.body), isNoncedTransaction);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
@@ -349,14 +349,15 @@ p2pServer.listen();
 module.exports = app;
 
 function createSingleSetTxData(input, opType) {
-  const txData = {
-    operation: {
-      type: opType,
-      ref: input.ref,
-      value: input.value,
-      is_global: input.is_global,
-    }
+  const op = {
+    type: opType,
+    ref: input.ref,
+    value: input.value,
   };
+  if (input.is_global !== undefined) {
+    op.is_global = input.is_global;
+  }
+  const txData = { operation: op };
   if (input.address !== undefined) {
     txData.address = input.address;
   }
@@ -386,7 +387,7 @@ function createBatchTxData(input) {
   return { tx_list: input.tx_list };
 }
 
-function createTransaction(txData, isNoncedTransaction) {
+function createAndExecuteTransaction(txData, isNoncedTransaction) {
   const transaction = node.createTransaction(txData, isNoncedTransaction);
   return {
     tx_hash: transaction.hash,

--- a/client/index.js
+++ b/client/index.js
@@ -89,6 +89,17 @@ app.get('/get_owner', (req, res, next) => {
     .end();
 });
 
+/**
+ * Returns a proof of the state node in the given full database path.
+ */
+app.get('/get_proof', (req, res, next) => {
+  const result = node.db.getProof(req.query.ref);
+  res.status(200)
+    .set('Content-Type', 'application/json')
+    .send({code: result !== null ? 0 : 1, result})
+    .end();
+});
+
 app.get('/match_function', (req, res, next) => {
   const result = node.db.matchFunction(req.query.ref, req.query.is_global);
   res.status(200)
@@ -137,17 +148,6 @@ app.post('/get', (req, res, next) => {
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
-    .end();
-});
-
-/**
- * Returns a proof of the state node in the given full database path.
- */
-app.get('/get_proof', (req, res, next) => {
-  const result = node.db.getProof(req.query.ref);
-  res.status(200)
-    .set('Content-Type', 'application/json')
-    .send({code: result !== null ? 0 : 1, result})
     .end();
 });
 

--- a/db/index.js
+++ b/db/index.js
@@ -157,6 +157,10 @@ class DB {
   getValue(valuePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(valuePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.VALUES_ROOT);
     return this.readDatabase(fullPath);
   }
@@ -164,6 +168,10 @@ class DB {
   getFunction(functionPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(functionPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     return this.readDatabase(fullPath);
   }
@@ -171,6 +179,10 @@ class DB {
   getRule(rulePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(rulePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
     return this.readDatabase(fullPath);
   }
@@ -178,6 +190,10 @@ class DB {
   getOwner(ownerPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(ownerPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     return this.readDatabase(fullPath);
   }
@@ -210,30 +226,50 @@ class DB {
   matchFunction(funcPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(funcPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     return this.convertFunctionMatch(this.matchFunctionForParsedPath(localPath));
   }
 
   matchRule(valuePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(valuePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     return this.convertRuleMatch(this.matchRuleForParsedPath(localPath));
   }
 
   matchOwner(rulePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(rulePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     return this.convertOwnerMatch(this.matchOwnerForParsedPath(localPath));
   }
 
   evalRule(valuePath, value, isGlobal, address, timestamp) {
     const parsedPath = ChainUtil.parsePath(valuePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     return this.getPermissionForValue(localPath, value, address, timestamp);
   }
 
   evalOwner(refPath, permission, isGlobal, address) {
     const parsedPath = ChainUtil.parsePath(refPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // No matched local path.
+      return null;
+    }
     const matched = this.matchOwnerForParsedPath(localPath);
     return this.checkPermission(matched.closestOwner.config, address, permission);
   }
@@ -281,6 +317,10 @@ class DB {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // There is nothing to do.
+      return true;
+    }
     if (!this.getPermissionForValue(localPath, value, address, timestamp)) {
       return {code: 2, error_message: `No .write permission on: ${valuePath}`};
     }
@@ -326,6 +366,10 @@ class DB {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // There is nothing to do.
+      return true;
+    }
     if (!this.getPermissionForFunction(localPath, address)) {
       return {code: 3, error_message: `No write_function permission on: ${functionPath}`};
     }
@@ -349,6 +393,10 @@ class DB {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // There is nothing to do.
+      return true;
+    }
     if (!this.getPermissionForRule(localPath, address)) {
       return {code: 3, error_message: `No write_rule permission on: ${rulePath}`};
     }
@@ -370,6 +418,10 @@ class DB {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
+    if (localPath === null) {
+      // There is nothing to do.
+      return true;
+    }
     if (!this.getPermissionForOwner(localPath, address)) {
       return {code: 4, error_message: `No write_owner or branch_owner permission on: ${ownerPath}`};
     }

--- a/db/index.js
+++ b/db/index.js
@@ -29,7 +29,7 @@ const RuleUtil = require('./rule-util');
 
 class DB {
   constructor(bc, blockNumberSnapshot) {
-    this.shardingPath = ChainUtil.parsePath(GenesisSharding[ShardingProperties.SHARDING_PATH]);
+    this.setShardingPath(GenesisSharding[ShardingProperties.SHARDING_PATH]);
     this.isRoot = (this.shardingPath.length === 0);
     this.stateTree = new StateNode();
     this.initDbData();
@@ -67,6 +67,27 @@ class DB {
   setFunctionsForTesting(functionsPath, functions) {
     this.writeDatabase([PredefinedDbPaths.FUNCTIONS_ROOT,
       ...ChainUtil.parsePath(functionsPath)], functions);
+  }
+
+  // For testing purpose only.
+  setValuesForTesting(valuesPath, values) {
+    this.writeDatabase([PredefinedDbPaths.VALUES_ROOT,
+      ...ChainUtil.parsePath(valuesPath)], values);
+  }
+
+  // For testing purpose only.
+  setShardingForTesting(sharding) {
+    this.setValuesForTesting(
+        ChainUtil.formatPath([PredefinedDbPaths.SHARDING, PredefinedDbPaths.SHARDING_CONFIG]),
+        sharding);
+    this.setShardingPath(sharding[ShardingProperties.SHARDING_PATH]);
+  }
+
+  /**
+   * Sets the sharding path of the database.
+   */
+  setShardingPath(shardingPath) {
+    this.shardingPath = ChainUtil.parsePath(shardingPath);
   }
 
   /**

--- a/db/index.js
+++ b/db/index.js
@@ -231,14 +231,14 @@ class DB {
   /**
    * Returns a proof of a state node.
    * 
-   * @param {*} dbPath full database path to the state node to be proved.
+   * @param {string} fullPath full database path to the state node to be proved.
    */
-  getProof(dbPath) {
+  getProof(fullPath) {
+    const parsedPath = ChainUtil.parsePath(fullPath);
     let node = this.stateTree;
-    const fullPath = ChainUtil.parsePath(dbPath);
     const rootProof = { [ProofProperties.PROOF_HASH]: node.getProofHash() };
     let proof = rootProof;
-    for (const label of fullPath) {
+    for (const label of parsedPath) {
       if (node.hasChild(label)) {
         node.getChildLabels().forEach(label => {
           Object.assign(proof,
@@ -316,7 +316,7 @@ class DB {
       } else if (op.type === ReadDbOperations.GET_OWNER) {
         resultList.push(this.getOwner(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.GET_PROOF) {
-        resultList.push(this.getProof(op.ref, op.is_global));
+        resultList.push(this.getProof(op.ref));
       } else if (op.type === ReadDbOperations.MATCH_FUNCTION) {
         resultList.push(this.matchFunction(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.MATCH_RULE) {

--- a/db/index.js
+++ b/db/index.js
@@ -228,7 +228,6 @@ class DB {
     return this.readDatabase(fullPath);
   }
 
-<<<<<<< HEAD
   /**
    * Returns a proof of a state node.
    * 
@@ -254,8 +253,6 @@ class DB {
     return rootProof;
   }
 
-=======
->>>>>>> Do not apply local path convertion to getProof().
   matchFunction(funcPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(funcPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;

--- a/db/index.js
+++ b/db/index.js
@@ -198,6 +198,7 @@ class DB {
     return this.readDatabase(fullPath);
   }
 
+<<<<<<< HEAD
   /**
    * Returns a proof of a state node.
    * 
@@ -223,6 +224,8 @@ class DB {
     return rootProof;
   }
 
+=======
+>>>>>>> Do not apply local path convertion to getProof().
   matchFunction(funcPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(funcPath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
@@ -507,9 +510,9 @@ class DB {
   /**
    * Returns full path with given root node.
    */
-  getFullPath(parsedPath, root) {
+  getFullPath(parsedPath, rootLabel) {
     const fullPath = parsedPath.slice();
-    fullPath.unshift(root);
+    fullPath.unshift(rootLabel);
     return fullPath;
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -156,32 +156,28 @@ class DB {
 
   getValue(valuePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(valuePath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.VALUES_ROOT);
     return this.readDatabase(fullPath);
   }
 
   getFunction(functionPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(functionPath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     return this.readDatabase(fullPath);
   }
 
   getRule(rulePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(rulePath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
     return this.readDatabase(fullPath);
   }
 
   getOwner(ownerPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(ownerPath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     return this.readDatabase(fullPath);
   }
@@ -213,36 +209,31 @@ class DB {
 
   matchFunction(funcPath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(funcPath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     return this.convertFunctionMatch(this.matchFunctionForParsedPath(localPath));
   }
 
   matchRule(valuePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(valuePath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     return this.convertRuleMatch(this.matchRuleForParsedPath(localPath));
   }
 
   matchOwner(rulePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(rulePath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     return this.convertOwnerMatch(this.matchOwnerForParsedPath(localPath));
   }
 
   evalRule(valuePath, value, isGlobal, address, timestamp) {
     const parsedPath = ChainUtil.parsePath(valuePath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     return this.getPermissionForValue(localPath, value, address, timestamp);
   }
 
   evalOwner(refPath, permission, isGlobal, address) {
     const parsedPath = ChainUtil.parsePath(refPath);
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     const matched = this.matchOwnerForParsedPath(localPath);
     return this.checkPermission(matched.closestOwner.config, address, permission);
   }
@@ -289,8 +280,7 @@ class DB {
     if (!isValidPath.isValid) {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (!this.getPermissionForValue(localPath, value, address, timestamp)) {
       return {code: 2, error_message: `No .write permission on: ${valuePath}`};
     }
@@ -335,8 +325,7 @@ class DB {
     if (!isValidPath.isValid) {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (!this.getPermissionForFunction(localPath, address)) {
       return {code: 3, error_message: `No write_function permission on: ${functionPath}`};
     }
@@ -359,8 +348,7 @@ class DB {
     if (!isValidPath.isValid) {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (!this.getPermissionForRule(localPath, address)) {
       return {code: 3, error_message: `No write_rule permission on: ${rulePath}`};
     }
@@ -381,8 +369,7 @@ class DB {
     if (!isValidPath.isValid) {
       return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
-    const localPath = (isGlobal === true && !this.isRoot) ?
-        this.toLocalPath(parsedPath) : parsedPath;
+    const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (!this.getPermissionForOwner(localPath, address)) {
       return {code: 4, error_message: `No write_owner or branch_owner permission on: ${ownerPath}`};
     }
@@ -478,6 +465,9 @@ class DB {
    * Converts to local path by removing the sharding path part of the given parsed path.
    */
   toLocalPath(parsedPath) {
+    if (this.isRoot) {
+      return parsedPath;
+    }
     if (parsedPath.length < this.shardingPath.length) {
       return null;
     }

--- a/db/index.js
+++ b/db/index.js
@@ -233,6 +233,7 @@ class DB {
    * 
    * @param {string} fullPath full database path to the state node to be proved.
    */
+  // TODO(seo): Consider supporting global path for getProof().
   getProof(fullPath) {
     const parsedPath = ChainUtil.parsePath(fullPath);
     let node = this.stateTree;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -53,6 +53,15 @@ class RuleUtil {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
 
+  isValShardProto(value) {
+    const { ShardingProtocols } = require('../constants');
+    return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;
+  }
+
+  toBool(value) {
+    return this.isBool(value) ? value : value === 'true';
+  }
+
   // TODO(lia): normalize addresses in rule strings using this function.
   toCksumAddr(addr) {
     try {
@@ -60,11 +69,6 @@ class RuleUtil {
     } catch (e) {
       return '';
     }
-  }
-
-  isValShardProto(value) {
-    const { ShardingProtocols } = require('../constants');
-    return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;
   }
 }
 

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -82,7 +82,7 @@ setUp = () => {
       op_list: [
         {
           type: 'SET_VALUE',
-          ref: 'test/test',
+          ref: 'test/test_value/some/path',
           value: 100
         },
         {
@@ -142,7 +142,7 @@ cleanUp = () => {
         },
         {
           type: 'SET_VALUE',
-          ref: 'test/test',
+          ref: 'test/test_value/some/path',
           value: null
         }
       ]
@@ -245,17 +245,18 @@ describe('API Tests', () => {
 
     describe('/get_value', () => {
       it('get_value', () => {
-        const body = JSON.parse(syncRequest('GET', server1 + '/get_value?ref=test/test')
-            .body.toString('utf-8'));
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_value?ref=test/test_value/some/path')
+          .body.toString('utf-8'));
         assert.deepEqual(body, {code: 0, result: 100});
       })
     })
 
     describe('/get_function', () => {
       it('get_function', () => {
-        const body =
-            JSON.parse(syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
-              .body.toString('utf-8'));
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
+          .body.toString('utf-8'));
         assert.deepEqual(body, {
           code: 0,
           result: {
@@ -528,7 +529,7 @@ describe('API Tests', () => {
           op_list: [
             {
               type: "GET_VALUE",
-              ref: "/test/test",
+              ref: "/test/test_value/some/path",
             },
             {
               type: 'GET_FUNCTION',
@@ -647,31 +648,31 @@ describe('API Tests', () => {
 
     describe('/set_value', () => {
       it('set_value', () => {
-        const request = {ref: 'test/value', value: "something"};
+        const request = {ref: 'test/test_value/some/path', value: "something"};
         const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
     describe('/inc_value', () => {
       it('inc_value', () => {
-        const request = {ref: "test/test", value: 10};
+        const request = {ref: "test/test_value/some/path", value: 10};
         const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
     describe('/dec_value', () => {
       it('dec_value', () => {
-        const request = {ref: "test/test", value: 10};
+        const request = {ref: "test/test_value/some/path", value: 10};
         const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -685,8 +686,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -700,8 +701,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -715,8 +716,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -731,12 +732,12 @@ describe('API Tests', () => {
             },
             {
               type: 'INC_VALUE',
-              ref: "test/test",
+              ref: "test/test_value/some/path",
               value: 10
             },
             {
               type: 'DEC_VALUE',
-              ref: "test/test2",
+              ref: "test/test_value/some/path2",
               value: 10
             },
             {
@@ -764,8 +765,8 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
           .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -783,14 +784,14 @@ describe('API Tests', () => {
             {
               operation: {
                 type: 'INC_VALUE',
-                ref: "test/test",
+                ref: "test/test_value/some/path",
                 value: 10
               }
             },
             {
               operation: {
                 type: 'DEC_VALUE',
-                ref: "test/test2",
+                ref: "test/test_value/some/path2",
                 value: 10
               }
             },
@@ -835,12 +836,12 @@ describe('API Tests', () => {
                   },
                   {
                     type: 'INC_VALUE',
-                    ref: "test/test",
+                    ref: "test/test_value/some/path",
                     value: 5
                   },
                   {
                     type: 'DEC_VALUE',
-                    ref: "test/test2",
+                    ref: "test/test_value/some/path2",
                     value: 5
                   },
                   {
@@ -871,7 +872,6 @@ describe('API Tests', () => {
         };
         const body = JSON.parse(syncRequest('POST', server1 + '/batch', {json: request})
             .body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.deepEqual(body.result.result, [
           true,
           true,
@@ -881,6 +881,7 @@ describe('API Tests', () => {
           true,
           true,
         ]);
+        assert.equal(body.code, 0);
       })
     })
 
@@ -991,8 +992,8 @@ describe('API Tests', () => {
           ref: transferPath + '/1/value',
           value: transferAmount
         }}).body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
         waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const fromAfterBalance = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
@@ -1137,8 +1138,8 @@ describe('API Tests', () => {
           ref: depositPath + '/1/value',
           value: depositAmount
         }}).body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
         waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/1/value`).body.toString('utf-8')).result;
@@ -1295,8 +1296,8 @@ describe('API Tests', () => {
           value: depositAmount,
           is_nonced_transaction: false // TODO (lia): remove this once state snapshot is fixed and txs aren't getting dropped
         }}).body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
         waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositAccountValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositAccountPath}/value`).body.toString('utf-8')).result;
@@ -1321,8 +1322,8 @@ describe('API Tests', () => {
           value: newDepositAmount,
           is_nonced_transaction: false // TODO (lia): remove this once state snapshot is fixed and txs aren't getting dropped
         }}).body.toString('utf-8'));
-        assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
         waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/3/value`).body.toString('utf-8')).result;

--- a/integration/dev.test.js
+++ b/integration/dev.test.js
@@ -58,7 +58,7 @@ const server1 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[0].ACCO
 const server2 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[1].ACCOUNT_INDEX))
 const server3 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[2].ACCOUNT_INDEX))
 const server4 = 'http://localhost:' + String(8081 + Number(ENV_VARIABLES[3].ACCOUNT_INDEX))
-const servers = [ server1, server2, server3, server4 ];
+const SERVERS = [ server1, server2, server3, server4 ];
 
 function startServer(application, serverName, envVars, stdioInherit = false) {
   const options = {
@@ -118,7 +118,7 @@ setUp = () => {
       ]
     }
   }).body.toString('utf-8')).result;
-  waitUntilTxFinalized(servers, res.tx_hash);
+  waitUntilTxFinalized(SERVERS, res.tx_hash);
 }
 
 cleanUp = () => {
@@ -148,7 +148,7 @@ cleanUp = () => {
       ]
     }
   }).body.toString('utf-8')).result;
-  waitUntilTxFinalized(servers, res.tx_hash);
+  waitUntilTxFinalized(SERVERS, res.tx_hash);
 }
 
 setUpForSharding = (shardingConfig) => {
@@ -203,7 +203,7 @@ setUpForSharding = (shardingConfig) => {
       }
     ).body.toString('utf-8')
   ).result;
-  waitUntilTxFinalized(servers, res.tx_hash);
+  waitUntilTxFinalized(SERVERS, res.tx_hash);
 }
 
 describe('API Tests', () => {
@@ -973,12 +973,12 @@ describe('API Tests', () => {
 
       let res = JSON.parse(syncRequest('POST', server1+'/set_value',
                   {json: {ref: `/accounts/${depositServiceAdmin}/balance`, value: 1000}}).body.toString('utf-8')).result;
-      waitUntilTxFinalized(servers, res.tx_hash);
+      waitUntilTxFinalized(SERVERS, res.tx_hash);
       res = JSON.parse(syncRequest('POST', server1+'/set_value', {json: {ref: depositBalancePath, value: 1000}}).body.toString('utf-8')).result;
-      waitUntilTxFinalized(servers, res.tx_hash);
+      waitUntilTxFinalized(SERVERS, res.tx_hash);
       res = JSON.parse(syncRequest('POST', server1+'/set_value',
                   {json: {ref: `/accounts/${depositActorBad}/balance`, value: 1000}}).body.toString('utf-8')).result;
-      waitUntilTxFinalized(servers, res.tx_hash);
+      waitUntilTxFinalized(SERVERS, res.tx_hash);
     })
 
     describe('_transfer', () => {
@@ -993,7 +993,7 @@ describe('API Tests', () => {
         }}).body.toString('utf-8'));
         assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
-        waitUntilTxFinalized(servers, body.result.tx_hash);
+        waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const fromAfterBalance = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = JSON.parse(syncRequest('GET',
@@ -1127,7 +1127,7 @@ describe('API Tests', () => {
           ]
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(0);
-        waitUntilTxFinalized(servers, body.result.tx_hash);
+        waitUntilTxFinalized(SERVERS, body.result.tx_hash);
       })
 
       it('deposit', () => {
@@ -1139,7 +1139,7 @@ describe('API Tests', () => {
         }}).body.toString('utf-8'));
         assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
-        waitUntilTxFinalized(servers, body.result.tx_hash);
+        waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/1/value`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',
@@ -1194,7 +1194,7 @@ describe('API Tests', () => {
         const account = ainUtil.createAccount();
         const res = JSON.parse(syncRequest('POST', server2+'/set_value',
                     {json: {ref: `/accounts/${account.address}/balance`, value: 1000}}).body.toString('utf-8')).result;
-        waitUntilTxFinalized(servers, res.tx_hash);
+        waitUntilTxFinalized(SERVERS, res.tx_hash);
         const transaction = {
           operation: {
             type: 'SET_VALUE',
@@ -1297,7 +1297,7 @@ describe('API Tests', () => {
         }}).body.toString('utf-8'));
         assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
-        waitUntilTxFinalized(servers, body.result.tx_hash);
+        waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositAccountValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositAccountPath}/value`).body.toString('utf-8')).result;
         const balance = JSON.parse(syncRequest('GET',
@@ -1323,7 +1323,7 @@ describe('API Tests', () => {
         }}).body.toString('utf-8'));
         assert.equal(body.code, 0);
         assert.equal(body.result.result, true);
-        waitUntilTxFinalized(servers, body.result.tx_hash);
+        waitUntilTxFinalized(SERVERS, body.result.tx_hash);
         const depositValue = JSON.parse(syncRequest('GET',
             server2 + `/get_value?ref=${depositPath}/3/value`).body.toString('utf-8')).result;
         const depositAccountValue = JSON.parse(syncRequest('GET',
@@ -1353,7 +1353,7 @@ describe('API Tests', () => {
         const shardReportRes = JSON.parse(
           syncRequest('POST', server2 + '/set_value', { json: reportVal }).body.toString('utf-8')
         ).result;
-        waitUntilTxFinalized(servers, shardReportRes.tx_hash);
+        waitUntilTxFinalized(SERVERS, shardReportRes.tx_hash);
         const shardingPathRes = JSON.parse(
           syncRequest('GET', server1 + `/get_value?ref=${shardingPath}`).body.toString('utf-8')
         ).result;
@@ -1381,7 +1381,7 @@ describe('API Tests', () => {
         const shardReportRes = JSON.parse(
           syncRequest('POST', server2 + '/set', { json: multipleReportVal }).body.toString('utf-8')
         ).result;
-        waitUntilTxFinalized(servers, shardReportRes.tx_hash);
+        waitUntilTxFinalized(SERVERS, shardReportRes.tx_hash);
         const shardingPathRes = JSON.parse(
           syncRequest('GET', server1 + `/get_value?ref=${shardingPath}`).body.toString('utf-8')
         ).result;

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -349,6 +349,14 @@ describe('Sharding', () => {
         assert.deepEqual(body.result, 100);
       })
 
+      it('/get_value with is_global = false (explicit)', () => {
+        const body = JSON.parse(syncRequest(
+            'GET', server1 + '/get_value?ref=/test/test_value/some/path&is_global=false')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, 100);
+      })
+
       it('/get_value with is_global = true', () => {
         const body = JSON.parse(syncRequest(
             'GET', server1 + '/get_value?ref=/apps/afan/test/test_value/some/path&is_global=true')

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -4,21 +4,24 @@ const assert = chai.assert;
 const expect = chai.expect;
 const spawn = require("child_process").spawn;
 const ainUtil = require('@ainblockchain/ain-util');
+const sleep = require('system-sleep');
+const syncRequest = require('sync-request');
+const jayson = require('jayson/promise');
+const rimraf = require("rimraf")
+const _ = require('lodash');
 const PROJECT_ROOT = require('path').dirname(__filename) + "/../"
 const TRACKER_SERVER = PROJECT_ROOT + "tracker-server/index.js"
 const APP_SERVER = PROJECT_ROOT + "client/index.js"
-const sleep = require('system-sleep');
-const syncRequest = require('sync-request');
-const rimraf = require("rimraf")
-const _ = require('lodash');
 const {
   BLOCKCHAINS_DIR,
 } = require('../constants');
 const {
   readConfigFile,
   waitForNewBlocks,
-  waitUntilNodeSyncs
+  waitUntilNodeSyncs,
+  waitUntilTxFinalized,
 } = require('../test/test-util');
+const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
 
 const ENV_VARIABLES = [
   {
@@ -64,6 +67,7 @@ const server1 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[2].ACCO
 const server2 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[3].ACCOUNT_INDEX))
 const server3 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[4].ACCOUNT_INDEX))
 const server4 = 'http://localhost:' + String(9091 + Number(ENV_VARIABLES[5].ACCOUNT_INDEX))
+const SERVERS = [ server1, server2, server3, server4 ];
 
 function startServer(application, serverName, envVars, stdioInherit = false) {
   const options = {
@@ -93,6 +97,81 @@ function waitUntilShardReporterStarts() {
   }
 }
 
+setUp = () => {
+  let res = JSON.parse(syncRequest('POST', server2 + '/set', {
+    json: {
+      op_list: [
+        {
+          type: 'SET_VALUE',
+          ref: 'test/test_value/some/path',
+          value: 100
+        },
+        {
+          type: 'SET_RULE',
+          ref: '/test/test_rule/some/path',
+          value: {
+            ".write": "auth === 'abcd'"
+          }
+        },
+        {
+          type: 'SET_FUNCTION',
+          ref: '/test/test_function/some/path',
+          value: {
+            ".function": "some function config"
+          }
+        },
+        {
+          type: 'SET_OWNER',
+          ref: '/test/test_owner/some/path',
+          value: {
+            ".owner": {
+              "owners": {
+                "*": {
+                  "branch_owner": false,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": false,
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }).body.toString('utf-8')).result;
+  waitUntilTxFinalized(SERVERS, res.tx_hash);
+}
+
+cleanUp = () => {
+  let res = JSON.parse(syncRequest('POST', server2 + '/set', {
+    json: {
+      op_list: [
+        {
+          type: 'SET_OWNER',
+          ref: '/test/test_owner/some/path',
+          value: null
+        },
+        {
+          type: 'SET_RULE',
+          ref: '/test/test_rule/some/path',
+          value: null
+        },
+        {
+          type: 'SET_FUNCTION',
+          ref: '/test/test_function/some/path',
+          value: null
+        },
+        {
+          type: 'SET_VALUE',
+          ref: 'test/test_value/some/path',
+          value: null
+        }
+      ]
+    }
+  }).body.toString('utf-8')).result;
+  waitUntilTxFinalized(SERVERS, res.tx_hash);
+}
+
 describe('Sharding', () => {
   const token =
       readConfigFile(path.resolve(__dirname, '../blockchain/afan_shard', 'genesis_token.json'));
@@ -109,7 +188,7 @@ describe('Sharding', () => {
 
     parent_chain_tracker_proc = startServer(TRACKER_SERVER, 'parent tracker server', {}, false);
     sleep(2000);
-    parent_chain_server_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[0]);
+    parent_chain_server_proc = startServer(APP_SERVER, 'parent server1', ENV_VARIABLES[0]);
     sleep(2000);
     tracker_proc = startServer(TRACKER_SERVER, 'tracker server', ENV_VARIABLES[1], false);
     sleep(2000);
@@ -135,7 +214,6 @@ describe('Sharding', () => {
 
     rimraf.sync(BLOCKCHAINS_DIR)
   });
-
 
   describe('Parent chain initialization', () => {
     describe('DB values', () => {
@@ -252,6 +330,900 @@ describe('Sharding', () => {
       })
     })
   });
+
+  describe('API Tests', () => {
+    describe('APIs (gets)', () => {
+      before(() => {
+        setUp();
+      })
+
+      after(() => {
+        cleanUp();
+      })
+
+      it('/get_value with is_global = false', () => {
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_value?ref=/test/test_value/some/path')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, 100);
+      })
+
+      it('/get_value with is_global = true', () => {
+        const body = JSON.parse(syncRequest(
+            'GET', server1 + '/get_value?ref=/apps/afan/test/test_value/some/path&is_global=true')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, 100);
+      })
+
+      it('/get_function with is_global = false', () => {
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, { '.function': 'some function config' });
+      })
+
+      it('/get_function with is_global = true', () => {
+        const body = JSON.parse(syncRequest(
+            'GET', server1 + '/get_function?ref=/apps/afan/test/test_function/some/path&is_global=true')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, { '.function': 'some function config' });
+      })
+
+      it('/get_rule with is_global = false', () => {
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_rule?ref=/test/test_rule/some/path')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
+      })
+
+      it('/get_rule with is_global = true', () => {
+        const body = JSON.parse(syncRequest(
+            'GET', server1 + '/get_rule?ref=/apps/afan/test/test_rule/some/path&is_global=true')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
+      })
+
+      it('/get_owner with is_global = false', () => {
+        const body = JSON.parse(
+            syncRequest('GET', server1 + '/get_owner?ref=/test/test_owner/some/path')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, {
+          ".owner": {
+            "owners": {
+              "*": {
+                "branch_owner": false,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": false,
+              }
+            }
+          }
+        });
+      })
+
+      it('/get_owner with is_global = true', () => {
+        const body = JSON.parse(syncRequest(
+            'GET', server1 + '/get_owner?ref=/apps/afan/test/test_owner/some/path&is_global=true')
+          .body.toString('utf-8'));
+        assert.equal(body.code, 0);
+        assert.deepEqual(body.result, {
+          ".owner": {
+            "owners": {
+              "*": {
+                "branch_owner": false,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": false,
+              }
+            }
+          }
+        });
+      })
+
+      it('/match_function with is_global = false', () => {
+        const ref = "/test/test_function/some/path";
+        const body = JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/test/test_function/some/path",
+            "ref_path": "/test/test_function/some/path",
+            "path_vars": {},
+          },
+          "matched_config": {
+            "config": "some function config",
+            "path": "/test/test_function/some/path"
+          },
+          "subtree_configs": []
+        }});
+      })
+
+      it('/match_function with is_global = true', () => {
+        const ref = "/apps/afan/test/test_function/some/path";
+        const body =
+            JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}&is_global=true`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/apps/afan/test/test_function/some/path",
+            "ref_path": "/apps/afan/test/test_function/some/path",
+            "path_vars": {},
+          },
+          "matched_config": {
+            "config": "some function config",
+            "path": "/apps/afan/test/test_function/some/path"
+          },
+          "subtree_configs": []
+        }});
+      })
+
+      it('/match_rule with is_global = false', () => {
+        const ref = "/test/test_rule/some/path";
+        const body = JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/test/test_rule/some/path",
+            "ref_path": "/test/test_rule/some/path",
+            "path_vars": {},
+          },
+          "matched_config": {
+            "config": "auth === 'abcd'",
+            "path": "/test/test_rule/some/path"
+          },
+          "subtree_configs": []
+        }});
+      })
+
+      it('/match_rule with is_global = true', () => {
+        const ref = "/apps/afan/test/test_rule/some/path";
+        const body =
+            JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}&is_global=true`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/apps/afan/test/test_rule/some/path",
+            "ref_path": "/apps/afan/test/test_rule/some/path",
+            "path_vars": {},
+          },
+          "matched_config": {
+            "config": "auth === 'abcd'",
+            "path": "/apps/afan/test/test_rule/some/path"
+          },
+          "subtree_configs": []
+        }});
+      })
+
+      it('/match_owner with is_global = false', () => {
+        const ref = "/test/test_owner/some/path";
+        const body = JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/test/test_owner/some/path"
+          },
+          "matched_config": {
+            "config": {
+              "owners": {
+                "*": {
+                  "branch_owner": false,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": false
+                }
+              }
+            },
+            "path": "/test/test_owner/some/path"
+          }
+        }});
+      })
+
+      it('/match_owner with is_global = true', () => {
+        const ref = "/apps/afan/test/test_owner/some/path";
+        const body =
+            JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}&is_global=true`)
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: {
+          "matched_path": {
+            "target_path": "/apps/afan/test/test_owner/some/path"
+          },
+          "matched_config": {
+            "config": {
+              "owners": {
+                "*": {
+                  "branch_owner": false,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": false
+                }
+              }
+            },
+            "path": "/apps/afan/test/test_owner/some/path"
+          }
+        }});
+      })
+
+      it('/eval_rule with is_global = false', () => {
+        const ref = "/test/test_rule/some/path";
+        const value = "value";
+        const address = "abcd";
+        const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
+        const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: true});
+      })
+
+      it('/eval_rule with is_global = true', () => {
+        const ref = "/apps/afan/test/test_rule/some/path";
+        const value = "value";
+        const address = "abcd";
+        const is_global = true;
+        const request = { ref, value, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
+        const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {code: 0, result: true});
+      })
+
+      it('/eval_owner with is_global = false', () => {
+        const ref = "/test/test_owner/some/path";
+        const address = "abcd";
+        const permission = "write_owner";
+        const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
+        const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: true,
+        });
+      })
+
+      it('/eval_owner with is_global = true', () => {
+        const ref = "/apps/afan/test/test_owner/some/path";
+        const address = "abcd";
+        const permission = "write_owner";
+        const is_global = true;
+        const request = { ref, permission, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
+        const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: true,
+        });
+      })
+
+      it('/get with is_global = false', () => {
+        const request = {
+          op_list: [
+            {
+              type: "GET_VALUE",
+              ref: "/test/test_value/some/path",
+            },
+            {
+              type: 'GET_FUNCTION',
+              ref: "/test/test_function/some/path",
+            },
+            {
+              type: 'GET_RULE',
+              ref: "/test/test_rule/some/path",
+            },
+            {
+              type: 'GET_OWNER',
+              ref: "/test/test_owner/some/path",
+            },
+            {
+              type: 'EVAL_RULE',
+              ref: "/test/test_rule/some/path",
+              value: "value",
+              address: "abcd"
+            },
+            {
+              type: 'EVAL_OWNER',
+              ref: "/test/test_owner/some/path",
+              permission: "write_owner",
+              address: "abcd"
+            }
+          ]
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: [
+            100,
+            {
+              ".function": "some function config"
+            },
+            {
+              ".write": "auth === 'abcd'"
+            },
+            {
+              ".owner": {
+                "owners": {
+                  "*": {
+                    "branch_owner": false,
+                    "write_function": true,
+                    "write_owner": true,
+                    "write_rule": false,
+                  }
+                }
+              }
+            },
+            true,
+            true,
+          ]
+        });
+      })
+
+      it('/get with is_global = true', () => {
+        const request = {
+          op_list: [
+            {
+              type: "GET_VALUE",
+              ref: "/apps/afan/test/test_value/some/path",
+              is_global: true,
+            },
+            {
+              type: 'GET_FUNCTION',
+              ref: "/apps/afan/test/test_function/some/path",
+              is_global: true,
+            },
+            {
+              type: 'GET_RULE',
+              ref: "/apps/afan/test/test_rule/some/path",
+              is_global: true,
+            },
+            {
+              type: 'GET_OWNER',
+              ref: "/apps/afan/test/test_owner/some/path",
+              is_global: true,
+            },
+            {
+              type: 'EVAL_RULE',
+              ref: "/apps/afan/test/test_rule/some/path",
+              value: "value",
+              address: "abcd",
+              is_global: true,
+            },
+            {
+              type: 'EVAL_OWNER',
+              ref: "/apps/afan/test/test_owner/some/path",
+              permission: "write_owner",
+              address: "abcd",
+              is_global: true,
+            }
+          ]
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: [
+            100,
+            {
+              ".function": "some function config"
+            },
+            {
+              ".write": "auth === 'abcd'"
+            },
+            {
+              ".owner": {
+                "owners": {
+                  "*": {
+                    "branch_owner": false,
+                    "write_function": true,
+                    "write_owner": true,
+                    "write_rule": false,
+                  }
+                }
+              }
+            },
+            true,
+            true,
+          ]
+        });
+      })
+
+      it('ain_get with is_global = false', () => {
+        const expected = 100;
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request('ain_get', {
+          protoVer: CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/test/test_value/some/path"
+        })
+        .then(res => {
+          expect(res.result.result).to.equal(expected);
+        });
+      });
+
+      it('ain_get with is_global = true', () => {
+        const expected = 100;
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request('ain_get', {
+          protoVer: CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/afan/test/test_value/some/path",
+          is_global: true,
+        })
+        .then(res => {
+          expect(res.result.result).to.equal(expected);
+        });
+      });
+
+      it('ain_matchFunction with is_global = false', () => {
+        const ref = "/test/test_function/some/path";
+        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/test/test_function/some/path",
+              "ref_path": "/test/test_function/some/path",
+              "path_vars": {},
+            },
+            "matched_config": {
+              "config": "some function config",
+              "path": "/test/test_function/some/path"
+            },
+            "subtree_configs": []
+          });
+        })
+      })
+
+      it('ain_matchFunction with is_global = true', () => {
+        const ref = "/apps/afan/test/test_function/some/path";
+        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/apps/afan/test/test_function/some/path",
+              "ref_path": "/apps/afan/test/test_function/some/path",
+              "path_vars": {},
+            },
+            "matched_config": {
+              "config": "some function config",
+              "path": "/apps/afan/test/test_function/some/path"
+            },
+            "subtree_configs": []
+          });
+        })
+      })
+
+      it('ain_matchRule with is_global = false', () => {
+        const ref = "/test/test_rule/some/path";
+        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/test/test_rule/some/path",
+              "ref_path": "/test/test_rule/some/path",
+              "path_vars": {},
+            },
+            "matched_config": {
+              "config": "auth === 'abcd'",
+              "path": "/test/test_rule/some/path"
+            },
+            "subtree_configs": []
+          });
+        })
+      })
+
+      it('ain_matchRule with is_global = true', () => {
+        const ref = "/apps/afan/test/test_rule/some/path";
+        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/apps/afan/test/test_rule/some/path",
+              "ref_path": "/apps/afan/test/test_rule/some/path",
+              "path_vars": {},
+            },
+            "matched_config": {
+              "config": "auth === 'abcd'",
+              "path": "/apps/afan/test/test_rule/some/path"
+            },
+            "subtree_configs": []
+          });
+        })
+      })
+
+      it('ain_matchOwner with is_global = false', () => {
+        const ref = "/test/test_owner/some/path";
+        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/test/test_owner/some/path"
+            },
+            "matched_config": {
+              "config": {
+                "owners": {
+                  "*": {
+                    "branch_owner": false,
+                    "write_function": true,
+                    "write_owner": true,
+                    "write_rule": false
+                  }
+                }
+              },
+              "path": "/test/test_owner/some/path"
+            }
+          });
+        })
+      })
+
+      it('ain_matchOwner with is_global = true', () => {
+        const ref = "/apps/afan/test/test_owner/some/path";
+        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "matched_path": {
+              "target_path": "/apps/afan/test/test_owner/some/path"
+            },
+            "matched_config": {
+              "config": {
+                "owners": {
+                  "*": {
+                    "branch_owner": false,
+                    "write_function": true,
+                    "write_owner": true,
+                    "write_rule": false
+                  }
+                }
+              },
+              "path": "/apps/afan/test/test_owner/some/path"
+            }
+          });
+        })
+      })
+
+      it('ain_evalRule with is_global = false', () => {
+        const ref = "/test/test_rule/some/path";
+        const value = "value";
+        const address = "abcd";
+        const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
+        .then(res => {
+          expect(res.result.result).to.equal(true);
+        })
+      })
+
+      it('ain_evalRule with is_global = true', () => {
+        const ref = "/apps/afan/test/test_rule/some/path";
+        const value = "value";
+        const address = "abcd";
+        const request =
+            { ref, value, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
+        .then(res => {
+          expect(res.result.result).to.equal(true);
+        })
+      })
+
+      it('ain_evalOwner with is_global = false', () => {
+        const ref = "/test/test_owner/some/path";
+        const address = "abcd";
+        const permission = "write_owner";
+        const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, true);
+        })
+      })
+
+      it('ain_evalOwner with is_global = true', () => {
+        const ref = "/apps/afan/test/test_owner/some/path";
+        const address = "abcd";
+        const permission = "write_owner";
+        const request =
+            { ref, permission, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+        return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
+        .then(res => {
+          assert.deepEqual(res.result.result, true);
+        })
+      })
+    })
+
+    describe('APIs (sets)', () => {
+      beforeEach(() => {
+        setUp();
+      })
+
+      afterEach(() => {
+        cleanUp();
+      })
+
+      it('/set_value with is_global = false', () => {
+        const request = {ref: 'test/test_value/some/path', value: "some value"};
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_value with is_global = true', () => {
+        const request = {
+          ref: 'apps/afan/test/test_value/some/path', value: "some value", is_global: true
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/inc_value with is_global = false', () => {
+        const request = {ref: 'test/test_value/some/path', value: 10};
+        const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/inc_value with is_global = true', () => {
+        const request = {
+          ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/dec_value with is_global = false', () => {
+        const request = {ref: 'test/test_value/some/path', value: 10};
+        const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/dec_value with is_global = true', () => {
+        const request = {
+          ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
+          .body.toString('utf-8'));
+        assert.deepEqual(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_function with is_global = false', () => {
+        const request = {
+          ref: "test/test_function/other/path",
+          value: {
+            ".function": "some other function config"
+          }
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_function with is_global = true', () => {
+        const request = {
+          ref: "apps/afan/test/test_function/other/path",
+          value: {
+            ".function": "some other function config"
+          },
+          is_global: true,
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_rule with is_global = false', () => {
+        const request = {
+          ref: "test/test_rule/other/path",
+          value: {
+            ".write": "some other rule config"
+          }
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_rule with is_global = true', () => {
+        const request = {
+          ref: "apps/afan/test/test_rule/other/path",
+          value: {
+            ".write": "some other rule config"
+          },
+          is_global: true,
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_owner with is_global = false', () => {
+        const request = {
+          ref: "test/test_owner/other/path",
+          value: {
+            ".owner": "some other owner config"
+          }
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set_owner with is_global = true', () => {
+        const request = {
+          ref: "apps/afan/test/test_owner/other2/path",
+          value: {
+            ".owner": "some other2 owner config"
+          },
+          is_global: true,
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set with is_global = false', () => {
+        const request = {
+          op_list: [
+            {
+              // Default type: SET_VALUE
+              ref: "test/test_value/other3/path",
+              value: "some other3 value",
+            },
+            {
+              type: 'INC_VALUE',
+              ref: "test/test_value/some/path",
+              value: 10
+            },
+            {
+              type: 'DEC_VALUE',
+              ref: "test/test_value/some/path2",
+              value: 10
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: "/test/test_function/other3/path",
+              value: {
+                ".function": "some other3 function config"
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: "/test/test_rule/other3/path",
+              value: {
+                ".write": "some other3 rule config"
+              }
+            },
+            {
+              type: 'SET_OWNER',
+              ref: "/test/test_owner/other3/path",
+              value: {
+                ".owner": "some other3 owner config"
+              }
+            }
+          ]
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('/set with is_global = true', () => {
+        const request = {
+          op_list: [
+            {
+              // Default type: SET_VALUE
+              ref: "test/test_value/other4/path",
+              value: "some other4 value",
+              is_global: true,
+            },
+            {
+              type: 'INC_VALUE',
+              ref: "test/test_value/some/path",
+              value: 10,
+              is_global: true,
+            },
+            {
+              type: 'DEC_VALUE',
+              ref: "test/test_value/some/path4",
+              value: 10,
+              is_global: true,
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: "/test/test_function/other4/path",
+              value: {
+                ".function": "some other4 function config"
+              },
+              is_global: true,
+            },
+            {
+              type: 'SET_RULE',
+              ref: "/test/test_rule/other4/path",
+              value: {
+                ".write": "some other4 rule config"
+              },
+              is_global: true,
+            },
+            {
+              type: 'SET_OWNER',
+              ref: "/test/test_owner/other4/path",
+              value: {
+                ".owner": "some other4 owner config"
+              },
+              is_global: true,
+            }
+          ]
+        };
+        const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
+          .body.toString('utf-8'));
+        assert.equal(body.result.result, true);
+        assert.equal(body.code, 0);
+      })
+
+      it('ain_sendSignedTransaction with is_global = false', () => {
+        const account = ainUtil.createAccount();
+        const client = jayson.client.http(server1 + '/json-rpc');
+        const transaction = {
+          operation: {
+            type: 'SET_VALUE',
+            value: 'some other value',
+            ref: `test/test_value/some/path`
+          },
+          timestamp: Date.now(),
+          nonce: -1
+        }
+        const signature =
+            ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+        return client.request('ain_sendSignedTransaction', { transaction, signature,
+            protoVer: CURRENT_PROTOCOL_VERSION })
+          .then((res) => {
+            assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
+          })
+      })
+
+      it('ain_sendSignedTransaction with is_global = true', () => {
+        const account = ainUtil.createAccount();
+        const client = jayson.client.http(server1 + '/json-rpc');
+        const transaction = {
+          operation: {
+            type: 'SET_VALUE',
+            value: 'some other value',
+            ref: `apps/afan/test/test_value/some/path`,
+            is_global: true,
+          },
+          timestamp: Date.now(),
+          nonce: -1
+        }
+        const signature =
+            ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+        return client.request('ain_sendSignedTransaction', { transaction, signature,
+            protoVer: CURRENT_PROTOCOL_VERSION })
+          .then((res) => {
+            assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
+          })
+      })
+    })
+  })
 
   describe('Shard state proof hash reporting', () => {
     before(() => {

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -393,436 +393,114 @@ describe('Sharding', () => {
         cleanUp();
       })
 
-      it('/get_value with is_global = false', () => {
-        const body = JSON.parse(
-            syncRequest('GET', server1 + '/get_value?ref=/test/test_value/some/path')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, 100);
+      describe('/get_value', () => {
+        it('/get_value with is_global = false', () => {
+          const body = JSON.parse(
+              syncRequest('GET', server1 + '/get_value?ref=/test/test_value/some/path')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, 100);
+        })
+
+        it('/get_value with is_global = false (explicit)', () => {
+          const body = JSON.parse(syncRequest(
+              'GET', server1 + '/get_value?ref=/test/test_value/some/path&is_global=false')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, 100);
+        })
+
+        it('/get_value with is_global = true', () => {
+          const body = JSON.parse(syncRequest(
+              'GET', server1 + '/get_value?ref=/apps/afan/test/test_value/some/path&is_global=true')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, 100);
+        })
       })
 
-      it('/get_value with is_global = false (explicit)', () => {
-        const body = JSON.parse(syncRequest(
-            'GET', server1 + '/get_value?ref=/test/test_value/some/path&is_global=false')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, 100);
+      describe('/get_function', () => {
+        it('/get_function with is_global = false', () => {
+          const body = JSON.parse(
+              syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, { '.function': 'some function config' });
+        })
+
+        it('/get_function with is_global = true', () => {
+          const body = JSON.parse(syncRequest(
+              'GET', server1 + '/get_function?ref=/apps/afan/test/test_function/some/path&is_global=true')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, { '.function': 'some function config' });
+        })
       })
 
-      it('/get_value with is_global = true', () => {
-        const body = JSON.parse(syncRequest(
-            'GET', server1 + '/get_value?ref=/apps/afan/test/test_value/some/path&is_global=true')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, 100);
+      describe('/get_rule', () => {
+        it('/get_rule with is_global = false', () => {
+          const body = JSON.parse(
+              syncRequest('GET', server1 + '/get_rule?ref=/test/test_rule/some/path')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
+        })
+
+        it('/get_rule with is_global = true', () => {
+          const body = JSON.parse(syncRequest(
+              'GET', server1 + '/get_rule?ref=/apps/afan/test/test_rule/some/path&is_global=true')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
+        })
       })
 
-      it('/get_function with is_global = false', () => {
-        const body = JSON.parse(
-            syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, { '.function': 'some function config' });
-      })
-
-      it('/get_function with is_global = true', () => {
-        const body = JSON.parse(syncRequest(
-            'GET', server1 + '/get_function?ref=/apps/afan/test/test_function/some/path&is_global=true')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, { '.function': 'some function config' });
-      })
-
-      it('/get_rule with is_global = false', () => {
-        const body = JSON.parse(
-            syncRequest('GET', server1 + '/get_rule?ref=/test/test_rule/some/path')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
-      })
-
-      it('/get_rule with is_global = true', () => {
-        const body = JSON.parse(syncRequest(
-            'GET', server1 + '/get_rule?ref=/apps/afan/test/test_rule/some/path&is_global=true')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, { '.write': 'auth === \'abcd\'' });
-      })
-
-      it('/get_owner with is_global = false', () => {
-        const body = JSON.parse(
-            syncRequest('GET', server1 + '/get_owner?ref=/test/test_owner/some/path')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, {
-          ".owner": {
-            "owners": {
-              "*": {
-                "branch_owner": false,
-                "write_function": true,
-                "write_owner": true,
-                "write_rule": false,
-              }
-            }
-          }
-        });
-      })
-
-      it('/get_owner with is_global = true', () => {
-        const body = JSON.parse(syncRequest(
-            'GET', server1 + '/get_owner?ref=/apps/afan/test/test_owner/some/path&is_global=true')
-          .body.toString('utf-8'));
-        assert.equal(body.code, 0);
-        assert.deepEqual(body.result, {
-          ".owner": {
-            "owners": {
-              "*": {
-                "branch_owner": false,
-                "write_function": true,
-                "write_owner": true,
-                "write_rule": false,
-              }
-            }
-          }
-        });
-      })
-
-      it('/match_function with is_global = false', () => {
-        const ref = "/test/test_function/some/path";
-        const body = JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/test/test_function/some/path",
-            "ref_path": "/test/test_function/some/path",
-            "path_vars": {},
-          },
-          "matched_config": {
-            "config": "some function config",
-            "path": "/test/test_function/some/path"
-          },
-          "subtree_configs": []
-        }});
-      })
-
-      it('/match_function with is_global = true', () => {
-        const ref = "/apps/afan/test/test_function/some/path";
-        const body =
-            JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}&is_global=true`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/apps/afan/test/test_function/some/path",
-            "ref_path": "/apps/afan/test/test_function/some/path",
-            "path_vars": {},
-          },
-          "matched_config": {
-            "config": "some function config",
-            "path": "/apps/afan/test/test_function/some/path"
-          },
-          "subtree_configs": []
-        }});
-      })
-
-      it('/match_rule with is_global = false', () => {
-        const ref = "/test/test_rule/some/path";
-        const body = JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/test/test_rule/some/path",
-            "ref_path": "/test/test_rule/some/path",
-            "path_vars": {},
-          },
-          "matched_config": {
-            "config": "auth === 'abcd'",
-            "path": "/test/test_rule/some/path"
-          },
-          "subtree_configs": []
-        }});
-      })
-
-      it('/match_rule with is_global = true', () => {
-        const ref = "/apps/afan/test/test_rule/some/path";
-        const body =
-            JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}&is_global=true`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/apps/afan/test/test_rule/some/path",
-            "ref_path": "/apps/afan/test/test_rule/some/path",
-            "path_vars": {},
-          },
-          "matched_config": {
-            "config": "auth === 'abcd'",
-            "path": "/apps/afan/test/test_rule/some/path"
-          },
-          "subtree_configs": []
-        }});
-      })
-
-      it('/match_owner with is_global = false', () => {
-        const ref = "/test/test_owner/some/path";
-        const body = JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/test/test_owner/some/path"
-          },
-          "matched_config": {
-            "config": {
+      describe('/get_owner', () => {
+        it('/get_owner with is_global = false', () => {
+          const body = JSON.parse(
+              syncRequest('GET', server1 + '/get_owner?ref=/test/test_owner/some/path')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, {
+            ".owner": {
               "owners": {
                 "*": {
                   "branch_owner": false,
                   "write_function": true,
                   "write_owner": true,
-                  "write_rule": false
+                  "write_rule": false,
                 }
               }
-            },
-            "path": "/test/test_owner/some/path"
-          }
-        }});
-      })
+            }
+          });
+        })
 
-      it('/match_owner with is_global = true', () => {
-        const ref = "/apps/afan/test/test_owner/some/path";
-        const body =
-            JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}&is_global=true`)
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: {
-          "matched_path": {
-            "target_path": "/apps/afan/test/test_owner/some/path"
-          },
-          "matched_config": {
-            "config": {
+        it('/get_owner with is_global = true', () => {
+          const body = JSON.parse(syncRequest(
+              'GET', server1 + '/get_owner?ref=/apps/afan/test/test_owner/some/path&is_global=true')
+            .body.toString('utf-8'));
+          assert.equal(body.code, 0);
+          assert.deepEqual(body.result, {
+            ".owner": {
               "owners": {
                 "*": {
                   "branch_owner": false,
                   "write_function": true,
                   "write_owner": true,
-                  "write_rule": false
+                  "write_rule": false,
                 }
               }
-            },
-            "path": "/apps/afan/test/test_owner/some/path"
-          }
-        }});
-      })
-
-      it('/eval_rule with is_global = false', () => {
-        const ref = "/test/test_rule/some/path";
-        const value = "value";
-        const address = "abcd";
-        const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
-        const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-      })
-
-      it('/eval_rule with is_global = true', () => {
-        const ref = "/apps/afan/test/test_rule/some/path";
-        const value = "value";
-        const address = "abcd";
-        const is_global = true;
-        const request = { ref, value, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
-        const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {code: 0, result: true});
-      })
-
-      it('/eval_owner with is_global = false', () => {
-        const ref = "/test/test_owner/some/path";
-        const address = "abcd";
-        const permission = "write_owner";
-        const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
-        const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {
-          code: 0,
-          result: true,
-        });
-      })
-
-      it('/eval_owner with is_global = true', () => {
-        const ref = "/apps/afan/test/test_owner/some/path";
-        const address = "abcd";
-        const permission = "write_owner";
-        const is_global = true;
-        const request = { ref, permission, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
-        const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {
-          code: 0,
-          result: true,
-        });
-      })
-
-      it('/get with is_global = false', () => {
-        const request = {
-          op_list: [
-            {
-              type: "GET_VALUE",
-              ref: "/test/test_value/some/path",
-            },
-            {
-              type: 'GET_FUNCTION',
-              ref: "/test/test_function/some/path",
-            },
-            {
-              type: 'GET_RULE',
-              ref: "/test/test_rule/some/path",
-            },
-            {
-              type: 'GET_OWNER',
-              ref: "/test/test_owner/some/path",
-            },
-            {
-              type: 'EVAL_RULE',
-              ref: "/test/test_rule/some/path",
-              value: "value",
-              address: "abcd"
-            },
-            {
-              type: 'EVAL_OWNER',
-              ref: "/test/test_owner/some/path",
-              permission: "write_owner",
-              address: "abcd"
             }
-          ]
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {
-          code: 0,
-          result: [
-            100,
-            {
-              ".function": "some function config"
-            },
-            {
-              ".write": "auth === 'abcd'"
-            },
-            {
-              ".owner": {
-                "owners": {
-                  "*": {
-                    "branch_owner": false,
-                    "write_function": true,
-                    "write_owner": true,
-                    "write_rule": false,
-                  }
-                }
-              }
-            },
-            true,
-            true,
-          ]
-        });
+          });
+        })
       })
 
-      it('/get with is_global = true', () => {
-        const request = {
-          op_list: [
-            {
-              type: "GET_VALUE",
-              ref: "/apps/afan/test/test_value/some/path",
-              is_global: true,
-            },
-            {
-              type: 'GET_FUNCTION',
-              ref: "/apps/afan/test/test_function/some/path",
-              is_global: true,
-            },
-            {
-              type: 'GET_RULE',
-              ref: "/apps/afan/test/test_rule/some/path",
-              is_global: true,
-            },
-            {
-              type: 'GET_OWNER',
-              ref: "/apps/afan/test/test_owner/some/path",
-              is_global: true,
-            },
-            {
-              type: 'EVAL_RULE',
-              ref: "/apps/afan/test/test_rule/some/path",
-              value: "value",
-              address: "abcd",
-              is_global: true,
-            },
-            {
-              type: 'EVAL_OWNER',
-              ref: "/apps/afan/test/test_owner/some/path",
-              permission: "write_owner",
-              address: "abcd",
-              is_global: true,
-            }
-          ]
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body, {
-          code: 0,
-          result: [
-            100,
-            {
-              ".function": "some function config"
-            },
-            {
-              ".write": "auth === 'abcd'"
-            },
-            {
-              ".owner": {
-                "owners": {
-                  "*": {
-                    "branch_owner": false,
-                    "write_function": true,
-                    "write_owner": true,
-                    "write_rule": false,
-                  }
-                }
-              }
-            },
-            true,
-            true,
-          ]
-        });
-      })
-
-      it('ain_get with is_global = false', () => {
-        const expected = 100;
-        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
-        return jsonRpcClient.request('ain_get', {
-          protoVer: CURRENT_PROTOCOL_VERSION,
-          type: 'GET_VALUE',
-          ref: "/test/test_value/some/path"
-        })
-        .then(res => {
-          expect(res.result.result).to.equal(expected);
-        });
-      });
-
-      it('ain_get with is_global = true', () => {
-        const expected = 100;
-        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
-        return jsonRpcClient.request('ain_get', {
-          protoVer: CURRENT_PROTOCOL_VERSION,
-          type: 'GET_VALUE',
-          ref: "/apps/afan/test/test_value/some/path",
-          is_global: true,
-        })
-        .then(res => {
-          expect(res.result.result).to.equal(expected);
-        });
-      });
-
-      it('ain_matchFunction with is_global = false', () => {
-        const ref = "/test/test_function/some/path";
-        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+      describe('/match_function', () => {
+        it('/match_function with is_global = false', () => {
+          const ref = "/test/test_function/some/path";
+          const body = JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/test/test_function/some/path",
               "ref_path": "/test/test_function/some/path",
@@ -833,16 +511,15 @@ describe('Sharding', () => {
               "path": "/test/test_function/some/path"
             },
             "subtree_configs": []
-          });
+          }});
         })
-      })
 
-      it('ain_matchFunction with is_global = true', () => {
-        const ref = "/apps/afan/test/test_function/some/path";
-        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+        it('/match_function with is_global = true', () => {
+          const ref = "/apps/afan/test/test_function/some/path";
+          const body =
+              JSON.parse(syncRequest('GET', `${server1}/match_function?ref=${ref}&is_global=true`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/apps/afan/test/test_function/some/path",
               "ref_path": "/apps/afan/test/test_function/some/path",
@@ -853,16 +530,16 @@ describe('Sharding', () => {
               "path": "/apps/afan/test/test_function/some/path"
             },
             "subtree_configs": []
-          });
+          }});
         })
       })
 
-      it('ain_matchRule with is_global = false', () => {
-        const ref = "/test/test_rule/some/path";
-        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+      describe('/match_rule', () => {
+        it('/match_rule with is_global = false', () => {
+          const ref = "/test/test_rule/some/path";
+          const body = JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/test/test_rule/some/path",
               "ref_path": "/test/test_rule/some/path",
@@ -873,16 +550,15 @@ describe('Sharding', () => {
               "path": "/test/test_rule/some/path"
             },
             "subtree_configs": []
-          });
+          }});
         })
-      })
 
-      it('ain_matchRule with is_global = true', () => {
-        const ref = "/apps/afan/test/test_rule/some/path";
-        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+        it('/match_rule with is_global = true', () => {
+          const ref = "/apps/afan/test/test_rule/some/path";
+          const body =
+              JSON.parse(syncRequest('GET', `${server1}/match_rule?ref=${ref}&is_global=true`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/apps/afan/test/test_rule/some/path",
               "ref_path": "/apps/afan/test/test_rule/some/path",
@@ -893,16 +569,16 @@ describe('Sharding', () => {
               "path": "/apps/afan/test/test_rule/some/path"
             },
             "subtree_configs": []
-          });
+          }});
         })
       })
 
-      it('ain_matchOwner with is_global = false', () => {
-        const ref = "/test/test_owner/some/path";
-        const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+      describe('/match_owner', () => {
+        it('/match_owner with is_global = false', () => {
+          const ref = "/test/test_owner/some/path";
+          const body = JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/test/test_owner/some/path"
             },
@@ -919,16 +595,15 @@ describe('Sharding', () => {
               },
               "path": "/test/test_owner/some/path"
             }
-          });
+          }});
         })
-      })
 
-      it('ain_matchOwner with is_global = true', () => {
-        const ref = "/apps/afan/test/test_owner/some/path";
-        const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, {
+        it('/match_owner with is_global = true', () => {
+          const ref = "/apps/afan/test/test_owner/some/path";
+          const body =
+              JSON.parse(syncRequest('GET', `${server1}/match_owner?ref=${ref}&is_global=true`)
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: {
             "matched_path": {
               "target_path": "/apps/afan/test/test_owner/some/path"
             },
@@ -945,53 +620,424 @@ describe('Sharding', () => {
               },
               "path": "/apps/afan/test/test_owner/some/path"
             }
+          }});
+        })
+      })
+
+      describe('/eval_rule', () => {
+        it('/eval_rule with is_global = false', () => {
+          const ref = "/test/test_rule/some/path";
+          const value = "value";
+          const address = "abcd";
+          const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
+          const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: true});
+        })
+
+        it('/eval_rule with is_global = true', () => {
+          const ref = "/apps/afan/test/test_rule/some/path";
+          const value = "value";
+          const address = "abcd";
+          const is_global = true;
+          const request = { ref, value, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
+          const body = JSON.parse(syncRequest('POST', server1 + '/eval_rule', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {code: 0, result: true});
+        })
+      })
+
+      describe('/eval_owner', () => {
+        it('/eval_owner with is_global = false', () => {
+          const ref = "/test/test_owner/some/path";
+          const address = "abcd";
+          const permission = "write_owner";
+          const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
+          const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {
+            code: 0,
+            result: true,
+          });
+        })
+
+        it('/eval_owner with is_global = true', () => {
+          const ref = "/apps/afan/test/test_owner/some/path";
+          const address = "abcd";
+          const permission = "write_owner";
+          const is_global = true;
+          const request = { ref, permission, address, is_global, protoVer: CURRENT_PROTOCOL_VERSION };
+          const body = JSON.parse(syncRequest('POST', server1 + '/eval_owner', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {
+            code: 0,
+            result: true,
           });
         })
       })
 
-      it('ain_evalRule with is_global = false', () => {
-        const ref = "/test/test_rule/some/path";
-        const value = "value";
-        const address = "abcd";
-        const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
-        .then(res => {
-          expect(res.result.result).to.equal(true);
+      describe('/get', () => {
+        it('/get with is_global = false', () => {
+          const request = {
+            op_list: [
+              {
+                type: "GET_VALUE",
+                ref: "/test/test_value/some/path",
+              },
+              {
+                type: 'GET_FUNCTION',
+                ref: "/test/test_function/some/path",
+              },
+              {
+                type: 'GET_RULE',
+                ref: "/test/test_rule/some/path",
+              },
+              {
+                type: 'GET_OWNER',
+                ref: "/test/test_owner/some/path",
+              },
+              {
+                type: 'EVAL_RULE',
+                ref: "/test/test_rule/some/path",
+                value: "value",
+                address: "abcd"
+              },
+              {
+                type: 'EVAL_OWNER',
+                ref: "/test/test_owner/some/path",
+                permission: "write_owner",
+                address: "abcd"
+              }
+            ]
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {
+            code: 0,
+            result: [
+              100,
+              {
+                ".function": "some function config"
+              },
+              {
+                ".write": "auth === 'abcd'"
+              },
+              {
+                ".owner": {
+                  "owners": {
+                    "*": {
+                      "branch_owner": false,
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": false,
+                    }
+                  }
+                }
+              },
+              true,
+              true,
+            ]
+          });
+        })
+
+        it('/get with is_global = true', () => {
+          const request = {
+            op_list: [
+              {
+                type: "GET_VALUE",
+                ref: "/apps/afan/test/test_value/some/path",
+                is_global: true,
+              },
+              {
+                type: 'GET_FUNCTION',
+                ref: "/apps/afan/test/test_function/some/path",
+                is_global: true,
+              },
+              {
+                type: 'GET_RULE',
+                ref: "/apps/afan/test/test_rule/some/path",
+                is_global: true,
+              },
+              {
+                type: 'GET_OWNER',
+                ref: "/apps/afan/test/test_owner/some/path",
+                is_global: true,
+              },
+              {
+                type: 'EVAL_RULE',
+                ref: "/apps/afan/test/test_rule/some/path",
+                value: "value",
+                address: "abcd",
+                is_global: true,
+              },
+              {
+                type: 'EVAL_OWNER',
+                ref: "/apps/afan/test/test_owner/some/path",
+                permission: "write_owner",
+                address: "abcd",
+                is_global: true,
+              }
+            ]
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/get', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body, {
+            code: 0,
+            result: [
+              100,
+              {
+                ".function": "some function config"
+              },
+              {
+                ".write": "auth === 'abcd'"
+              },
+              {
+                ".owner": {
+                  "owners": {
+                    "*": {
+                      "branch_owner": false,
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": false,
+                    }
+                  }
+                }
+              },
+              true,
+              true,
+            ]
+          });
         })
       })
 
-      it('ain_evalRule with is_global = true', () => {
-        const ref = "/apps/afan/test/test_rule/some/path";
-        const value = "value";
-        const address = "abcd";
-        const request =
-            { ref, value, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
-        .then(res => {
-          expect(res.result.result).to.equal(true);
+      describe('ain_get', () => {
+        it('ain_get with is_global = false', () => {
+          const expected = 100;
+          const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+          return jsonRpcClient.request('ain_get', {
+            protoVer: CURRENT_PROTOCOL_VERSION,
+            type: 'GET_VALUE',
+            ref: "/test/test_value/some/path"
+          })
+          .then(res => {
+            expect(res.result.result).to.equal(expected);
+          });
+        });
+
+        it('ain_get with is_global = false (explicit)', () => {
+          const expected = 100;
+          const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+          return jsonRpcClient.request('ain_get', {
+            protoVer: CURRENT_PROTOCOL_VERSION,
+            type: 'GET_VALUE',
+            ref: "/test/test_value/some/path",
+            is_global: false,
+          })
+          .then(res => {
+            expect(res.result.result).to.equal(expected);
+          });
+        });
+
+        it('ain_get with is_global = true', () => {
+          const expected = 100;
+          const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+          return jsonRpcClient.request('ain_get', {
+            protoVer: CURRENT_PROTOCOL_VERSION,
+            type: 'GET_VALUE',
+            ref: "/apps/afan/test/test_value/some/path",
+            is_global: true,
+          })
+          .then(res => {
+            expect(res.result.result).to.equal(expected);
+          });
+        });
+      })
+
+      describe('ain_matchFunction', () => {
+        it('ain_matchFunction with is_global = false', () => {
+          const ref = "/test/test_function/some/path";
+          const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/test/test_function/some/path",
+                "ref_path": "/test/test_function/some/path",
+                "path_vars": {},
+              },
+              "matched_config": {
+                "config": "some function config",
+                "path": "/test/test_function/some/path"
+              },
+              "subtree_configs": []
+            });
+          })
+        })
+
+        it('ain_matchFunction with is_global = true', () => {
+          const ref = "/apps/afan/test/test_function/some/path";
+          const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchFunction', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/apps/afan/test/test_function/some/path",
+                "ref_path": "/apps/afan/test/test_function/some/path",
+                "path_vars": {},
+              },
+              "matched_config": {
+                "config": "some function config",
+                "path": "/apps/afan/test/test_function/some/path"
+              },
+              "subtree_configs": []
+            });
+          })
         })
       })
 
-      it('ain_evalOwner with is_global = false', () => {
-        const ref = "/test/test_owner/some/path";
-        const address = "abcd";
-        const permission = "write_owner";
-        const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, true);
+      describe('ain_matchRule', () => {
+        it('ain_matchRule with is_global = false', () => {
+          const ref = "/test/test_rule/some/path";
+          const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/test/test_rule/some/path",
+                "ref_path": "/test/test_rule/some/path",
+                "path_vars": {},
+              },
+              "matched_config": {
+                "config": "auth === 'abcd'",
+                "path": "/test/test_rule/some/path"
+              },
+              "subtree_configs": []
+            });
+          })
+        })
+
+        it('ain_matchRule with is_global = true', () => {
+          const ref = "/apps/afan/test/test_rule/some/path";
+          const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchRule', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/apps/afan/test/test_rule/some/path",
+                "ref_path": "/apps/afan/test/test_rule/some/path",
+                "path_vars": {},
+              },
+              "matched_config": {
+                "config": "auth === 'abcd'",
+                "path": "/apps/afan/test/test_rule/some/path"
+              },
+              "subtree_configs": []
+            });
+          })
         })
       })
 
-      it('ain_evalOwner with is_global = true', () => {
-        const ref = "/apps/afan/test/test_owner/some/path";
-        const address = "abcd";
-        const permission = "write_owner";
-        const request =
-            { ref, permission, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
-        return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
-        .then(res => {
-          assert.deepEqual(res.result.result, true);
+      describe('ain_matchOwner', () => {
+        it('ain_matchOwner with is_global = false', () => {
+          const ref = "/test/test_owner/some/path";
+          const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/test/test_owner/some/path"
+              },
+              "matched_config": {
+                "config": {
+                  "owners": {
+                    "*": {
+                      "branch_owner": false,
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": false
+                    }
+                  }
+                },
+                "path": "/test/test_owner/some/path"
+              }
+            });
+          })
+        })
+
+        it('ain_matchOwner with is_global = true', () => {
+          const ref = "/apps/afan/test/test_owner/some/path";
+          const request = { ref, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_matchOwner', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, {
+              "matched_path": {
+                "target_path": "/apps/afan/test/test_owner/some/path"
+              },
+              "matched_config": {
+                "config": {
+                  "owners": {
+                    "*": {
+                      "branch_owner": false,
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": false
+                    }
+                  }
+                },
+                "path": "/apps/afan/test/test_owner/some/path"
+              }
+            });
+          })
+        })
+      })
+
+      describe('ain_evalRule', () => {
+        it('ain_evalRule with is_global = false', () => {
+          const ref = "/test/test_rule/some/path";
+          const value = "value";
+          const address = "abcd";
+          const request = { ref, value, address, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
+          .then(res => {
+            expect(res.result.result).to.equal(true);
+          })
+        })
+
+        it('ain_evalRule with is_global = true', () => {
+          const ref = "/apps/afan/test/test_rule/some/path";
+          const value = "value";
+          const address = "abcd";
+          const request =
+              { ref, value, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_evalRule', request)
+          .then(res => {
+            expect(res.result.result).to.equal(true);
+          })
+        })
+      })
+
+      describe('ain_evalOwner', () => {
+        it('ain_evalOwner with is_global = false', () => {
+          const ref = "/test/test_owner/some/path";
+          const address = "abcd";
+          const permission = "write_owner";
+          const request = { ref, permission, address, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, true);
+          })
+        })
+
+        it('ain_evalOwner with is_global = true', () => {
+          const ref = "/apps/afan/test/test_owner/some/path";
+          const address = "abcd";
+          const permission = "write_owner";
+          const request =
+              { ref, permission, address, is_global: true, protoVer: CURRENT_PROTOCOL_VERSION };
+          return jayson.client.http(server1 + '/json-rpc').request('ain_evalOwner', request)
+          .then(res => {
+            assert.deepEqual(res.result.result, true);
+          })
         })
       })
     })
@@ -1005,282 +1051,328 @@ describe('Sharding', () => {
         cleanUp();
       })
 
-      it('/set_value with is_global = false', () => {
-        const request = {ref: 'test/test_value/some/path', value: "some value"};
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
+      describe('/set_value', () => {
+        it('/set_value with is_global = false', () => {
+          const request = {ref: 'test/test_value/some/path', value: "some value"};
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/set_value with is_global = false (explicit)', () => {
+          const request = {ref: 'test/test_value/some/path', value: "some value", is_global: false};
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/set_value with is_global = true', () => {
+          const request = {
+            ref: 'apps/afan/test/test_value/some/path', value: "some value", is_global: true
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
       })
 
-      it('/set_value with is_global = true', () => {
-        const request = {
-          ref: 'apps/afan/test/test_value/some/path', value: "some value", is_global: true
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
+      describe('/inc_value', () => {
+        it('/inc_value with is_global = false', () => {
+          const request = {ref: 'test/test_value/some/path', value: 10};
+          const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/inc_value with is_global = true', () => {
+          const request = {
+            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
       })
 
-      it('/inc_value with is_global = false', () => {
-        const request = {ref: 'test/test_value/some/path', value: 10};
-        const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
+      describe('/dec_value', () => {
+        it('/dec_value with is_global = false', () => {
+          const request = {ref: 'test/test_value/some/path', value: 10};
+          const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/dec_value with is_global = true', () => {
+          const request = {
+            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
+            .body.toString('utf-8'));
+          assert.deepEqual(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
       })
 
-      it('/inc_value with is_global = true', () => {
-        const request = {
-          ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/inc_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/dec_value with is_global = false', () => {
-        const request = {ref: 'test/test_value/some/path', value: 10};
-        const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/dec_value with is_global = true', () => {
-        const request = {
-          ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/dec_value', {json: request})
-          .body.toString('utf-8'));
-        assert.deepEqual(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_function with is_global = false', () => {
-        const request = {
-          ref: "test/test_function/other/path",
-          value: {
-            ".function": "some other function config"
-          }
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_function with is_global = true', () => {
-        const request = {
-          ref: "apps/afan/test/test_function/other/path",
-          value: {
-            ".function": "some other function config"
-          },
-          is_global: true,
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_rule with is_global = false', () => {
-        const request = {
-          ref: "test/test_rule/other/path",
-          value: {
-            ".write": "some other rule config"
-          }
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_rule with is_global = true', () => {
-        const request = {
-          ref: "apps/afan/test/test_rule/other/path",
-          value: {
-            ".write": "some other rule config"
-          },
-          is_global: true,
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_owner with is_global = false', () => {
-        const request = {
-          ref: "test/test_owner/other/path",
-          value: {
-            ".owner": "some other owner config"
-          }
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set_owner with is_global = true', () => {
-        const request = {
-          ref: "apps/afan/test/test_owner/other2/path",
-          value: {
-            ".owner": "some other2 owner config"
-          },
-          is_global: true,
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('/set with is_global = false', () => {
-        const request = {
-          op_list: [
-            {
-              // Default type: SET_VALUE
-              ref: "test/test_value/other3/path",
-              value: "some other3 value",
-            },
-            {
-              type: 'INC_VALUE',
-              ref: "test/test_value/some/path",
-              value: 10
-            },
-            {
-              type: 'DEC_VALUE',
-              ref: "test/test_value/some/path2",
-              value: 10
-            },
-            {
-              type: 'SET_FUNCTION',
-              ref: "/test/test_function/other3/path",
-              value: {
-                ".function": "some other3 function config"
-              }
-            },
-            {
-              type: 'SET_RULE',
-              ref: "/test/test_rule/other3/path",
-              value: {
-                ".write": "some other3 rule config"
-              }
-            },
-            {
-              type: 'SET_OWNER',
-              ref: "/test/test_owner/other3/path",
-              value: {
-                ".owner": "some other3 owner config"
-              }
+      describe('/set_function', () => {
+        it('/set_function with is_global = false', () => {
+          const request = {
+            ref: "test/test_function/other/path",
+            value: {
+              ".function": "some other function config"
             }
-          ]
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
 
-      it('/set with is_global = true', () => {
-        const request = {
-          op_list: [
-            {
-              // Default type: SET_VALUE
-              ref: "test/test_value/other4/path",
-              value: "some other4 value",
-              is_global: true,
+        it('/set_function with is_global = true', () => {
+          const request = {
+            ref: "apps/afan/test/test_function/other/path",
+            value: {
+              ".function": "some other function config"
             },
-            {
-              type: 'INC_VALUE',
-              ref: "test/test_value/some/path",
-              value: 10,
-              is_global: true,
-            },
-            {
-              type: 'DEC_VALUE',
-              ref: "test/test_value/some/path4",
-              value: 10,
-              is_global: true,
-            },
-            {
-              type: 'SET_FUNCTION',
-              ref: "/test/test_function/other4/path",
-              value: {
-                ".function": "some other4 function config"
-              },
-              is_global: true,
-            },
-            {
-              type: 'SET_RULE',
-              ref: "/test/test_rule/other4/path",
-              value: {
-                ".write": "some other4 rule config"
-              },
-              is_global: true,
-            },
-            {
-              type: 'SET_OWNER',
-              ref: "/test/test_owner/other4/path",
-              value: {
-                ".owner": "some other4 owner config"
-              },
-              is_global: true,
-            }
-          ]
-        };
-        const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
-          .body.toString('utf-8'));
-        assert.equal(body.result.result, true);
-        assert.equal(body.code, 0);
-      })
-
-      it('ain_sendSignedTransaction with is_global = false', () => {
-        const account = ainUtil.createAccount();
-        const client = jayson.client.http(server1 + '/json-rpc');
-        const transaction = {
-          operation: {
-            type: 'SET_VALUE',
-            value: 'some other value',
-            ref: `test/test_value/some/path`
-          },
-          timestamp: Date.now(),
-          nonce: -1
-        }
-        const signature =
-            ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
-        return client.request('ain_sendSignedTransaction', { transaction, signature,
-            protoVer: CURRENT_PROTOCOL_VERSION })
-          .then((res) => {
-            assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
-          })
-      })
-
-      it('ain_sendSignedTransaction with is_global = true', () => {
-        const account = ainUtil.createAccount();
-        const client = jayson.client.http(server1 + '/json-rpc');
-        const transaction = {
-          operation: {
-            type: 'SET_VALUE',
-            value: 'some other value',
-            ref: `apps/afan/test/test_value/some/path`,
             is_global: true,
-          },
-          timestamp: Date.now(),
-          nonce: -1
-        }
-        const signature =
-            ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
-        return client.request('ain_sendSignedTransaction', { transaction, signature,
-            protoVer: CURRENT_PROTOCOL_VERSION })
-          .then((res) => {
-            assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
-          })
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_function', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+      })
+
+      describe('/set_rule', () => {
+        it('/set_rule with is_global = false', () => {
+          const request = {
+            ref: "test/test_rule/other/path",
+            value: {
+              ".write": "some other rule config"
+            }
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/set_rule with is_global = true', () => {
+          const request = {
+            ref: "apps/afan/test/test_rule/other/path",
+            value: {
+              ".write": "some other rule config"
+            },
+            is_global: true,
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_rule', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+      })
+
+      describe('/set_owner', () => {
+        it('/set_owner with is_global = false', () => {
+          const request = {
+            ref: "test/test_owner/other/path",
+            value: {
+              ".owner": "some other owner config"
+            }
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/set_owner with is_global = true', () => {
+          const request = {
+            ref: "apps/afan/test/test_owner/other2/path",
+            value: {
+              ".owner": "some other2 owner config"
+            },
+            is_global: true,
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set_owner', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+      })
+
+      describe('/set', () => {
+        it('/set with is_global = false', () => {
+          const request = {
+            op_list: [
+              {
+                // Default type: SET_VALUE
+                ref: "test/test_value/other3/path",
+                value: "some other3 value",
+              },
+              {
+                type: 'INC_VALUE',
+                ref: "test/test_value/some/path",
+                value: 10
+              },
+              {
+                type: 'DEC_VALUE',
+                ref: "test/test_value/some/path2",
+                value: 10
+              },
+              {
+                type: 'SET_FUNCTION',
+                ref: "/test/test_function/other3/path",
+                value: {
+                  ".function": "some other3 function config"
+                }
+              },
+              {
+                type: 'SET_RULE',
+                ref: "/test/test_rule/other3/path",
+                value: {
+                  ".write": "some other3 rule config"
+                }
+              },
+              {
+                type: 'SET_OWNER',
+                ref: "/test/test_owner/other3/path",
+                value: {
+                  ".owner": "some other3 owner config"
+                }
+              }
+            ]
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+
+        it('/set with is_global = true', () => {
+          const request = {
+            op_list: [
+              {
+                // Default type: SET_VALUE
+                ref: "test/test_value/other4/path",
+                value: "some other4 value",
+                is_global: true,
+              },
+              {
+                type: 'INC_VALUE',
+                ref: "test/test_value/some/path",
+                value: 10,
+                is_global: true,
+              },
+              {
+                type: 'DEC_VALUE',
+                ref: "test/test_value/some/path4",
+                value: 10,
+                is_global: true,
+              },
+              {
+                type: 'SET_FUNCTION',
+                ref: "/test/test_function/other4/path",
+                value: {
+                  ".function": "some other4 function config"
+                },
+                is_global: true,
+              },
+              {
+                type: 'SET_RULE',
+                ref: "/test/test_rule/other4/path",
+                value: {
+                  ".write": "some other4 rule config"
+                },
+                is_global: true,
+              },
+              {
+                type: 'SET_OWNER',
+                ref: "/test/test_owner/other4/path",
+                value: {
+                  ".owner": "some other4 owner config"
+                },
+                is_global: true,
+              }
+            ]
+          };
+          const body = JSON.parse(syncRequest('POST', server1 + '/set', {json: request})
+            .body.toString('utf-8'));
+          assert.equal(body.result.result, true);
+          assert.equal(body.code, 0);
+        })
+      })
+
+      describe('ain_sendSignedTransaction', () => {
+        it('ain_sendSignedTransaction with is_global = false', () => {
+          const account = ainUtil.createAccount();
+          const client = jayson.client.http(server1 + '/json-rpc');
+          const transaction = {
+            operation: {
+              type: 'SET_VALUE',
+              value: 'some other value',
+              ref: `test/test_value/some/path`
+            },
+            timestamp: Date.now(),
+            nonce: -1
+          }
+          const signature =
+              ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+          return client.request('ain_sendSignedTransaction', { transaction, signature,
+              protoVer: CURRENT_PROTOCOL_VERSION })
+            .then((res) => {
+              assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
+            })
+        })
+
+        it('ain_sendSignedTransaction with is_global = false (explicit)', () => {
+          const account = ainUtil.createAccount();
+          const client = jayson.client.http(server1 + '/json-rpc');
+          const transaction = {
+            operation: {
+              type: 'SET_VALUE',
+              value: 'some other value',
+              ref: `test/test_value/some/path`,
+              is_global: false,
+            },
+            timestamp: Date.now(),
+            nonce: -1
+          }
+          const signature =
+              ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+          return client.request('ain_sendSignedTransaction', { transaction, signature,
+              protoVer: CURRENT_PROTOCOL_VERSION })
+            .then((res) => {
+              assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
+            })
+        })
+
+        it('ain_sendSignedTransaction with is_global = true', () => {
+          const account = ainUtil.createAccount();
+          const client = jayson.client.http(server1 + '/json-rpc');
+          const transaction = {
+            operation: {
+              type: 'SET_VALUE',
+              value: 'some other value',
+              ref: `apps/afan/test/test_value/some/path`,
+              is_global: true,
+            },
+            timestamp: Date.now(),
+            nonce: -1
+          }
+          const signature =
+              ainUtil.ecSignTransaction(transaction, Buffer.from(account.private_key, 'hex'));
+          return client.request('ain_sendSignedTransaction', { transaction, signature,
+              protoVer: CURRENT_PROTOCOL_VERSION })
+            .then((res) => {
+              assert.deepEqual(res.result, { "protoVer": "0.1.0", "result": true });
+            })
+        })
       })
     })
   })

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -230,13 +230,13 @@ module.exports = function getMethods(
 
     ain_evalRule: function(args, done) {
       const result = p2pServer.node.db.evalRule(
-          args.ref, args.value, args.is_global, args.address, args.timestamp || Date.now());
+          args.ref, args.value, args.address, args.timestamp || Date.now(), args.is_global);
       done(null, addProtocolVersion({ result }));
     },
 
     ain_evalOwner: function(args, done) {
       const result =
-          p2pServer.node.db.evalOwner(args.ref, args.permission, args.is_global, args.address);
+          p2pServer.node.db.evalOwner(args.ref, args.permission, args.address, args.is_global);
       done (null, addProtocolVersion({ result }));
     },
 

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -179,22 +179,34 @@ module.exports = function getMethods(
     ain_get: function(args, done) { // TODO (lia): split this method
       switch (args.type) {
         case ReadDbOperations.GET_VALUE:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.getValue(args.ref) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.getValue(args.ref, args.is_global)
+          }));
           return;
         case ReadDbOperations.GET_RULE:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.getRule(args.ref) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.getRule(args.ref, args.is_global)
+          }));
           return;
         case ReadDbOperations.GET_FUNCTION:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.getFunction(args.ref) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.getFunction(args.ref, args.is_global)
+          }));
           return;
         case ReadDbOperations.GET_OWNER:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.getOwner(args.ref) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.getOwner(args.ref, args.is_global)
+          }));
           return;
         case ReadDbOperations.GET_PROOF:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.getProof(args.ref) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.getProof(args.ref, args.is_global)
+          }));
           return;
         case ReadDbOperations.GET:
-          done(null, addProtocolVersion({ result: p2pServer.node.db.get(args.op_list) }));
+          done(null, addProtocolVersion({
+            result: p2pServer.node.db.get(args.op_list, args.is_global)
+          }));
           return;
         default:
           done(null, addProtocolVersion({ code: 1, message: "Invalid get request type" }));
@@ -202,28 +214,29 @@ module.exports = function getMethods(
     },
 
     ain_matchFunction: function(args, done) {
-      const result = p2pServer.node.db.matchFunction(args.ref);
+      const result = p2pServer.node.db.matchFunction(args.ref, args.is_global);
       done(null, addProtocolVersion({ result }));
     },
 
     ain_matchRule: function(args, done) {
-      const result = p2pServer.node.db.matchRule(args.ref);
+      const result = p2pServer.node.db.matchRule(args.ref, args.is_global);
       done(null, addProtocolVersion({ result }));
     },
 
     ain_matchOwner: function(args, done) {
-      const result = p2pServer.node.db.matchOwner(args.ref);
+      const result = p2pServer.node.db.matchOwner(args.ref, args.is_global);
       done (null, addProtocolVersion({ result }));
     },
 
     ain_evalRule: function(args, done) {
       const result = p2pServer.node.db.evalRule(
-          args.ref, args.value, args.address, args.timestamp || Date.now());
+          args.ref, args.value, args.is_global, args.address, args.timestamp || Date.now());
       done(null, addProtocolVersion({ result }));
     },
 
     ain_evalOwner: function(args, done) {
-      const result = p2pServer.node.db.evalOwner(args.ref, args.permission, args.address);
+      const result =
+          p2pServer.node.db.evalOwner(args.ref, args.permission, args.is_global, args.address);
       done (null, addProtocolVersion({ result }));
     },
 

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -200,7 +200,7 @@ module.exports = function getMethods(
           return;
         case ReadDbOperations.GET_PROOF:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getProof(args.ref, args.is_global)
+            result: p2pServer.node.db.getProof(args.ref)
           }));
           return;
         case ReadDbOperations.GET:

--- a/test/data/owners_for_testing.json
+++ b/test/data/owners_for_testing.json
@@ -35,6 +35,18 @@
       }
     }
   },
+  "test_sharding": {
+    ".owner": {
+      "owners": {
+        "*": {
+          "branch_owner": true,
+          "write_function": true,
+          "write_owner": true,
+          "write_rule": true
+        }
+      }
+    }
+  },
   "empty_rules": {
     ".owner": {
       "owners": {

--- a/test/data/sharding_for_testing.json
+++ b/test/data/sharding_for_testing.json
@@ -1,0 +1,6 @@
+{
+  "sharding_protocol": "POA",
+  "sharding_path": "/apps/afan",
+  "parent_chain_poc": "http://127.0.0.1:8081",
+  "reporting_period": 5
+}

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -59,13 +59,17 @@ describe("DB initialization", () => {
 
   describe("sharding", () => {
     it("loading sharding properly on initialization", () => {
-      assert.deepEqual(node.db.getValue(`/${PredefinedDbPaths.SHARDING}/${PredefinedDbPaths.SHARDING_CONFIG}`), GenesisSharding);
+      assert.deepEqual(
+        node.db.getValue(`/${PredefinedDbPaths.SHARDING}/${PredefinedDbPaths.SHARDING_CONFIG}`),
+        GenesisSharding);
     })
   })
 
   describe("whitelist", () => {
     it("loading whitelist properly on initialization", () => {
-      assert.deepEqual(node.db.getValue(`/${ConsensusDbPaths.CONSENSUS}/${ConsensusDbPaths.WHITELIST}`), GenesisWhitelist);
+      assert.deepEqual(
+        node.db.getValue(`/${ConsensusDbPaths.CONSENSUS}/${ConsensusDbPaths.WHITELIST}`),
+        GenesisWhitelist);
     })
   })
 
@@ -582,63 +586,70 @@ describe("DB operations", () => {
 
   describe("evalRule operations", () => {
     it("when evaluating existing variable path rule", () => {
-      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', 'abcd', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', false, 'abcd', Date.now()))
         .to.equal(false);
-      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', 'other', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', false, 'other', Date.now()))
         .to.equal(true);
     })
 
     it("when evaluating existing non-variable path rule", () => {
-      expect(node.db.evalRule("/test/test_rule/some/path", 'value', 'abcd', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/path", 'value', false, 'abcd', Date.now()))
         .to.equal(true);
-      expect(node.db.evalRule("/test/test_rule/some/path", 'value', 'other', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/path", 'value', false, 'other', Date.now()))
         .to.equal(false);
       expect(node.db.evalRule(
-          "/test/test_rule/some/path/deeper/path", 'value', 'ijkl', Date.now()))
+          "/test/test_rule/some/path/deeper/path", 'value', false, 'ijkl', Date.now()))
         .to.equal(true);
-      expect(node.db.evalRule("/test/test_rule/some/path/deeper/path", 'value', 'other', Date.now()))
+      expect(node.db.evalRule(
+            "/test/test_rule/some/path/deeper/path", 'value', false, 'other', Date.now()))
         .to.equal(false);
     })
 
     it("when evaluating existing closest rule", () => {
-      expect(node.db.evalRule("/test/test_rule/some/path/deeper", 'value', 'abcd', Date.now()))
+      expect(node.db.evalRule(
+          "/test/test_rule/some/path/deeper", 'value', false, 'abcd', Date.now()))
         .to.equal(true);
-      expect(node.db.evalRule("/test/test_rule/some/path/deeper", 'value', 'other', Date.now()))
+      expect(node.db.evalRule(
+          "/test/test_rule/some/path/deeper", 'value', false, 'other', Date.now()))
         .to.equal(false);
     })
   })
 
   describe("evalOwner operations", () => {
     it("when evaluating existing owner with matching address", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', false, 'abcd'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', false, 'abcd'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper/path", 'write_owner', 'ijkl'))
+      expect(node.db.evalOwner(
+          "/test/test_owner/some/path/deeper/path", 'write_owner', false, 'ijkl'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper/path", 'write_rule', 'ijkl'))
+      expect(node.db.evalOwner(
+          "/test/test_owner/some/path/deeper/path", 'write_rule', false, 'ijkl'))
         .to.equal(false);
     })
 
     it("when evaluating existing owner without matching address", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', false, 'other'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', false, 'other'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper/path", 'write_owner', 'other'))
+      expect(node.db.evalOwner(
+          "/test/test_owner/some/path/deeper/path", 'write_owner', false, 'other'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper/path", 'write_rule', 'other'))
+      expect(node.db.evalOwner(
+          "/test/test_owner/some/path/deeper/path", 'write_rule', false, 'other'))
         .to.equal(true);
     })
 
     it("when evaluating closest owner", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', false, 'abcd'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', false, 'abcd'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', false, 'other'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', false, 'other'))
         .to.equal(true);
     })
   })
@@ -1136,7 +1147,8 @@ describe("DB operations", () => {
   describe("setOwner operations", () => {
     it("when overwriting existing owner config", () => {
       const ownerConfig = {".owner": "other owner config"};
-      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, 'abcd')).to.equal(true)
+      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, false, 'abcd'))
+        .to.equal(true)
       assert.deepEqual(node.db.getOwner("/test/test_owner/some/path"), ownerConfig)
     })
 
@@ -1712,58 +1724,72 @@ describe("DB rule config", () => {
   });
 
   it("only allows certain users to write certain info if balance is greater than 0", () => {
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, 0, null, null))
+    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, 0, false, null, null))
       .to.equal(true)
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, -1, null, null))
+    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, -1, false, null, null))
       .to.equal(false)
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/balance`, 1, null, null))
+    expect(node1.db.evalRule(`test/users/${node1.account.address}/balance`, 1, false, null, null))
       .to.equal(true)
   })
 
   it("only allows certain users to write certain info if data exists", () => {
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/info`, "something", null, null))
+    expect(node1.db.evalRule(
+        `test/users/${node1.account.address}/info`, "something", false, null, null))
       .to.equal(true)
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/info`, "something else", null,
-        null)).to.equal(false)
     expect(node2.db.evalRule(
-        `test/users/${node2.account.address}/new_info`, "something",
-        node2.account.address, null))
+        `test/users/${node2.account.address}/info`, "something else", false, null, null))
+      .to.equal(false)
+    expect(node2.db.evalRule(
+        `test/users/${node2.account.address}/new_info`, "something", false, node2.account.address,
+        null))
       .to.equal(true)
   })
 
   it("apply the closest ancestor's rule config if not exists", () => {
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/child/grandson`, "something",
-        node1.account.address, null)).to.equal(true)
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/child/grandson`, "something",
+    expect(node1.db.evalRule(
+        `test/users/${node1.account.address}/child/grandson`, "something", false,
+        node1.account.address, null))
+      .to.equal(true)
+    expect(node2.db.evalRule(
+        `test/users/${node2.account.address}/child/grandson`, "something", false,
         node1.account.address, null))
       .to.equal(false)
   })
 
   it("only allows certain users to write certain info if data at other locations exists", () => {
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance_info`, "something", null,
-        null)).to.equal(true)
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/balance_info`, "something", null,
-        null))
+    expect(node2.db.evalRule(
+        `test/users/${node2.account.address}/balance_info`, "something", false, null, null))
+      .to.equal(true)
+    expect(node1.db.evalRule(
+        `test/users/${node1.account.address}/balance_info`, "something", false, null, null))
       .to.equal(false)
   })
 
   it("validates old data and new data together", () => {
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/next_counter`, 11, null,  null))
+    expect(node1.db.evalRule(
+        `test/users/${node1.account.address}/next_counter`, 11, false, null,  null))
       .to.equal(true)
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/next_counter`, 12, null, null))
+    expect(node1.db.evalRule(
+        `test/users/${node1.account.address}/next_counter`, 12, false, null, null))
       .to.equal(false)
   })
 
   it("can handle nested path variables", () => {
-    expect(node2.db.evalRule(`test/second_users/${node2.account.address}/${node2.account.address}`,
-        "some value", null, null)).to.equal(true)
-    expect(node1.db.evalRule(`test/second_users/${node1.account.address}/next_counter`,
-        "some other value", null, null)).to.equal(false)
+    expect(node2.db.evalRule(
+        `test/second_users/${node2.account.address}/${node2.account.address}`, "some value", false,
+        null, null))
+      .to.equal(true)
+    expect(node1.db.evalRule(
+        `test/second_users/${node1.account.address}/next_counter`, "some other value", false, null,
+        null))
+      .to.equal(false)
   })
 
   it("duplicated path variables", () => {
-    expect(node1.db.evalRule('test/no_dup_key/aaa/bbb', "some value", null, null)).to.equal(true)
-    expect(node1.db.evalRule('test/dup_key/aaa/bbb', "some value", null, null)).to.equal(true)
+    expect(node1.db.evalRule('test/no_dup_key/aaa/bbb', "some value", false, null, null))
+      .to.equal(true)
+    expect(node1.db.evalRule('test/dup_key/aaa/bbb', "some value", false, null, null))
+      .to.equal(true)
   })
 })
 
@@ -1887,136 +1913,192 @@ describe("DB owner config", () => {
 
   // Known user
   it("branch_owner permission for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/branch', 'branch_owner',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/branch', 'branch_owner',
-        'known_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/branch', 'branch_owner',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/branch', 'branch_owner',
-        'known_user')).to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', false, 'known_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', false, 'known_user'))
+      .to.equal(true)
   })
 
   it("write_owner permission for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true', 'write_owner', false, 'known_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true', 'write_owner', false, 'known_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true', 'write_owner', false, 'known_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false', 'write_owner', false, 'known_user'))
       .to.equal(true)
   })
 
   it("write_rule permission for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true', 'write_rule', false, 'known_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true', 'write_rule', false, 'known_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true', 'write_rule', false, 'known_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule', 'known_user'))
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false', 'write_rule', false, 'known_user'))
       .to.equal(false)
   })
 
   it("write_rule permission on deeper path for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
-        'known_user')).to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule', false, 'known_user'))
+      .to.equal(false)
   })
 
   it("write_function permission for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_function',
-        'known_user')).to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true', 'write_function', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true', 'write_function', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true', 'write_function', false, 'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false', 'write_function', false, 'known_user'))
+      .to.equal(false)
   })
 
   it("write_Function permission on deeper path for known user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
-        'known_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
-        'known_user')).to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', false,
+        'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', false,
+        'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', false,
+        'known_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', false,
+        'known_user'))
+      .to.equal(false)
   })
 
   // Unknown user
   it("branch_owner permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/branch', 'branch_owner',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/branch', 'branch_owner',
-        'unknown_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/branch', 'branch_owner',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/branch', 'branch_owner',
-        'unknown_user')).to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', false,
+        'unknown_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', false,
+        'unknown_user'))
+      .to.equal(false)
   })
 
   it("write_owner permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner',
-        'unknown_user')).to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner',
-        'unknown_user')).to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner', false,
+        'unknown_user'))
+      .to.equal(true)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner', false,
+        'unknown_user'))
+      .to.equal(false)
   })
 
   it("write_rule permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule',
-        'unknown_user')).to.equal(true)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule', false,
+        'unknown_user'))
+      .to.equal(true)
   })
 
   it("write_rule permission on deeper path for unknown user with mixed config", () => {
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
-        'unknown_user')).to.equal(false)
+        false, 'unknown_user'))
+      .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
-        'unknown_user')).to.equal(false)
+        false, 'unknown_user'))
+      .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
-        'unknown_user')).to.equal(false)
+        false, 'unknown_user'))
+      .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
-        'unknown_user')).to.equal(true)
+        false, 'unknown_user'))
+      .to.equal(true)
   })
 
   it("write_function permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_function',
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_function', false,
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_function',
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_function', false,
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_function',
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_function', false,
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_function',
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_function', false,
         'unknown_user')).to.equal(true)
   })
 
   it("write_function permission on deeper path for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
-        'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
-        'unknown_user')).to.equal(true)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', false,
+        'unknown_user'))
+      .to.equal(false)
+    expect(node.db.evalOwner(
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', false,
+        'unknown_user'))
+      .to.equal(true)
   })
 })
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -586,70 +586,70 @@ describe("DB operations", () => {
 
   describe("evalRule operations", () => {
     it("when evaluating existing variable path rule", () => {
-      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', false, 'abcd', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', 'abcd', Date.now()))
         .to.equal(false);
-      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', false, 'other', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/var_path", 'value', 'other', Date.now()))
         .to.equal(true);
     })
 
     it("when evaluating existing non-variable path rule", () => {
-      expect(node.db.evalRule("/test/test_rule/some/path", 'value', false, 'abcd', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/path", 'value', 'abcd', Date.now()))
         .to.equal(true);
-      expect(node.db.evalRule("/test/test_rule/some/path", 'value', false, 'other', Date.now()))
+      expect(node.db.evalRule("/test/test_rule/some/path", 'value', 'other', Date.now()))
         .to.equal(false);
       expect(node.db.evalRule(
-          "/test/test_rule/some/path/deeper/path", 'value', false, 'ijkl', Date.now()))
+          "/test/test_rule/some/path/deeper/path", 'value', 'ijkl', Date.now()))
         .to.equal(true);
       expect(node.db.evalRule(
-            "/test/test_rule/some/path/deeper/path", 'value', false, 'other', Date.now()))
+            "/test/test_rule/some/path/deeper/path", 'value', 'other', Date.now()))
         .to.equal(false);
     })
 
     it("when evaluating existing closest rule", () => {
       expect(node.db.evalRule(
-          "/test/test_rule/some/path/deeper", 'value', false, 'abcd', Date.now()))
+          "/test/test_rule/some/path/deeper", 'value', 'abcd', Date.now()))
         .to.equal(true);
       expect(node.db.evalRule(
-          "/test/test_rule/some/path/deeper", 'value', false, 'other', Date.now()))
+          "/test/test_rule/some/path/deeper", 'value', 'other', Date.now()))
         .to.equal(false);
     })
   })
 
   describe("evalOwner operations", () => {
     it("when evaluating existing owner with matching address", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', false, 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', 'abcd'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', false, 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', 'abcd'))
         .to.equal(false);
       expect(node.db.evalOwner(
-          "/test/test_owner/some/path/deeper/path", 'write_owner', false, 'ijkl'))
+          "/test/test_owner/some/path/deeper/path", 'write_owner', 'ijkl'))
         .to.equal(true);
       expect(node.db.evalOwner(
-          "/test/test_owner/some/path/deeper/path", 'write_rule', false, 'ijkl'))
+          "/test/test_owner/some/path/deeper/path", 'write_rule', 'ijkl'))
         .to.equal(false);
     })
 
     it("when evaluating existing owner without matching address", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', false, 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', 'other'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', false, 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', 'other'))
         .to.equal(true);
       expect(node.db.evalOwner(
-          "/test/test_owner/some/path/deeper/path", 'write_owner', false, 'other'))
+          "/test/test_owner/some/path/deeper/path", 'write_owner', 'other'))
         .to.equal(false);
       expect(node.db.evalOwner(
-          "/test/test_owner/some/path/deeper/path", 'write_rule', false, 'other'))
+          "/test/test_owner/some/path/deeper/path", 'write_rule', 'other'))
         .to.equal(true);
     })
 
     it("when evaluating closest owner", () => {
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', false, 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', 'abcd'))
         .to.equal(true);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', false, 'abcd'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', 'abcd'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', false, 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_owner', 'other'))
         .to.equal(false);
-      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', false, 'other'))
+      expect(node.db.evalOwner("/test/test_owner/some/path/deeper", 'write_rule', 'other'))
         .to.equal(true);
     })
   })
@@ -1147,7 +1147,7 @@ describe("DB operations", () => {
   describe("setOwner operations", () => {
     it("when overwriting existing owner config", () => {
       const ownerConfig = {".owner": "other owner config"};
-      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, false, 'abcd'))
+      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, 'abcd'))
         .to.equal(true)
       assert.deepEqual(node.db.getOwner("/test/test_owner/some/path"), ownerConfig)
     })
@@ -1724,71 +1724,69 @@ describe("DB rule config", () => {
   });
 
   it("only allows certain users to write certain info if balance is greater than 0", () => {
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, 0, false, null, null))
+    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, 0, null, null))
       .to.equal(true)
-    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, -1, false, null, null))
+    expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, -1, null, null))
       .to.equal(false)
-    expect(node1.db.evalRule(`test/users/${node1.account.address}/balance`, 1, false, null, null))
+    expect(node1.db.evalRule(`test/users/${node1.account.address}/balance`, 1, null, null))
       .to.equal(true)
   })
 
   it("only allows certain users to write certain info if data exists", () => {
     expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/info`, "something", false, null, null))
+        `test/users/${node1.account.address}/info`, "something", null, null))
       .to.equal(true)
     expect(node2.db.evalRule(
-        `test/users/${node2.account.address}/info`, "something else", false, null, null))
+        `test/users/${node2.account.address}/info`, "something else", null, null))
       .to.equal(false)
     expect(node2.db.evalRule(
-        `test/users/${node2.account.address}/new_info`, "something", false, node2.account.address,
-        null))
+        `test/users/${node2.account.address}/new_info`, "something", node2.account.address, null))
       .to.equal(true)
   })
 
   it("apply the closest ancestor's rule config if not exists", () => {
     expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/child/grandson`, "something", false,
-        node1.account.address, null))
+        `test/users/${node1.account.address}/child/grandson`, "something", node1.account.address,
+        null))
       .to.equal(true)
     expect(node2.db.evalRule(
-        `test/users/${node2.account.address}/child/grandson`, "something", false,
-        node1.account.address, null))
+        `test/users/${node2.account.address}/child/grandson`, "something", node1.account.address,
+        null))
       .to.equal(false)
   })
 
   it("only allows certain users to write certain info if data at other locations exists", () => {
     expect(node2.db.evalRule(
-        `test/users/${node2.account.address}/balance_info`, "something", false, null, null))
+        `test/users/${node2.account.address}/balance_info`, "something", null, null))
       .to.equal(true)
     expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/balance_info`, "something", false, null, null))
+        `test/users/${node1.account.address}/balance_info`, "something", null, null))
       .to.equal(false)
   })
 
   it("validates old data and new data together", () => {
     expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/next_counter`, 11, false, null,  null))
+        `test/users/${node1.account.address}/next_counter`, 11, null,  null))
       .to.equal(true)
     expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/next_counter`, 12, false, null, null))
+        `test/users/${node1.account.address}/next_counter`, 12, null, null))
       .to.equal(false)
   })
 
   it("can handle nested path variables", () => {
     expect(node2.db.evalRule(
-        `test/second_users/${node2.account.address}/${node2.account.address}`, "some value", false,
-        null, null))
+        `test/second_users/${node2.account.address}/${node2.account.address}`, "some value", null,
+        null))
       .to.equal(true)
     expect(node1.db.evalRule(
-        `test/second_users/${node1.account.address}/next_counter`, "some other value", false, null,
-        null))
+        `test/second_users/${node1.account.address}/next_counter`, "some other value", null, null))
       .to.equal(false)
   })
 
   it("duplicated path variables", () => {
-    expect(node1.db.evalRule('test/no_dup_key/aaa/bbb', "some value", false, null, null))
+    expect(node1.db.evalRule('test/no_dup_key/aaa/bbb', "some value", null, null))
       .to.equal(true)
-    expect(node1.db.evalRule('test/dup_key/aaa/bbb', "some value", false, null, null))
+    expect(node1.db.evalRule('test/dup_key/aaa/bbb', "some value", null, null))
       .to.equal(true)
   })
 })
@@ -1914,190 +1912,178 @@ describe("DB owner config", () => {
   // Known user
   it("branch_owner permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', false, 'known_user'))
+        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', 'known_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', 'known_user'))
       .to.equal(true)
   })
 
   it("write_owner permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true', 'write_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/true', 'write_owner', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true', 'write_owner', false, 'known_user'))
+        '/test/test_owner/mixed/false/true/true', 'write_owner', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true', 'write_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/false/true', 'write_owner', 'known_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false', 'write_owner', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/false', 'write_owner', 'known_user'))
       .to.equal(true)
   })
 
   it("write_rule permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/true', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/false/true/true', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/false/true', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/false', 'write_rule', 'known_user'))
       .to.equal(false)
   })
 
   it("write_rule permission on deeper path for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule', 'known_user'))
       .to.equal(false)
   })
 
   it("write_function permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true', 'write_function', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/true', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true', 'write_function', false, 'known_user'))
+        '/test/test_owner/mixed/false/true/true', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true', 'write_function', false, 'known_user'))
+        '/test/test_owner/mixed/true/false/true', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false', 'write_function', false, 'known_user'))
+        '/test/test_owner/mixed/true/true/false', 'write_function', 'known_user'))
       .to.equal(false)
   })
 
   it("write_Function permission on deeper path for known user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', false,
-        'known_user'))
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', false,
-        'known_user'))
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', false,
-        'known_user'))
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', 'known_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', false,
-        'known_user'))
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', 'known_user'))
       .to.equal(false)
   })
 
   // Unknown user
   it("branch_owner permission for unknown user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', 'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', 'unknown_user'))
       .to.equal(true)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', 'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', 'unknown_user'))
       .to.equal(false)
   })
 
   it("write_owner permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner',
         'unknown_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner',
         'unknown_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner',
         'unknown_user'))
       .to.equal(true)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner',
         'unknown_user'))
       .to.equal(false)
   })
 
   it("write_rule permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule',
         'unknown_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule',
         'unknown_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule',
         'unknown_user'))
       .to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule',
         'unknown_user'))
       .to.equal(true)
   })
 
   it("write_rule permission on deeper path for unknown user with mixed config", () => {
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
-        false, 'unknown_user'))
+        'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
-        false, 'unknown_user'))
+        'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
-        false, 'unknown_user'))
+        'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
-        false, 'unknown_user'))
+        'unknown_user'))
       .to.equal(true)
   })
 
   it("write_function permission for unknown user with mixed config", () => {
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_function', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_function',
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_function', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_function',
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_function', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_function',
         'unknown_user')).to.equal(false)
-    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_function', false,
+    expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_function',
         'unknown_user')).to.equal(true)
   })
 
   it("write_function permission on deeper path for unknown user with mixed config", () => {
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function', 'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function', 'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function', 'unknown_user'))
       .to.equal(false)
     expect(node.db.evalOwner(
-        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', false,
-        'unknown_user'))
+        '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', 'unknown_user'))
       .to.equal(true)
   })
 })

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -6,7 +6,6 @@ const assert = chai.assert;
 const Node = require('../node')
 const {
   BLOCKCHAINS_DIR,
-  PredefinedDbPaths,
   GenesisToken,
   GenesisAccounts,
   GenesisSharding,
@@ -16,9 +15,6 @@ const {
   GenesisOwners,
   ProofProperties,
 } = require('../constants')
-const {
-  ConsensusDbPaths,
-} = require('../consensus/constants')
 const {
   setDbForTesting,
 } = require('./test-util');
@@ -40,9 +36,19 @@ describe("DB initialization", () => {
     rimraf.sync(BLOCKCHAINS_DIR);
   });
 
+  describe("sharding path", () => {
+    it("getShardingPath", () => {
+      expect(node.db.getShardingPath()).to.equal(GenesisSharding.sharding_path);
+    })
+
+    it("isRoot", () => {
+      expect(node.db.isRoot).to.equal(GenesisSharding.sharding_protocol === 'NONE');
+    })
+  })
+
   describe("token", () => {
     it("loading token properly on initialization", () => {
-      assert.deepEqual(node.db.getValue(`/${PredefinedDbPaths.TOKEN}`), GenesisToken);
+      assert.deepEqual(node.db.getValue(`/token`), GenesisToken);
     })
   })
 
@@ -50,26 +56,20 @@ describe("DB initialization", () => {
     it("loading balances properly on initialization", () => {
       const expected =
           GenesisToken.total_supply - GenesisAccounts.others.length * GenesisAccounts.shares;
-      const dbPath =
-          `/${PredefinedDbPaths.ACCOUNTS}/${GenesisAccounts.owner.address}/` +
-          `${PredefinedDbPaths.BALANCE}`;
+      const dbPath = `/accounts/${GenesisAccounts.owner.address}/balance`;
       expect(node.db.getValue(dbPath)).to.equal(expected);
     })
   })
 
   describe("sharding", () => {
     it("loading sharding properly on initialization", () => {
-      assert.deepEqual(
-        node.db.getValue(`/${PredefinedDbPaths.SHARDING}/${PredefinedDbPaths.SHARDING_CONFIG}`),
-        GenesisSharding);
+      assert.deepEqual(node.db.getValue(`/sharding/config`), GenesisSharding);
     })
   })
 
   describe("whitelist", () => {
     it("loading whitelist properly on initialization", () => {
-      assert.deepEqual(
-        node.db.getValue(`/${ConsensusDbPaths.CONSENSUS}/${ConsensusDbPaths.WHITELIST}`),
-        GenesisWhitelist);
+      assert.deepEqual(node.db.getValue(`/consensus/whitelist`), GenesisWhitelist);
     })
   })
 
@@ -1798,7 +1798,7 @@ describe("DB owner config", () => {
     rimraf.sync(BLOCKCHAINS_DIR);
 
     node = new Node();
-    setDbForTesting(node, 0);
+    setDbForTesting(node);
     node.db.setOwner("test/test_owner/mixed/true/true/true",
       {
         ".owner": {
@@ -2085,6 +2085,524 @@ describe("DB owner config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function', 'unknown_user'))
       .to.equal(true)
+  })
+})
+
+
+describe("DB sharding config", () => {
+  let node;
+
+  beforeEach(() => {
+    let result;
+
+    rimraf.sync(BLOCKCHAINS_DIR);
+
+    node = new Node();
+    setDbForTesting(node, 0, false, false);
+
+    dbValues = {
+      "some": {
+        "path": {
+          "to": {
+            "value": "this",
+            "number": 10,
+          }
+        }
+      }
+    };
+    result = node.db.setValue("test/test_sharding", dbValues);
+    console.log(`Result of setValue(): ${JSON.stringify(result, null, 2)}`);
+
+    dbFuncs = {
+      "some": {
+        "path": {
+          "to": {
+            ".function": "some function config",
+            "deeper": {
+              ".function": "some deeper function config",
+            }
+          }
+        }
+      }
+    };
+    result = node.db.setFunction("test/test_sharding", dbFuncs);
+    console.log(`Result of setFunction(): ${JSON.stringify(result, null, 2)}`);
+
+    dbRules = {
+      "some": {
+        "path": {
+          ".write": "false",
+          "to": {
+            ".write": "auth === 'known_user'",
+            "deeper": {
+              ".write": "some deeper rule config",
+            }
+          }
+        }
+      }
+    };
+    result = node.db.setRule("test/test_sharding", dbRules);
+    console.log(`Result of setRule(): ${JSON.stringify(result, null, 2)}`);
+
+    dbOwners = {
+      "some": {
+        "path": {
+          "to": {
+            ".owner": {
+              "owners": {
+                "*": {
+                  "branch_owner": false,
+                  "write_function": false,
+                  "write_owner": false,
+                  "write_rule": false,
+                },
+                "known_user": {
+                  "branch_owner": true,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": true,
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    result = node.db.setOwner("test/test_sharding", dbOwners);
+    console.log(`Result of setOwner(): ${JSON.stringify(result, null, 2)}`);
+  })
+
+  afterEach(() => {
+    rimraf.sync(BLOCKCHAINS_DIR);
+  });
+
+  describe("sharding path", () => {
+    it("getShardingPath", () => {
+      expect(node.db.getShardingPath()).to.equal("/apps/afan");
+    })
+
+    it("setShardingPath", () => {
+      node.db.setShardingPath("/apps/another_app");
+      expect(node.db.getShardingPath()).to.equal("/apps/another_app");
+    })
+
+    it("isRoot", () => {
+      expect(node.db.isRoot).to.equal(false);
+    })
+  })
+
+  describe("value operations", () => {
+    const value = "this";
+    const newValue = "that";
+    const incDelta = 5;
+    const decDelta = 3;
+
+    it("getValue with isGlobal = false", () => {
+      expect(node.db.getValue("test/test_sharding/some/path/to/value")).to.equal(value);
+      expect(node.db.getValue("apps/test_sharding/afan/test/some/path/to/value")).to.equal(null);
+    })
+
+    it("getValue with isGlobal = true", () => {
+      expect(node.db.getValue("test/test_sharding/some/path/to/value", true)).to.equal(null);
+      expect(node.db.getValue("apps/afan/test/test_sharding/some/path/to/value", true))
+        .to.equal(value);
+    })
+
+    it("getValue with isGlobal = true and non-existing path", () => {
+      expect(node.db.getValue("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("setValue with isGlobal = false", () => {
+      expect(node.db.setValue("test/test_sharding/some/path/to/value", newValue, 'known_user'))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/value")).to.equal(newValue);
+    })
+
+    it("setValue with isGlobal = true", () => {
+      expect(node.db.setValue(
+          "apps/afan/test/test_sharding/some/path/to/value", newValue, 'known_user', null, null,
+          true))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/value")).to.equal(newValue);
+    })
+
+    it("setValue with isGlobal = true and non-existing path", () => {
+      expect(node.db.setValue("some/non-existing/path", newValue, 'known_user', null, null, true))
+        .to.equal(true);
+    })
+
+    it("incValue with isGlobal = false", () => {
+      expect(node.db.incValue("test/test_sharding/some/path/to/number", incDelta, 'known_user'))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 + incDelta);
+    })
+
+    it("incValue with isGlobal = true", () => {
+      expect(node.db.incValue(
+          "apps/afan/test/test_sharding/some/path/to/number", incDelta, 'known_user', null, null, true))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 + incDelta);
+    })
+
+    it("incValue with isGlobal = true and non-existing path", () => {
+      expect(node.db.incValue("some/non-existing/path", incDelta, 'known_user', null, null, true))
+        .to.equal(true);
+    })
+
+    it("decValue with isGlobal = false", () => {
+      expect(node.db.decValue("test/test_sharding/some/path/to/number", decDelta, 'known_user'))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 - decDelta);
+    })
+
+    it("decValue with isGlobal = true", () => {
+      expect(node.db.decValue(
+          "apps/afan/test/test_sharding/some/path/to/number", decDelta, 'known_user', null, null, true))
+        .to.equal(true);
+      expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 - decDelta);
+    })
+
+    it("decValue with isGlobal = true and non-existing path", () => {
+      expect(node.db.decValue("some/non-existing/path", decDelta, 'known_user', null, null, true))
+        .to.equal(true);
+    })
+  })
+
+  describe("function operations", () => {
+    const func = {
+      ".function": "some function config",
+      "deeper": {
+        ".function": "some deeper function config"
+      }
+    };
+    const newFunc = { ".function": "another function config" };
+
+    it("getFunction with isGlobal = false", () => {
+      assert.deepEqual(node.db.getFunction("test/test_sharding/some/path/to"), func);
+      expect(node.db.getFunction("apps/afan/test/test_sharding/some/path/to")).to.equal(null);
+    })
+
+    it("getFunction with isGlobal = true", () => {
+      expect(node.db.getFunction("test/test_sharding/some/path/to", true)).to.equal(null);
+      assert.deepEqual(
+          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), func);
+    })
+
+    it("getFunction with isGlobal = true and non-existing path", () => {
+      expect(node.db.getFunction("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("setFunction with isGlobal = false", () => {
+      expect(node.db.setFunction(
+          "test/test_sharding/some/path/to", newFunc, 'known_user'))
+        .to.equal(true);
+      assert.deepEqual(node.db.getFunction("test/test_sharding/some/path/to"), newFunc);
+    })
+
+    it("setFunction with isGlobal = true", () => {
+      expect(node.db.setFunction(
+          "apps/afan/test/test_sharding/some/path/to", newFunc, 'known_user', true))
+        .to.equal(true);
+      assert.deepEqual(
+          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), newFunc);
+    })
+
+    it("setFunction with isGlobal = true and non-existing path", () => {
+      expect(node.db.setFunction("some/non-existing/path", newFunc, 'known_user', true))
+        .to.equal(true);
+    })
+
+    it("matchFunction with isGlobal = false", () => {
+      assert.deepEqual(node.db.matchFunction("/test/test_sharding/some/path/to"), {
+        "matched_path": {
+          "target_path": "/test/test_sharding/some/path/to",
+          "ref_path": "/test/test_sharding/some/path/to",
+          "path_vars": {},
+        },
+        "matched_config": {
+          "config": "some function config",
+          "path": "/test/test_sharding/some/path/to"
+        },
+        "subtree_configs": [
+          {
+            "config": "some deeper function config",
+            "path": "/deeper",
+          }
+        ]
+      });
+    })
+
+    it("matchFunction with isGlobal = true", () => {
+      assert.deepEqual(node.db.matchFunction("/apps/afan/test/test_sharding/some/path/to", true), {
+        "matched_path": {
+          "target_path": "/apps/afan/test/test_sharding/some/path/to",
+          "ref_path": "/apps/afan/test/test_sharding/some/path/to",
+          "path_vars": {},
+        },
+        "matched_config": {
+          "config": "some function config",
+          "path": "/apps/afan/test/test_sharding/some/path/to"
+        },
+        "subtree_configs": [
+          {
+            "config": "some deeper function config",
+            "path": "/deeper",
+          }
+        ]
+      });
+    })
+
+    it("matchFunction with isGlobal = true and non-existing path", () => {
+      expect(node.db.matchFunction("some/non-existing/path", true)).to.equal(null);
+    })
+  })
+
+  describe("rule operations", () => {
+    const rule = {
+      ".write": "auth === 'known_user'",
+      "deeper": {
+        ".write": "some deeper rule config"
+      }
+    };
+    const newRule = { ".write": "another rule" };
+    const newValue = "that";
+
+    it("getRule with isGlobal = false", () => {
+      assert.deepEqual(node.db.getRule("test/test_sharding/some/path/to"), rule);
+      expect(node.db.getRule("apps/afan/test/test_sharding/some/path/to")).to.equal(null);
+    })
+
+    it("getRule with isGlobal = true", () => {
+      expect(node.db.getRule("test/test_sharding/some/path/to", true)).to.equal(null);
+      assert.deepEqual(
+          node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), rule);
+    })
+
+    it("getRule with isGlobal = true and non-existing path", () => {
+      expect(node.db.getRule("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("setRule with isGlobal = false", () => {
+      expect(node.db.setRule(
+          "test/test_sharding/some/path/to", newRule, 'known_user'))
+        .to.equal(true);
+      assert.deepEqual(node.db.getRule("test/test_sharding/some/path/to"), newRule);
+    })
+
+    it("setRule with isGlobal = true", () => {
+      expect(node.db.setRule(
+          "apps/afan/test/test_sharding/some/path/to", newRule, 'known_user', true))
+        .to.equal(true);
+      assert.deepEqual(
+          node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), newRule);
+    })
+
+    it("setRule with isGlobal = true and non-existing path", () => {
+      expect(node.db.setRule("some/non-existing/path", newRule, 'known_user', true))
+        .to.equal(true);
+    })
+
+    it("matchRule with isGlobal = false", () => {
+      assert.deepEqual(node.db.matchRule("/test/test_sharding/some/path/to"), {
+        "matched_path": {
+          "target_path": "/test/test_sharding/some/path/to",
+          "ref_path": "/test/test_sharding/some/path/to",
+          "path_vars": {},
+        },
+        "matched_config": {
+          "config": "auth === 'known_user'",
+          "path": "/test/test_sharding/some/path/to"
+        },
+        "subtree_configs": [
+          {
+            "config": "some deeper rule config",
+            "path": "/deeper",
+          }
+        ]
+      });
+    })
+
+    it("matchRule with isGlobal = true", () => {
+      assert.deepEqual(node.db.matchRule("/apps/afan/test/test_sharding/some/path/to", true), {
+        "matched_path": {
+          "target_path": "/apps/afan/test/test_sharding/some/path/to",
+          "ref_path": "/apps/afan/test/test_sharding/some/path/to",
+          "path_vars": {},
+        },
+        "matched_config": {
+          "config": "auth === 'known_user'",
+          "path": "/apps/afan/test/test_sharding/some/path/to"
+        },
+        "subtree_configs": [
+          {
+            "config": "some deeper rule config",
+            "path": "/deeper",
+          }
+        ]
+      });
+    })
+
+    it("matchRule with isGlobal = true and non-existing path", () => {
+      expect(node.db.matchRule("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("evalRule with isGlobal = false", () => {
+      expect(node.db.evalRule("/test/test_sharding/some/path/to", newValue, "known_user"))
+        .to.equal(true);
+    })
+
+    it("evalRule with isGlobal = true", () => {
+      expect(node.db.evalRule(
+          "/apps/afan/test/test_sharding/some/path/to", newValue, "known_user", null, true))
+        .to.equal(true);
+    })
+
+    it("evalRule with isGlobal = true and non-existing path", () => {
+      expect(node.db.evalRule("/some/non-existing/path", newValue, "known_user", null, true))
+        .to.equal(null);
+    })
+  })
+
+  describe("owner operations", () => {
+    const owner = {
+      ".owner": {
+        "owners": {
+          "*": {
+            "branch_owner": false,
+            "write_function": false,
+            "write_owner": false,
+            "write_rule": false,
+          },
+          "known_user": {
+            "branch_owner": true,
+            "write_function": true,
+            "write_owner": true,
+            "write_rule": true,
+          }
+        }
+      }
+    };
+    const newOwner = {
+      ".owner": {
+        "owners": {
+          "*": {
+            "branch_owner": false,
+            "write_function": false,
+            "write_owner": false,
+            "write_rule": false,
+          },
+        }
+      }
+    };
+
+    it("getOwner with isGlobal = false", () => {
+      assert.deepEqual(node.db.getOwner("test/test_sharding/some/path/to"), owner);
+      expect(node.db.getOwner("apps/afan/test/test_sharding/some/path/to")).to.equal(null);
+    })
+
+    it("getOwner with isGlobal = true", () => {
+      expect(node.db.getOwner("test/test_sharding/some/path/to", true)).to.equal(null);
+      assert.deepEqual(
+          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), owner);
+    })
+
+    it("getOwner with isGlobal = true and non-existing path", () => {
+      expect(node.db.getOwner("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("setOwner with isGlobal = false", () => {
+      expect(node.db.setOwner(
+          "test/test_sharding/some/path/to", newOwner, 'known_user'))
+        .to.equal(true);
+      assert.deepEqual(node.db.getOwner("test/test_sharding/some/path/to"), newOwner);
+    })
+
+    it("setOwner with isGlobal = true", () => {
+      expect(node.db.setOwner(
+          "apps/afan/test/test_sharding/some/path/to", newOwner, 'known_user', true))
+        .to.equal(true);
+      assert.deepEqual(
+          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), newOwner);
+    })
+
+    it("setOwner with isGlobal = true and non-existing path", () => {
+      expect(node.db.setOwner("some/non-existing/path", newOwner, 'known_user', true))
+        .to.equal(true);
+    })
+
+    it("matchOwner with isGlobal = false", () => {
+      assert.deepEqual(node.db.matchOwner("/test/test_sharding/some/path/to"), {
+        "matched_path": {
+          "target_path": "/test/test_sharding/some/path/to",
+        },
+        "matched_config": {
+          "config": {
+            "owners": {
+              "*": {
+                "branch_owner": false,
+                "write_function": false,
+                "write_owner": false,
+                "write_rule": false,
+              },
+              "known_user": {
+                "branch_owner": true,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": true,
+              }
+            }
+          },
+          "path": "/test/test_sharding/some/path/to"
+        }
+      });
+    })
+
+    it("matchOwner with isGlobal = true", () => {
+      assert.deepEqual(node.db.matchOwner("/apps/afan/test/test_sharding/some/path/to", true), {
+        "matched_path": {
+          "target_path": "/apps/afan/test/test_sharding/some/path/to",
+        },
+        "matched_config": {
+          "config": {
+            "owners": {
+              "*": {
+                "branch_owner": false,
+                "write_function": false,
+                "write_owner": false,
+                "write_rule": false,
+              },
+              "known_user": {
+                "branch_owner": true,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": true,
+              }
+            }
+          },
+          "path": "/apps/afan/test/test_sharding/some/path/to"
+        }
+      });
+    })
+
+    it("matchOwner with isGlobal = true and non-existing path", () => {
+      expect(node.db.matchOwner("some/non-existing/path", true)).to.equal(null);
+    })
+
+    it("evalOwner with isGlobal = false", () => {
+      expect(node.db.evalOwner("/test/test_sharding/some/path/to", "write_rule", "known_user"))
+        .to.equal(true);
+    })
+
+    it("evalOwner with isGlobal = true", () => {
+      expect(node.db.evalOwner(
+          "/apps/afan/test/test_sharding/some/path/to", "write_rule", "known_user", true))
+        .to.equal(true);
+    })
+
+    it("evalOwner with isGlobal = true and non-existing path", () => {
+      expect(node.db.evalOwner("/some/non-existing/path", "write_rule", "known_user", true))
+        .to.equal(null);
+    })
   })
 })
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,4 +1,3 @@
-const fs = require("fs")
 const rimraf = require('rimraf');
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/rule-util.test.js
+++ b/test/rule-util.test.js
@@ -196,6 +196,32 @@ describe("RuleUtil", () => {
     })
   })
 
+  describe("toBool", () => {
+    it("returns false", () => {
+      expect(util.toBool(0)).to.equal(false);
+      expect(util.toBool(10)).to.equal(false);
+      expect(util.toBool(-1)).to.equal(false);
+      expect(util.toBool(15.5)).to.equal(false);
+      expect(util.toBool(null)).to.equal(false);
+      expect(util.toBool(undefined)).to.equal(false);
+      expect(util.toBool(Infinity)).to.equal(false);
+      expect(util.toBool(NaN)).to.equal(false);
+      expect(util.toBool('')).to.equal(false);
+      expect(util.toBool('abc')).to.equal(false);
+      expect(util.toBool('false')).to.equal(false);
+      expect(util.toBool({})).to.equal(false);
+      expect(util.toBool({a: 'A'})).to.equal(false);
+      expect(util.toBool([])).to.equal(false);
+      expect(util.toBool([10])).to.equal(false);
+      expect(util.toBool(false)).to.equal(false);
+    })
+
+    it("returns true", () => {
+      expect(util.toBool(true)).to.equal(true);
+      expect(util.toBool('true')).to.equal(true);
+    })
+  })
+
   describe("isValAddr", () => {
     it("when non-string input", () => {
       expect(util.isValAddr(true)).to.equal(false);

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -13,19 +13,13 @@ function readConfigFile(filePath) {
   return JSON.parse(fs.readFileSync(filePath));
 }
 
-function setDbForTesting(node, accountIndex = 0, skipTestingConfig = false) {
+function setDbForTesting(
+    node, accountIndex = 0, skipTestingConfig = false, skipShardingConfig = true) {
   node.setAccountForTesting(accountIndex);
 
   node.init(true);
 
   if (!skipTestingConfig) {
-    const shardingFile = path.resolve(__dirname, './data/sharding_for_testing.json');
-    if (!fs.existsSync(shardingFile)) {
-      throw Error('Missing sharding file: ' + shardingFile);
-    }
-    const sharding = JSON.parse(fs.readFileSync(shardingFile));
-    node.db.setShardingForTesting(sharding);
-
     const ownersFile = path.resolve(__dirname, './data/owners_for_testing.json');
     if (!fs.existsSync(ownersFile)) {
       throw Error('Missing owners file: ' + ownersFile);
@@ -46,6 +40,14 @@ function setDbForTesting(node, accountIndex = 0, skipTestingConfig = false) {
     }
     const functions = JSON.parse(fs.readFileSync(functionsFile));
     node.db.setFunctionsForTesting("test", functions);
+  }
+  if (!skipShardingConfig) {
+    const shardingFile = path.resolve(__dirname, './data/sharding_for_testing.json');
+    if (!fs.existsSync(shardingFile)) {
+      throw Error('Missing sharding file: ' + shardingFile);
+    }
+    const sharding = JSON.parse(fs.readFileSync(shardingFile));
+    node.db.setShardingForTesting(sharding);
   }
 }
 

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -19,15 +19,30 @@ function setDbForTesting(node, accountIndex = 0, skipTestingConfig = false) {
   node.init(true);
 
   if (!skipTestingConfig) {
+    const shardingFile = path.resolve(__dirname, './data/sharding_for_testing.json');
+    if (!fs.existsSync(shardingFile)) {
+      throw Error('Missing sharding file: ' + shardingFile);
+    }
+    const sharding = JSON.parse(fs.readFileSync(shardingFile));
+    node.db.setShardingForTesting(sharding);
+
     const ownersFile = path.resolve(__dirname, './data/owners_for_testing.json');
+    if (!fs.existsSync(ownersFile)) {
+      throw Error('Missing owners file: ' + ownersFile);
+    }
     const owners = readConfigFile(ownersFile);
     node.db.setOwnersForTesting("test", owners);
+
     const rulesFile = path.resolve(__dirname, './data/rules_for_testing.json');
+    if (!fs.existsSync(rulesFile)) {
+      throw Error('Missing rules file: ' + rulesFile);
+    }
     const rules = readConfigFile(rulesFile);
     node.db.setRulesForTesting("test", rules);
+
     const functionsFile = path.resolve(__dirname, './data/functions_for_testing.json');
     if (!fs.existsSync(functionsFile)) {
-      throw Error('Missing rules file: ' + functionsFile);
+      throw Error('Missing functions file: ' + functionsFile);
     }
     const functions = JSON.parse(fs.readFileSync(functionsFile));
     node.db.setFunctionsForTesting("test", functions);

--- a/test/tx-pool.test.js
+++ b/test/tx-pool.test.js
@@ -13,7 +13,7 @@ describe('TransactionPool', () => {
 
   beforeEach(() => {
     node = new Node();
-    setDbForTesting(node, 0);
+    setDbForTesting(node);
 
     transaction = getTransaction(node, {
       operation: {


### PR DESCRIPTION
Summary:
- Add is_global option to all DB operations except getProof()
- Add is_global option to all DB read/write APIs except getProof()
- Make sharding is testable in DB level by adding setShardingPath(), setValuesForTesting(), and setShardingForTesting()
- Refactor transaction sanitization logic
- Refactor tests in dev.test.js
- Fix test flakyness by using waitUntilTxFinalized()
- Fix flaky test case by removing unnecessary permission checks

#60 