### PR TITLE
Fix axios.post() bug. Set the initial value of proof_hash_map/latest …

### DIFF
--- a/consensus/index.js
+++ b/consensus/index.js
@@ -832,6 +832,7 @@ class Consensus {
               `${ShardingProperties.PROOF_HASH}`,
           value: block.stateProofHash
         });
+        this.lastReportedBlockNumberSent = blockNumberToReport;
         if (blockNumberToReport >= MAX_SHARD_REPORT) {
           // Remove old reports
           opList.push({
@@ -863,7 +864,6 @@ class Consensus {
     } catch (e) {
       logger.error(`[${LOG_PREFIX}] Failed to report state proof hashes: ${e}`);
     }
-    this.lastReportedBlockNumberSent = lastFinalizedBlockNumber;
     this.isReporting = false;
   }
 

--- a/constants.js
+++ b/constants.js
@@ -92,7 +92,6 @@ const PredefinedDbPaths = {
   SHARDING: 'sharding',
   SHARDING_CONFIG: 'config',
   SHARDING_SHARD: 'shard',
-  SHARDING_LATEST: 'latest'
 };
 
 /**
@@ -186,6 +185,7 @@ const NativeFunctionIds = {
  * @enum {string}
  */
 const ShardingProperties = {
+  LATEST: 'latest',
   PARENT_CHAIN_POC: 'parent_chain_poc',
   PROOF_HASH: 'proof_hash',
   PROOF_HASH_MAP: 'proof_hash_map',

--- a/db/functions.js
+++ b/db/functions.js
@@ -239,7 +239,7 @@ class Functions {
   }
 
   _getLatestShardReportPath(functionPath) {
-    return `${functionPath}/${PredefinedDbPaths.SHARDING_LATEST}`;
+    return `${functionPath}/${ShardingProperties.LATEST}`;
   }
 
   _getFullValuePath(parsedPath) {

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -242,7 +242,10 @@ describe('Sharding', () => {
         assert.deepEqual(body, {
           code: 0,
           result: {
-            sharding_enabled: true
+            sharding_enabled: true,
+            proof_hash_map: {
+              latest: -1
+            }
           },
         });
       });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ainblockchain/ain-util": "^1.1.6",
     "@google-cloud/logging-winston": "^3.0.5",
     "ajv": "^5.5.2",
-    "axios": "^0.19.2",
+    "axios": "^0.20.0",
     "bluebird": "^3.5.3",
     "body-parser": "^1.18.3",
     "crypto": "^1.0.1",

--- a/server/index.js
+++ b/server/index.js
@@ -541,7 +541,8 @@ class P2pServer {
       return null;
     }
     if (this.node.bc.syncedAfterStartup === false) {
-      logger.debug(`[${P2P_PREFIX}] NOT SYNCED YET. WILL ADD TX TO THE POOL: ${JSON.stringify(transaction)}`);
+      logger.debug(`[${P2P_PREFIX}] NOT SYNCED YET. WILL ADD TX TO THE POOL: ` +
+          `${JSON.stringify(transaction)}`);
       this.node.tp.addTransaction(transaction);
       return null;
     }
@@ -549,7 +550,8 @@ class P2pServer {
     if (!ChainUtil.transactionFailed(result)) {
       this.node.tp.addTransaction(transaction);
     } else {
-      logger.debug(`[${P2P_PREFIX}] FAILED TRANSACTION: ${JSON.stringify(transaction)}\t RESULT:${JSON.stringify(result)}`);
+      logger.debug(`[${P2P_PREFIX}] FAILED TRANSACTION: ${JSON.stringify(transaction)}\t ` +
+          `RESULT:${JSON.stringify(result)}`);
     }
     return result;
   }
@@ -573,8 +575,8 @@ class P2pServer {
 
       return resultList;
     } else {
-      const transaction = transactionWithSig instanceof Transaction ? transactionWithSig
-                                                                    : new Transaction(transactionWithSig);
+      const transaction = transactionWithSig instanceof Transaction ?
+          transactionWithSig : new Transaction(transactionWithSig);
       const response = this.executeTransaction(transaction);
       logger.debug(`\n[${P2P_PREFIX}] TX RESPONSE: ` + JSON.stringify(response))
       if (!ChainUtil.transactionFailed(response)) {
@@ -678,7 +680,10 @@ class P2pServer {
               ref: shardingPath,
               value: {
                 [ShardingProperties.SHARD]: {
-                  [ShardingProperties.SHARDING_ENABLED]: true
+                  [ShardingProperties.SHARDING_ENABLED]: true,
+                  [ShardingProperties.PROOF_HASH_MAP]: {
+                    [ShardingProperties.LATEST]: -1,
+                  }
                 }
               }
             },

--- a/server/util.js
+++ b/server/util.js
@@ -124,6 +124,8 @@ async function waitUntilTxFinalize(endpoint, txHash) {
 }
 
 async function sendGetRequest(endpoint, method, params) {
+  // NOTE(seo): .then() was used here to avoid some unexpected behavior or axios.post()
+  //            (see https://github.com/ainblockchain/ain-blockchain/issues/101)
   return await axios.post(
       endpoint,
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,12 +586,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
+  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -1152,13 +1152,6 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -2017,12 +2010,10 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Summary:
- Use
```
  return await axios.post(
      ...
  .then(function (resp) {
    return _.get(resp, 'data.result.result');
  });
```
pattern to avoid exceptions with empty {} value
- Set the initial value of proof_hash_map/latest to -1
- Tweak proof hash reporting logic to minimize report conflicts


Background:
- Just found that sometimes axios.post() throws some empty exceptions when used with `const response = await axios.post();` pattern

#101 