### PR TITLE
Feature/platfowner/global path

### DIFF
--- a/consensus/index.js
+++ b/consensus/index.js
@@ -26,7 +26,7 @@ const {
 } = require('../constants');
 const { ConsensusMessageTypes, ConsensusConsts, ConsensusStatus, ConsensusDbPaths }
   = require('./constants');
-const { signAndSendTx, sendGetRequest } = require('../server/util');
+const { signAndSendTxList, sendGetRequest } = require('../server/util');
 const { sleep } = require('sleep');
 const LOG_PREFIX = 'CONSENSUS';
 const parentChainEndpoint = GenesisSharding[ShardingProperties.PARENT_CHAIN_POC] + '/json-rpc';
@@ -846,9 +846,9 @@ class Consensus {
         nonce: -1
       };
       // TODO(lia): save the blockNumber - txHash mapping at /sharding/reports of the child state
-      await signAndSendTx(
+      await signAndSendTxList(
         parentChainEndpoint,
-        tx,
+        [ tx ],
         Buffer.from(this.node.account.private_key, 'hex')
       );
     } catch (e) {

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -625,7 +625,7 @@ class Consensus {
       }
     }
     this.blockPool.cleanUpAfterFinalization(finalizableChain[finalizableChain.length - 2]);
-    this.reportStateProofHash();
+    this.reportStateProofHashes();
   }
 
   catchUp(blockList) {
@@ -790,7 +790,7 @@ class Consensus {
     return depositTx;
   }
 
-  async reportStateProofHash() {
+  async reportStateProofHashes() {
     if (!isShardChain) {
       return;
     }
@@ -823,14 +823,19 @@ class Consensus {
         }
         opList.push({
           type: WriteDbOperations.SET_VALUE,
-          ref: `${shardingPath}/${blockNumberToReport}/${PredefinedDbPaths.SHARDING_PROOF_HASH}`,
+          ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+              `${ShardingProperties.PROOF_HASH_MAP}/${blockNumberToReport}/` +
+              `${ShardingProperties.PROOF_HASH}`,
           value: block.stateProofHash
         });
         if (blockNumberToReport >= MAX_SHARD_REPORT) {
           // Remove old reports
           opList.push({
             type: WriteDbOperations.SET_VALUE,
-            ref: `${shardingPath}/${blockNumberToReport - MAX_SHARD_REPORT}/${PredefinedDbPaths.SHARDING_PROOF_HASH}`,
+            ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+                `${ShardingProperties.PROOF_HASH_MAP}/` +
+                `${blockNumberToReport - MAX_SHARD_REPORT}/` +
+                `${ShardingProperties.PROOF_HASH}`,
             value: null
           });
         }
@@ -864,7 +869,8 @@ class Consensus {
         'ain_get',
         {
           type: ReadDbOperations.GET_VALUE,
-          ref: `${shardingPath}/${PredefinedDbPaths.SHARDING_LATEST}`
+          ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+              `${ShardingProperties.PROOF_HASH_MAP}/${PredefinedDbPaths.SHARDING_LATEST}`
         }
       );
       return _.get(response, 'data.result.result');
@@ -879,7 +885,8 @@ class Consensus {
 
   setStatus(status, setter = '') {
     const LOG_SUFFIX = 'setStatus';
-    logger.info(`[${LOG_PREFIX}:${LOG_SUFFIX}] setting consensus status from ${this.status} to ${status} (setter = ${setter})`);
+    logger.info(`[${LOG_PREFIX}:${LOG_SUFFIX}] setting consensus status from ${this.status} to ` +
+        `${status} (setter = ${setter})`);
     this.status = status;
     this.statusChangedBlockNumber = this.node.bc.lastBlockNumber();
     this.setter = setter;

--- a/constants.js
+++ b/constants.js
@@ -92,7 +92,6 @@ const PredefinedDbPaths = {
   SHARDING: 'sharding',
   SHARDING_CONFIG: 'config',
   SHARDING_SHARD: 'shard',
-  SHARDING_PROOF_HASH: 'proof_hash',
   SHARDING_LATEST: 'latest'
 };
 
@@ -188,6 +187,8 @@ const NativeFunctionIds = {
  */
 const ShardingProperties = {
   PARENT_CHAIN_POC: 'parent_chain_poc',
+  PROOF_HASH: 'proof_hash',
+  PROOF_HASH_MAP: 'proof_hash_map',
   REPORTING_PERIOD: 'reporting_period',
   SHARD: '.shard',
   SHARD_OWNER: 'shard_owner',

--- a/constants.js
+++ b/constants.js
@@ -189,8 +189,10 @@ const NativeFunctionIds = {
 const ShardingProperties = {
   PARENT_CHAIN_POC: 'parent_chain_poc',
   REPORTING_PERIOD: 'reporting_period',
+  SHARD: '.shard',
   SHARD_OWNER: 'shard_owner',
   SHARD_REPORTER: 'shard_reporter',
+  SHARD_ENABLED: 'shard_enabled',
   SHARDING_PATH: 'sharding_path',
   SHARDING_PROTOCOL: 'sharding_protocol',
 };

--- a/constants.js
+++ b/constants.js
@@ -192,7 +192,7 @@ const ShardingProperties = {
   SHARD: '.shard',
   SHARD_OWNER: 'shard_owner',
   SHARD_REPORTER: 'shard_reporter',
-  SHARD_ENABLED: 'shard_enabled',
+  SHARDING_ENABLED: 'sharding_enabled',
   SHARDING_PATH: 'sharding_path',
   SHARDING_PROTOCOL: 'sharding_protocol',
 };

--- a/db/functions.js
+++ b/db/functions.js
@@ -173,14 +173,15 @@ class Functions {
       // Invalid function path
       return;
     }
-    const shardingPath = ChainUtil.formatPath(context.functionPath.slice(0, index));
-    const latestReportPath = this._getLatestShardReportPath(shardingPath);
+    const functionPath = ChainUtil.formatPath(context.functionPath.slice(0, index));
+    const latestReportPath = this._getLatestShardReportPath(functionPath);
     const currentLatestBlockNumber = this.db.getValue(latestReportPath);
     if (currentLatestBlockNumber !== null && Number(currentLatestBlockNumber) >= blockNumber) {
       // Nothing to update
       return;
     }
-    this.db.writeDatabase(this._getFullValuePath(ChainUtil.parsePath(latestReportPath)), blockNumber);
+    this.db.writeDatabase(
+        this._getFullValuePath(ChainUtil.parsePath(latestReportPath)), blockNumber);
   }
 
   _transferInternal(fromPath, toPath, value) {
@@ -203,35 +204,42 @@ class Functions {
   }
 
   _getDepositLockupDurationPath(service) {
-    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/${PredefinedDbPaths.DEPOSIT_CONFIG}/${PredefinedDbPaths.DEPOSIT_LOCKUP_DURATION}`);
+    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/` +
+        `${PredefinedDbPaths.DEPOSIT_CONFIG}/${PredefinedDbPaths.DEPOSIT_LOCKUP_DURATION}`);
   }
 
   _getDepositAmountPath(service, user) {
-    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/${user}/${PredefinedDbPaths.DEPOSIT_VALUE}`);
+    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/${user}/` +
+        `${PredefinedDbPaths.DEPOSIT_VALUE}`);
   }
 
   _getDepositExpirationPath(service, user) {
-    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/${user}/${PredefinedDbPaths.DEPOSIT_EXPIRE_AT}`);
+    return (`${PredefinedDbPaths.DEPOSIT_ACCOUNTS}/${service}/${user}/` +
+        `${PredefinedDbPaths.DEPOSIT_EXPIRE_AT}`);
   }
 
   _getDepositCreatedAtPath(service, user, depositId) {
-    return (`${PredefinedDbPaths.DEPOSIT}/${service}/${user}/${depositId}/${PredefinedDbPaths.DEPOSIT_CREATED_AT}`);
+    return (`${PredefinedDbPaths.DEPOSIT}/${service}/${user}/${depositId}/` +
+        `${PredefinedDbPaths.DEPOSIT_CREATED_AT}`);
   }
 
   _getDepositResultPath(service, user, depositId) {
-    return (`${PredefinedDbPaths.DEPOSIT}/${service}/${user}/${depositId}/${PredefinedDbPaths.DEPOSIT_RESULT}`);
+    return (`${PredefinedDbPaths.DEPOSIT}/${service}/${user}/${depositId}/` +
+        `${PredefinedDbPaths.DEPOSIT_RESULT}`);
   }
 
   _getWithdrawCreatedAtPath(service, user, withdrawId) {
-    return (`${PredefinedDbPaths.WITHDRAW}/${service}/${user}/${withdrawId}/${PredefinedDbPaths.WITHDRAW_CREATED_AT}`);
+    return (`${PredefinedDbPaths.WITHDRAW}/${service}/${user}/${withdrawId}/` +
+        `${PredefinedDbPaths.WITHDRAW_CREATED_AT}`);
   }
 
   _getWithdrawResultPath(service, user, withdrawId) {
-    return (`${PredefinedDbPaths.WITHDRAW}/${service}/${user}/${withdrawId}/${PredefinedDbPaths.WITHDRAW_RESULT}`);
+    return (`${PredefinedDbPaths.WITHDRAW}/${service}/${user}/${withdrawId}/` +
+        `${PredefinedDbPaths.WITHDRAW_RESULT}`);
   }
 
-  _getLatestShardReportPath(shardingPath) {
-    return `${shardingPath}/${PredefinedDbPaths.SHARDING_LATEST}`;
+  _getLatestShardReportPath(functionPath) {
+    return `${functionPath}/${PredefinedDbPaths.SHARDING_LATEST}`;
   }
 
   _getFullValuePath(parsedPath) {

--- a/db/index.js
+++ b/db/index.js
@@ -345,6 +345,8 @@ class DB {
   // TODO(seo): Define error code explicitly.
   // TODO(seo): Consider making set operation and native function run tightly bound, i.e., revert
   //            the former if the latter fails.
+  // TODO(seo): Apply isWritablePathWithSharding() to setFunction(), setRule(), and setOwner()
+  //            as well.
   setValue(valuePath, value, address, timestamp, transaction, isGlobal) {
     const isValidObj = isValidJsObjectForStates(value);
     if (!isValidObj.isValid) {

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -61,21 +61,20 @@ function isWritablePathWithSharding(fullPath, root) {
   let isValid = true;
   const path = [];
   let curNode = root;
+  for (const label of fullPath) {
+    if (label !== ShardingProperties.SHARD && hasEnabledShardConfig(curNode)) {
+      isValid = false;
+      break;
+    }
+    if (curNode.hasChild(label)) {
+      curNode = curNode.getChild(label);
+      path.push(label);
+    } else {
+      break;
+    }
+  }
   if (hasEnabledShardConfig(curNode)) {
     isValid = false;
-  } else {
-    for (const label of fullPath) {
-      if (curNode.hasChild(label)) {
-        curNode = curNode.getChild(label);
-        path.push(label);
-        if (hasEnabledShardConfig(curNode)) {
-          isValid = false;
-          break;
-        }
-      } else {
-        break;
-      }
-    }
   }
   return { isValid, invalidPath: isValid ? '' : ChainUtil.formatPath(path) };
 }

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -232,6 +232,17 @@ describe('Sharding', () => {
           )
         });
       });
+
+      it('.shard', () => {
+        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard`)
+        .body.toString('utf-8'));
+        assert.deepEqual(body, {
+          code: 0,
+          result: {
+            sharding_enabled: true
+          },
+        });
+      });
     });
 
     describe('DB functions', () => {
@@ -342,7 +353,7 @@ describe('Sharding', () => {
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         let blockNumber = 0;
-        const sortedReports = _.without(Object.keys(body.result), 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(Object.keys(body.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
         for (const key of sortedReports) {
           expect(blockNumber).to.equal(Number(key));
           blockNumber++;
@@ -354,7 +365,7 @@ describe('Sharding', () => {
         .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         const latest = body.result.latest;
-        const sortedReports = _.without(Object.keys(body.result), 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(Object.keys(body.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
         const highest = sortedReports[sortedReports.length - 1];
         expect(latest).to.equal(Number(highest));
       });
@@ -373,7 +384,7 @@ describe('Sharding', () => {
         const reportsAfter = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}`)
             .body.toString('utf-8'));
         let blockNumber = 0;
-        const sortedReports = _.without(Object.keys(reportsAfter.result), 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(Object.keys(reportsAfter.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
         for (const key of sortedReports) {
           expect(blockNumber).to.equal(Number(key));
           blockNumber++;

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -218,8 +218,10 @@ describe('Sharding', () => {
   describe('Parent chain initialization', () => {
     describe('DB values', () => {
       it('sharding', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=/sharding/shard/${ainUtil.encode(sharding.sharding_path)}`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer +
+            `/get_value?ref=/sharding/shard/${ainUtil.encode(sharding.sharding_path)}`)
+          .body.toString('utf-8'));
         assert.deepEqual(body, {
           code: 0,
           result: Object.assign(
@@ -234,8 +236,9 @@ describe('Sharding', () => {
       });
 
       it('.shard', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard`)
+          .body.toString('utf-8'));
         assert.deepEqual(body, {
           code: 0,
           result: {
@@ -247,8 +250,10 @@ describe('Sharding', () => {
 
     describe('DB functions', () => {
       it('sharding path', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_function?ref=${sharding.sharding_path}`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer +
+            `/get_function?ref=${sharding.sharding_path}/.shard/proof_hash_map`)
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result).to.not.be.null;
         assert.deepEqual(body.result, {
@@ -266,8 +271,11 @@ describe('Sharding', () => {
 
     describe('DB rules', () => {
       it('sharding path', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_rule?ref=${sharding.sharding_path}/$block_number/proof_hash`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer +
+            `/get_rule?ref=${sharding.sharding_path}/` +
+            `.shard/proof_hash_map/$block_number/proof_hash`)
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result['.write']).to.have.string(accounts.others[0].address);
       });
@@ -275,8 +283,9 @@ describe('Sharding', () => {
 
     describe('DB owners', () => {
       it('sharding path', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_owner?ref=${sharding.sharding_path}`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_owner?ref=${sharding.sharding_path}`)
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result['.owner'].owners[accounts.owner.address]).to.not.be.null;
       });
@@ -287,27 +296,27 @@ describe('Sharding', () => {
     describe('DB values', () => {
       it('token', () => {
         const body = JSON.parse(syncRequest('GET', server1 + '/get_value?ref=/token')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         assert.deepEqual(body, {code: 0, result: token});
       })
 
       it('accounts', () => {
         const body1 = JSON.parse(syncRequest(
             'GET', server1 + '/get_value?ref=/accounts/' + accounts.owner.address + '/balance')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         expect(body1.code).to.equal(0);
         expect(body1.result).to.be.above(0);
 
         const body2 = JSON.parse(syncRequest(
             'GET', server1 + '/get_value?ref=/accounts/' + accounts.others[0].address + '/balance')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         expect(body2.code).to.equal(0);
         expect(body2.result).to.be.above(0);
       })
 
       it('sharding', () => {
         const body = JSON.parse(syncRequest('GET', server1 + '/get_value?ref=/sharding/config')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result.sharding_protocol).to.equal(sharding.sharding_protocol);
         expect(body.result.sharding_path).to.equal(sharding.sharding_path);
@@ -317,7 +326,7 @@ describe('Sharding', () => {
     describe('DB functions', () => {
       it('sharding', () => {
         const body = JSON.parse(syncRequest('GET', server2 + '/get_function?ref=/transfer')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result).to.not.be.null;
       })
@@ -326,7 +335,7 @@ describe('Sharding', () => {
     describe('DB rules', () => {
       it('sharding', () => {
         const body = JSON.parse(syncRequest('GET', server3 + '/get_rule?ref=/sharding/config')
-            .body.toString('utf-8'));
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result['.write']).to.have.string(accounts.owner.address);
       })
@@ -349,11 +358,13 @@ describe('Sharding', () => {
 
     describe('periodic reports', () => {
       it ('reports proof hashes periodically', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}`)
-            .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard/proof_hash_map`)
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         let blockNumber = 0;
-        const sortedReports = _.without(Object.keys(body.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(
+            Object.keys(body.result), 'latest').sort((a, b) => Number(a) - Number(b));
         for (const key of sortedReports) {
           expect(blockNumber).to.equal(Number(key));
           blockNumber++;
@@ -361,18 +372,21 @@ describe('Sharding', () => {
       });
 
       it ('updates latest block number', () => {
-        const body = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}`)
-        .body.toString('utf-8'));
+        const body = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard/proof_hash_map`)
+          .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         const latest = body.result.latest;
-        const sortedReports = _.without(Object.keys(body.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(
+            Object.keys(body.result), 'latest').sort((a, b) => Number(a) - Number(b));
         const highest = sortedReports[sortedReports.length - 1];
         expect(latest).to.equal(Number(highest));
       });
 
       it('can resume reporting after missing some reports', () => {
-        const reportsBefore = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}`)
-            .body.toString('utf-8'));
+        const reportsBefore = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard/proof_hash_map`)
+          .body.toString('utf-8'));
         console.log(`Shutting down server[0]...`);
         server1_proc.kill();
         waitForNewBlocks(server2, sharding.reporting_period);
@@ -381,10 +395,12 @@ describe('Sharding', () => {
         waitForNewBlocks(server2, sharding.reporting_period);
         waitUntilNodeSyncs(server1);
         waitForNewBlocks(server1, sharding.reporting_period);
-        const reportsAfter = JSON.parse(syncRequest('GET', parentServer + `/get_value?ref=${sharding.sharding_path}`)
-            .body.toString('utf-8'));
+        const reportsAfter = JSON.parse(syncRequest(
+            'GET', parentServer + `/get_value?ref=${sharding.sharding_path}/.shard/proof_hash_map`)
+          .body.toString('utf-8'));
         let blockNumber = 0;
-        const sortedReports = _.without(Object.keys(reportsAfter.result), '.shard', 'latest').sort((a,b) => Number(a) - Number(b));
+        const sortedReports = _.without(
+            Object.keys(reportsAfter.result), 'latest').sort((a, b) => Number(a) - Number(b));
         for (const key of sortedReports) {
           expect(blockNumber).to.equal(Number(key));
           blockNumber++;

--- a/logger/winston-util.js
+++ b/logger/winston-util.js
@@ -7,7 +7,7 @@ const { DEBUG, PORT, ACCOUNT_INDEX, HOSTING_ENV, LIGHTWEIGHT } = require('../con
 const { combine, timestamp, label, printf, colorize } = winston.format;
 
 const logDir = path.join(__dirname, '.', 'logs', String(PORT));
-const prefix = `node-${ACCOUNT_INDEX}`;
+const prefix = `node-${ACCOUNT_INDEX}-${PORT}`;
 const logFormat = printf(({ level, message, label, timestamp }) => {
   return `${timestamp} [${label}] ${level}: ${message}`;
 });

--- a/server/index.js
+++ b/server/index.js
@@ -601,6 +601,7 @@ class P2pServer {
     await this.setUpDbForSharding();
   }
 
+  // TODO(seo): Set .shard config for functions, rules, and owners as well.
   async setUpDbForSharding() {
     const parentChainEndpoint = GenesisSharding[ShardingProperties.PARENT_CHAIN_POC] + '/json-rpc';
     const shardOwner = GenesisSharding[ShardingProperties.SHARD_OWNER];

--- a/server/index.js
+++ b/server/index.js
@@ -613,8 +613,12 @@ class P2pServer {
     const shardingPathRules = `auth === '${shardOwner}'`;
     const proofHashRulesLight = `auth === '${shardReporter}'`;
     const proofHashRules = `auth === '${shardReporter}' && ` +
-        `((newData === null && Number($block_number) < (getValue('${shardingPath}/latest') || 0)) || ` +
-        `(newData !== null && ($block_number === '0' || $block_number === String((getValue('${shardingPath}/latest') || 0) + 1))))`;
+        `((newData === null && ` +
+        `Number($block_number) < (getValue('${shardingPath}/${ShardingProperties.SHARD}/` +
+            `${ShardingProperties.PROOF_HASH_MAP}/latest') || 0)) || ` +
+        `(newData !== null && ($block_number === '0' || ` +
+        `$block_number === String((getValue('${shardingPath}/${ShardingProperties.SHARD}/` +
+            `${ShardingProperties.PROOF_HASH_MAP}/latest') || 0) + 1))))`;
 
     const shardInitTxList = [
       {
@@ -644,8 +648,10 @@ class P2pServer {
               type: WriteDbOperations.SET_RULE,
               ref: ChainUtil.formatPath([
                 ...ChainUtil.parsePath(shardingPath),
+                ShardingProperties.SHARD,
+                ShardingProperties.PROOF_HASH_MAP,
                 '$block_number',
-                PredefinedDbPaths.SHARDING_PROOF_HASH
+                ShardingProperties.PROOF_HASH
               ]),
               value: {
                 [RuleProperties.WRITE]: LIGHTWEIGHT ? proofHashRulesLight : proofHashRules
@@ -655,8 +661,10 @@ class P2pServer {
               type: WriteDbOperations.SET_FUNCTION,
               ref: ChainUtil.formatPath([
                 ...ChainUtil.parsePath(shardingPath),
+                ShardingProperties.SHARD,
+                ShardingProperties.PROOF_HASH_MAP,
                 '$block_number',
-                PredefinedDbPaths.SHARDING_PROOF_HASH
+                ShardingProperties.PROOF_HASH
               ]),
               value: {
                 [FunctionProperties.FUNCTION]: {

--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,7 @@ const {
   LIGHTWEIGHT
 } = require('../constants');
 const ChainUtil = require('../chain-util');
-const { sendTxAndWaitForConfirmation } = require('./util');
+const { sendTxListAndWaitForConfirmation } = require('./util');
 
 const GCP_EXTERNAL_IP_URL = 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip';
 const CURRENT_PROTOCOL_VERSION = require('../package.json').version;
@@ -609,68 +609,87 @@ class P2pServer {
     const keyBuffer = Buffer.from(ownerPrivateKey, 'hex');
     const shardReporter = GenesisSharding[ShardingProperties.SHARD_REPORTER];
     const shardingPath = GenesisSharding[ShardingProperties.SHARDING_PATH];
-    const reportingPeriod = GenesisSharding[ShardingProperties.REPORTING_PERIOD];
-    const lightweightRules = `auth === '${shardReporter}'`;
-    const nonLightweightRules = `auth === '${shardReporter}' && ` +
+    const shardingPathRules = `auth === '${shardOwner}'`;
+    const proofHashRulesLight = `auth === '${shardReporter}'`;
+    const proofHashRules = `auth === '${shardReporter}' && ` +
         `((newData === null && Number($block_number) < (getValue('${shardingPath}/latest') || 0)) || ` +
         `(newData !== null && ($block_number === '0' || $block_number === String((getValue('${shardingPath}/latest') || 0) + 1))))`;
 
-    const shardInitTx = {
-      operation: {
-        type: WriteDbOperations.SET,
-        op_list: [
-          {
-            type: WriteDbOperations.SET_OWNER,
-            ref: shardingPath,
-            value: {
-              [OwnerProperties.OWNER]: {
-                [OwnerProperties.OWNERS]: {
-                  [shardOwner]: buildOwnerPermissions(false, true, true, true),
-                  [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
+    const shardInitTxList = [
+      {
+        operation: {
+          type: WriteDbOperations.SET,
+          op_list: [
+            {
+              type: WriteDbOperations.SET_OWNER,
+              ref: shardingPath,
+              value: {
+                [OwnerProperties.OWNER]: {
+                  [OwnerProperties.OWNERS]: {
+                    [shardOwner]: buildOwnerPermissions(false, true, true, true),
+                    [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
+                  }
                 }
               }
-            }
-          },
-          {
-            type: WriteDbOperations.SET_RULE,
-            ref: ChainUtil.formatPath([
-              ...ChainUtil.parsePath(shardingPath),
-              '$block_number',
-              PredefinedDbPaths.SHARDING_PROOF_HASH
-            ]),
-            value: {
-              [RuleProperties.WRITE]: LIGHTWEIGHT ? lightweightRules : nonLightweightRules
-            }
-          },
-          {
-            type: WriteDbOperations.SET_FUNCTION,
-            ref: ChainUtil.formatPath([
-              ...ChainUtil.parsePath(shardingPath),
-              '$block_number',
-              PredefinedDbPaths.SHARDING_PROOF_HASH
-            ]),
-            value: {
-              [FunctionProperties.FUNCTION]: {
-                [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
-                [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
+            },
+            {
+              type: WriteDbOperations.SET_RULE,
+              ref: shardingPath,
+              value: {
+                [RuleProperties.WRITE]: shardingPathRules
               }
+            },
+            {
+              type: WriteDbOperations.SET_RULE,
+              ref: ChainUtil.formatPath([
+                ...ChainUtil.parsePath(shardingPath),
+                '$block_number',
+                PredefinedDbPaths.SHARDING_PROOF_HASH
+              ]),
+              value: {
+                [RuleProperties.WRITE]: LIGHTWEIGHT ? proofHashRulesLight : proofHashRules
+              }
+            },
+            {
+              type: WriteDbOperations.SET_FUNCTION,
+              ref: ChainUtil.formatPath([
+                ...ChainUtil.parsePath(shardingPath),
+                '$block_number',
+                PredefinedDbPaths.SHARDING_PROOF_HASH
+              ]),
+              value: {
+                [FunctionProperties.FUNCTION]: {
+                  [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
+                  [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
+                }
+              }
+            },
+            {
+              type: WriteDbOperations.SET_VALUE,
+              ref: shardingPath,
+              value: {
+                [ShardingProperties.SHARD]: {
+                  [ShardingProperties.SHARD_ENABLED]: true
+                }
+              }
+            },
+            {
+              type: WriteDbOperations.SET_VALUE,
+              ref: ChainUtil.formatPath([
+                PredefinedDbPaths.SHARDING,
+                PredefinedDbPaths.SHARDING_SHARD,
+                ainUtil.encode(shardingPath)
+              ]),
+              value: GenesisSharding
             }
-          },
-          {
-            type: WriteDbOperations.SET_VALUE,
-            ref: ChainUtil.formatPath([
-              PredefinedDbPaths.SHARDING,
-              PredefinedDbPaths.SHARDING_SHARD,
-              ainUtil.encode(shardingPath)
-            ]),
-            value: GenesisSharding
-          }
-        ]
-      },
-      timestamp: Date.now(),
-      nonce: -1
-    };
-    await sendTxAndWaitForConfirmation(parentChainEndpoint, shardInitTx, keyBuffer);
+          ]
+        },
+        timestamp: Date.now(),
+        nonce: -1
+      }
+    ];
+
+    await sendTxListAndWaitForConfirmation(parentChainEndpoint, shardInitTxList, keyBuffer);
     logger.info(`[${P2P_PREFIX}] setUpDbForSharding success`);
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -669,7 +669,7 @@ class P2pServer {
               ref: shardingPath,
               value: {
                 [ShardingProperties.SHARD]: {
-                  [ShardingProperties.SHARD_ENABLED]: true
+                  [ShardingProperties.SHARDING_ENABLED]: true
                 }
               }
             },

--- a/start_servers_afan.sh
+++ b/start_servers_afan.sh
@@ -1,0 +1,17 @@
+rm -rf blockchain/blockchains logger/log
+
+# PARENT CHAIN
+node ./tracker-server/index.js &
+sleep 5
+NUM_VALIDATORS=3 ACCOUNT_INDEX=0 HOSTING_ENV=local node ./client/index.js &
+NUM_VALIDATORS=3 ACCOUNT_INDEX=1 HOSTING_ENV=local node ./client/index.js &
+NUM_VALIDATORS=3 ACCOUNT_INDEX=2 HOSTING_ENV=local node ./client/index.js &
+sleep 10
+
+# AFAN CHILD CHAIN
+PORT=9010 P2P_PORT=6010 node ./tracker-server/index.js &
+sleep 10
+PORT=9011 P2P_PORT=6011 TRACKER_WS_ADDR=ws://localhost:6010 NUM_VALIDATORS=3 ACCOUNT_INDEX=0 HOSTING_ENV=local GENESIS_CONFIGS_DIR=blockchain/afan_shard node ./client/index.js &
+PORT=9012 P2P_PORT=6012 TRACKER_WS_ADDR=ws://localhost:6010 NUM_VALIDATORS=3 ACCOUNT_INDEX=1 HOSTING_ENV=local GENESIS_CONFIGS_DIR=blockchain/afan_shard node ./client/index.js &
+PORT=9013 P2P_PORT=6013 TRACKER_WS_ADDR=ws://localhost:6010 NUM_VALIDATORS=3 ACCOUNT_INDEX=2 HOSTING_ENV=local GENESIS_CONFIGS_DIR=blockchain/afan_shard node ./client/index.js &
+sleep 10

--- a/test/state-util.test.js
+++ b/test/state-util.test.js
@@ -1,4 +1,6 @@
 const {
+  hasEnabledShardConfig,
+  isWritablePathWithSharding,
   hasReservedChar,
   hasAllowedPattern,
   isValidStateLabel,
@@ -19,6 +21,120 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 describe("state-util", () => {
+  describe("hasEnabledShardConfig", () => {
+    it("when input without matched shard config returning false", () => {
+      expect(hasEnabledShardConfig(jsObjectToStateTree(null))).to.equal(false);
+      expect(hasEnabledShardConfig(jsObjectToStateTree({}))).to.equal(false);
+      expect(hasEnabledShardConfig(jsObjectToStateTree({
+        subtree: {
+          path: "some value"
+        },
+        str: "string value"
+      }
+      ))).to.equal(false);
+      expect(hasEnabledShardConfig(jsObjectToStateTree({
+        subtree: {
+          path: "some value",
+          ".shard": {
+            sharding_enabled: true
+          }
+        },
+        str: "string value"
+      }
+      ))).to.equal(false);
+    })
+
+    it("when input with matched shard config returning false", () => {
+      expect(hasEnabledShardConfig(jsObjectToStateTree({
+        subtree: {
+          path: "some value",
+        },
+        str: "string value",
+        ".shard": {
+          sharding_enabled: false
+        }
+      }
+      ))).to.equal(false);
+    })
+
+    it("when input with shard config returning true", () => {
+      expect(hasEnabledShardConfig(jsObjectToStateTree({
+        subtree: {
+          path: "some value",
+        },
+        str: "string value",
+        ".shard": {
+          sharding_enabled: true
+        }
+      }
+      ))).to.equal(true);
+    })
+  })
+
+  describe("isWritablePathWithSharding", () => {
+    it("when writable input", () => {
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              path: {
+                ".shard": {
+                  sharding_enabled: true
+                }
+              }
+            }
+          })), {isValid: false, invalidPath: '/some/path'});
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              other_path: true,
+              ".shard": {
+                sharding_enabled: true
+              }
+            }
+          })), {isValid: false, invalidPath: '/some'});
+    })
+
+    it("when writable input", () => {
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              path: true
+            }
+          })), {isValid: true, invalidPath: ''});
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              other_path: true
+            }
+          })), {isValid: true, invalidPath: ''});
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              path: {
+                ".shard": {
+                  sharding_enabled: false
+                }
+              }
+            }
+          })), {isValid: true, invalidPath: ''});
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path'],
+          jsObjectToStateTree({
+            some: {
+              other_path: true,
+              ".shard": {
+                sharding_enabled: false
+              }
+            }
+          })), {isValid: true, invalidPath: ''});
+    })
+  })
+
   describe("hasReservedChar", () => {
     it("when non-string input", () => {
       expect(hasReservedChar(null)).to.equal(false);

--- a/test/state-util.test.js
+++ b/test/state-util.test.js
@@ -72,7 +72,7 @@ describe("state-util", () => {
   })
 
   describe("isWritablePathWithSharding", () => {
-    it("when writable input", () => {
+    it("when non-writable path with shard config", () => {
       assert.deepEqual(isWritablePathWithSharding(
           ['some', 'path'],
           jsObjectToStateTree({
@@ -96,7 +96,7 @@ describe("state-util", () => {
           })), {isValid: false, invalidPath: '/some'});
     })
 
-    it("when writable input", () => {
+    it("when writable path w/o shard config", () => {
       assert.deepEqual(isWritablePathWithSharding(
           ['some', 'path'],
           jsObjectToStateTree({
@@ -111,6 +111,8 @@ describe("state-util", () => {
               other_path: true
             }
           })), {isValid: true, invalidPath: ''});
+    })
+    it("when writable path with shard config", () => {
       assert.deepEqual(isWritablePathWithSharding(
           ['some', 'path'],
           jsObjectToStateTree({
@@ -129,6 +131,30 @@ describe("state-util", () => {
               other_path: true,
               ".shard": {
                 sharding_enabled: false
+              }
+            }
+          })), {isValid: true, invalidPath: ''});
+    })
+    it("when writable path through shard config", () => {
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path', '.shard', 'sharding_enabled'],
+          jsObjectToStateTree({
+            some: {
+              path: {
+                ".shard": {
+                  sharding_enabled: true
+                }
+              }
+            }
+          })), {isValid: true, invalidPath: ''});
+      assert.deepEqual(isWritablePathWithSharding(
+          ['some', 'path', '.shard', 'proof_hash_map'],
+          jsObjectToStateTree({
+            some: {
+              path: {
+                ".shard": {
+                  sharding_enabled: true
+                }
               }
             }
           })), {isValid: true, invalidPath: ''});

--- a/tracker-server/logger.js
+++ b/tracker-server/logger.js
@@ -3,6 +3,7 @@ const winstonDaily = require('winston-daily-rotate-file');
 const path = require('path');
 const { LoggingWinston } = require('@google-cloud/logging-winston');
 
+const PORT = process.env.PORT || 8080;
 const HOSTING_ENV = process.env.HOSTING_ENV || 'default';
 
 const { combine, timestamp, label, printf } = winston.format
@@ -11,7 +12,7 @@ const logFormat = printf(({ level, message, label, timestamp }) => {
 })
 
 const logDir = path.join(__dirname, '.', 'logs');
-const prefix = `tracker`;
+const prefix = `tracker-${PORT}`;
 
 function getTransports() {
   const transports = [


### PR DESCRIPTION
Summary:
- Add `.shard: { sharding_enabled: true }` config to the sharding path of the parent blockchain in the shard initialization
- In setValue() (along with incValue() and decValue()) operation, it's checked whether the path-to-write path includes any sharding path
  - If it's in the case, the setValue() operation returns error with isGlobal = false and do nothing with isGlobal = true
  - Otherwise it goes with the normal set value operation process 
  - Writing into the shard config (.shard) is allowed
- Move the path for proof hashes to <sharding_path>/.shard/proof_hash_map from <sharding_path>
- Move config util functions from db/index.js to db/state-util.js
- Add port number of the blockchain node to the prefix of the log messages

Background:
- This is needed for cross-shard token swap implementation: AIP-009