### PR TITLE
Feature/state version control/consensus

### DIFF
--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -143,15 +143,17 @@ class Blockchain {
     if (!(newBlock instanceof Block)) {
       newBlock = Block.parse(newBlock);
     }
-    if (!db.executeTransactionList(newBlock.last_votes)) {
-      logger.error('[blockchain.addNewBlockToChain] Failed to execute last_votes of block' +
-          `${JSON.stringify(newBlock, null, 2)}`);
-      return false;
-    }
-    if (!db.executeTransactionList(newBlock.transactions)) {
-      logger.error('[blockchain.addNewBlockToChain] Failed to execute transactions of block' +
-          `${JSON.stringify(newBlock, null, 2)}`);
-      return false;
+    if (db) {
+      if (!db.executeTransactionList(newBlock.last_votes)) {
+        logger.error('[blockchain.addNewBlockToChain] Failed to execute last_votes of block' +
+            `${JSON.stringify(newBlock, null, 2)}`);
+        return false;
+      }
+      if (!db.executeTransactionList(newBlock.transactions)) {
+        logger.error('[blockchain.addNewBlockToChain] Failed to execute transactions of block' +
+            `${JSON.stringify(newBlock, null, 2)}`);
+        return false;
+      }
     }
     this.chain.push(newBlock);
     this.writeChain();

--- a/consensus/constants.js
+++ b/consensus/constants.js
@@ -1,7 +1,7 @@
 const ConsensusConsts = {
   MAJORITY: 2 / 3,
   DAY_MS: 86400000,
-  EPOCH_MS: 3000,
+  EPOCH_MS: 1000,
   MAX_CONSENSUS_STATE_DB: 1000,
   INITIAL_NUM_VALIDATORS: process.env.NUM_VALIDATORS ? Number(process.env.NUM_VALIDATORS) : 5,
   INITIAL_STAKE: 250,

--- a/consensus/constants.js
+++ b/consensus/constants.js
@@ -1,7 +1,7 @@
 const ConsensusConsts = {
   MAJORITY: 2 / 3,
   DAY_MS: 86400000,
-  EPOCH_MS: 1000,
+  EPOCH_MS: 3000,
   MAX_CONSENSUS_STATE_DB: 1000,
   INITIAL_NUM_VALIDATORS: process.env.NUM_VALIDATORS ? Number(process.env.NUM_VALIDATORS) : 5,
   INITIAL_STAKE: 250,

--- a/unittest/blockchain.test.js
+++ b/unittest/blockchain.test.js
@@ -93,7 +93,8 @@ describe('Blockchain', () => {
       while (!node1.bc.lastBlock() || !node2.bc.lastBlock() || node1.bc.lastBlock().hash !== node2.bc.lastBlock().hash) {
         const blockSection = node1.bc.requestBlockchainSection(node2.bc.lastBlock());
         if (blockSection) {
-          node2.bc.merge(blockSection, node2.backupDb);
+          node2.bc.merge(blockSection, node2.createDb(node2.stateManager.getFinalizedVersion(),
+              `NODE:${blockSection[blockSection.length - 1].number}`, this.bc, this.tp, true));
         }
       }
       assert.deepEqual(JSON.stringify(node1.bc.chain), JSON.stringify(node2.bc.chain));

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,19 +948,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-deasync-promise@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deasync-promise/-/deasync-promise-1.0.1.tgz#2b27de478167af4ef34ba99879c52ec0cedd61c2"
-  dependencies:
-    deasync "^0.1.7"
-
-deasync@^0.1.7:
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.20.tgz#546fd2660688a1eeed55edce2308c5cf7104f9da"
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.7.1"
-
 debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
@@ -2734,10 +2721,6 @@ nock@^12.0.0:
     lodash "^4.17.13"
     propagate "^2.0.0"
 
-node-addon-api@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-
 node-cron@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-2.0.3.tgz#b9649784d0d6c00758410eef22fa54a10e3f602d"
@@ -3764,12 +3747,6 @@ sync-rpc@^1.2.1:
   resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.6.tgz#b2e8b2550a12ccbc71df8644810529deb68665a7"
   dependencies:
     get-port "^3.1.0"
-
-system-sleep@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/system-sleep/-/system-sleep-1.3.6.tgz#ed9b698ae991f3e6cee85aa0083c9a06a9b6bc03"
-  dependencies:
-    deasync-promise "1.0.1"
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
- Remove redundant backupDb and replace it with finalizedVersion
- By doing so, we avoid executing transactions to backupDb every time we finalize a block, since we already have a state constructed during the consensus process