### PR TITLE
Feature/platfowner/new feature

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -215,7 +215,7 @@ class DB {
     return stateNode.toJsObject();
   }
 
-  // TODO(seo): Support lookups on the finalized version.
+  // TODO(seo): Support lookups on the final version.
   getValue(valuePath, isGlobal) {
     const parsedPath = ChainUtil.parsePath(valuePath);
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;

--- a/db/state-manager.js
+++ b/db/state-manager.js
@@ -2,7 +2,7 @@ const logger = require('../logger')('STATE_MANAGER');
 const StateNode = require('./state-node');
 const {
   makeCopyOfStateTree,
-  replaceStateTreeVersion,
+  renameStateTreeVersion,
   deleteStateTree,
   deleteStateTreeVersion,
 } = require('./state-util');
@@ -126,13 +126,14 @@ class StateManager {
   }
 
   /**
-   * Replaces the subtree nodes' version of the given newVersion root with newVersion
-   * if their version is the given oldVersion.
+   * Renames the state tree's version of the given new version. Each node's version of
+   * the state tree specified with the new version is set with the new version if its value
+   * is equal to the given old version.
    * 
-   * @param {string} oldVersion state version to replace
-   * @param {string} newVersion new state version 
+   * @param {string} oldVersion state version to rename
+   * @param {string} newVersion version of the state tree to apply the renaming
    */
-  replaceVersion(oldVersion, newVersion) {
+  renameVersion(oldVersion, newVersion) {
     const LOG_HEADER = 'renameVersion';
     logger.debug(
         `[${LOG_HEADER}] Renaming version ${oldVersion} -> ${newVersion} (${this.numVersions()})`);
@@ -145,7 +146,7 @@ class StateManager {
       logger.error(`[${LOG_HEADER}] Null root of version: ${newVersion}`);
       return false;
     }
-    let numRenamedNodes = replaceStateTreeVersion(root, oldVersion, newVersion);
+    let numRenamedNodes = renameStateTreeVersion(root, oldVersion, newVersion);
     logger.debug(`[${LOG_HEADER}] Renamed ${numRenamedNodes} state nodes.`);
     return true;
   }

--- a/db/state-manager.js
+++ b/db/state-manager.js
@@ -100,7 +100,7 @@ class StateManager {
    */
   cloneVersion(version, newVersion) {
     const LOG_HEADER = 'cloneVersion';
-    logger.info(`[${LOG_HEADER}] Cloning version ${version} to version ${newVersion} ` +
+    logger.debug(`[${LOG_HEADER}] Cloning version ${version} to version ${newVersion} ` +
         `(${this.numVersions()})`);
     if (!this.hasVersion(version)) {
       logger.error(`[${LOG_HEADER}] Non-existing version: ${version}`);
@@ -134,7 +134,7 @@ class StateManager {
    */
   replaceVersion(oldVersion, newVersion) {
     const LOG_HEADER = 'renameVersion';
-    logger.info(
+    logger.debug(
         `[${LOG_HEADER}] Renaming version ${oldVersion} -> ${newVersion} (${this.numVersions()})`);
     if (!this.hasVersion(newVersion)) {
       logger.error(`[${LOG_HEADER}] Non-existing version: ${newVersion}`);
@@ -146,7 +146,7 @@ class StateManager {
       return false;
     }
     let numRenamedNodes = replaceStateTreeVersion(root, oldVersion, newVersion);
-    logger.info(`[${LOG_HEADER}] Renamed ${numRenamedNodes} state nodes.`);
+    logger.debug(`[${LOG_HEADER}] Renamed ${numRenamedNodes} state nodes.`);
     return true;
   }
 
@@ -157,19 +157,19 @@ class StateManager {
    */
   deleteVersion(version) {
     const LOG_HEADER = 'deleteVersion';
-    logger.info(`[${LOG_HEADER}] Deleting version ${version} (${this.numVersions()})`);
+    logger.debug(`[${LOG_HEADER}] Deleting version ${version} (${this.numVersions()})`);
     if (!this.hasVersion(version)) {
       logger.error(`[${LOG_HEADER}] Non-existing version: ${version}`);
-      return null;
+      return false;
     }
     if (version === this.finalVersion) {
       logger.error(`[${LOG_HEADER}] Not allowed to delete final version: ${version}`);
-      return null;
+      return false;
     }
     const root = this.getRoot(version);
     if (root === null) {
       logger.error(`[${LOG_HEADER}] Null root of version: ${version}`);
-      return null;
+      return false;
     }
     let numDeletedNodes = null;
     if (FeatureFlags.enableStateVersionOpt) {
@@ -177,9 +177,9 @@ class StateManager {
     } else {
       numDeletedNodes = deleteStateTree(root);
     }
-    logger.info(`[${LOG_HEADER}] Deleted ${numDeletedNodes} state nodes.`);
+    logger.debug(`[${LOG_HEADER}] Deleted ${numDeletedNodes} state nodes.`);
     this.rootMap.delete(version);
-    return root;
+    return true;
   }
 
   /**
@@ -189,7 +189,7 @@ class StateManager {
    */
   finalizeVersion(version) {
     const LOG_HEADER = 'finalizeVersion';
-    logger.info(`[${LOG_HEADER}] Finalizing version '${version}' among ` +
+    logger.debug(`[${LOG_HEADER}] Finalizing version '${version}' among ` +
         `${this.numVersions()} versions: ${JSON.stringify(this.getVersionList())}` +
         ` with latest final version: '${this.getFinalVersion()}'`);
     if (version === this.finalVersion) {

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -169,9 +169,12 @@ function setStateTreeVersion(node, version) {
 }
 
 /**
+ * Renames the version of the given state tree. Each node's version of the state tree is set with
+ * given new version if its value is equal to the given old version.
+ * 
  * Returns affected nodes' number.
  */
-function replaceStateTreeVersion(node, oldVersion, newVersion, isRootNode = true) {
+function renameStateTreeVersion(node, oldVersion, newVersion, isRootNode = true) {
   let numAffectedNodes = 0;
   if (node === null) {
     return numAffectedNodes;
@@ -185,7 +188,7 @@ function replaceStateTreeVersion(node, oldVersion, newVersion, isRootNode = true
   if (isRootNode || nodeVersionRenamed) {
     for (const label of node.getChildLabels()) {
       const childNode = node.getChild(label);
-      numAffectedNodes += replaceStateTreeVersion(childNode, oldVersion, newVersion, false);
+      numAffectedNodes += renameStateTreeVersion(childNode, oldVersion, newVersion, false);
     }
   }
 
@@ -339,7 +342,7 @@ module.exports = {
   isValidPathForStates,
   isValidJsObjectForStates,
   setStateTreeVersion,
-  replaceStateTreeVersion,
+  renameStateTreeVersion,
   deleteStateTree,
   deleteStateTreeVersion,
   makeCopyOfStateTree,

--- a/node/index.js
+++ b/node/index.js
@@ -136,8 +136,8 @@ class BlockchainNode {
     if (!this.stateManager.finalizeVersion(newFinalVersion)) {
       logger.error(`[${LOG_HEADER}] Failed to finalize version: ${newFinalVersion}`);
     }
-    logger.info(`[${LOG_HEADER}] Replacing version: ${version} -> ${newFinalVersion}`);
-    if (!this.stateManager.replaceVersion(version, newFinalVersion)) {
+    logger.info(`[${LOG_HEADER}] Renaming version: ${version} -> ${newFinalVersion}`);
+    if (!this.stateManager.renameVersion(version, newFinalVersion)) {
       logger.error(`[${LOG_HEADER}] Failed to replace version: ${version} -> ${newFinalVersion}`);
     }
     if (oldFinalVersion) {

--- a/node/index.js
+++ b/node/index.js
@@ -111,7 +111,7 @@ class BlockchainNode {
     }
     const clonedRoot = this.stateManager.cloneFinalVersion(newVersion);
     if (!clonedRoot) {
-      logger.error(`[${LOG_HEADER}] Failed to clone finalized state version: ` +
+      logger.error(`[${LOG_HEADER}] Failed to clone the final state version: ` +
           `${this.stateManager.getFinalVersion()}`);
     }
     this.db.setStateVersion(clonedRoot, newVersion);
@@ -123,17 +123,19 @@ class BlockchainNode {
 
   cloneAndFinalizeVersion(version, blockNumber) {
     const LOG_HEADER = 'cloneAndFinalizeVersion';
-    const oldVersion = this.stateManager.getFinalVersion();
-    const finalVersion = `${StateVersions.FINAL}:${blockNumber}`;
-    const clonedRoot = this.stateManager.cloneVersion(version, finalVersion);
+    const oldFinalVersion = this.stateManager.getFinalVersion();
+    const newFinalVersion = `${StateVersions.FINAL}:${blockNumber}`;
+    const clonedRoot = this.stateManager.cloneVersion(version, newFinalVersion);
     if (!clonedRoot) {
       logger.error(`[${LOG_HEADER}] Failed to clone state version: ${version}`);
       return;
     }
-    this.stateManager.finalizeVersion(finalVersion);
-    if (oldVersion) {
-      logger.info(`[${LOG_HEADER}] Deleting previously finalized version: ${oldVersion}`);
-      this.stateManager.deleteVersion(oldVersion);
+    this.stateManager.finalizeVersion(newFinalVersion);
+    logger.info(`[${LOG_HEADER}] Replacing version: ${version} -> ${newFinalVersion}`);
+    this.stateManager.replaceVersion(version, newFinalVersion);
+    if (oldFinalVersion) {
+      logger.info(`[${LOG_HEADER}] Deleting previous final version: ${oldFinalVersion}`);
+      this.stateManager.deleteVersion(oldFinalVersion);
     }
     const nodeVersion = `${StateVersions.NODE}:${blockNumber}`;
     this.syncDb(nodeVersion)

--- a/unittest/state-manager.test.js
+++ b/unittest/state-manager.test.js
@@ -147,8 +147,8 @@ describe("state-manager", () => {
       });
     });
 
-    describe("replaceVersion", () => {
-      it("replaceVersion w/ existing version", () => {
+    describe("renameVersion", () => {
+      it("renameVersion w/ existing version", () => {
         const newRoot = new StateNode();
         newRoot.setValue('some value');
         manager._setRoot('new version', newRoot);
@@ -156,10 +156,10 @@ describe("state-manager", () => {
         assert.deepEqual(
             manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
 
-        expect(manager.replaceVersion(finalVersion, 'new version')).to.equal(true);
+        expect(manager.renameVersion(finalVersion, 'new version')).to.equal(true);
       });
 
-      it("replaceVersion w/ non-existing version", () => {
+      it("renameVersion w/ non-existing version", () => {
         const newRoot = new StateNode();
         newRoot.setValue('some value');
         manager._setRoot('new version', newRoot);
@@ -167,16 +167,16 @@ describe("state-manager", () => {
         assert.deepEqual(
             manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
 
-        expect(manager.replaceVersion(finalVersion, 'non-existing version')).to.equal(false);
+        expect(manager.renameVersion(finalVersion, 'non-existing version')).to.equal(false);
       });
 
-      it("replaceVersion w/ a version of null root", () => {
+      it("renameVersion w/ a version of null root", () => {
         manager._setRoot('new version', null);
         expect(manager.numVersions()).to.equal(3);
         assert.deepEqual(
             manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
 
-        expect(manager.replaceVersion(finalVersion, 'new version')).to.equal(false);
+        expect(manager.renameVersion(finalVersion, 'new version')).to.equal(false);
       });
     });
 

--- a/unittest/state-manager.test.js
+++ b/unittest/state-manager.test.js
@@ -24,11 +24,13 @@ describe("state-manager", () => {
   });
 
   describe("Get APIs", () => {
+    const finalVersion = 'final version';
+
     beforeEach(() => {
       const finalRoot = new StateNode();
       finalRoot.setValue('final value');
-      manager._setRoot('final version', finalRoot);
-      manager.finalizeVersion('final version');
+      manager._setRoot(finalVersion, finalRoot);
+      manager.finalizeVersion(finalVersion);
     })
 
     it("numVersions", () => {
@@ -38,191 +40,236 @@ describe("state-manager", () => {
       expect(manager.numVersions()).to.equal(3);
     });
 
-    it("getFinaliersion", () => {
-      expect(manager.getFinalVersion()).to.equal('final version');
+    it("getFinalVersion", () => {
+      expect(manager.getFinalVersion()).to.equal(finalVersion);
     });
 
     it("isFinalVersion", () => {
-      expect(manager.isFinalVersion('final version')).to.equal(true);
+      expect(manager.isFinalVersion(finalVersion)).to.equal(true);
       expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
       expect(manager.isFinalVersion(null)).to.equal(false);
       expect(manager.isFinalVersion(undefined)).to.equal(false);
     });
 
     it("getFinalRoot", () => {
-      expect(manager.getFinalRoot()).to.equal(manager.rootMap.get('final version'));
+      expect(manager.getFinalRoot()).to.equal(manager.rootMap.get(finalVersion));
     });
 
     it("getRoot", () => {
       expect(manager.getRoot(StateVersions.EMPTY)).to.equal(manager.rootMap.get(StateVersions.EMPTY));
-      expect(manager.getRoot('final version')).to.equal(manager.rootMap.get('final version'));
+      expect(manager.getRoot(finalVersion)).to.equal(manager.rootMap.get(finalVersion));
     });
 
     it("hasVersion", () => {
       expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
+      expect(manager.hasVersion(finalVersion)).to.equal(true);
       expect(manager.hasVersion('some other version')).to.equal(false);
       expect(manager.hasVersion(null)).to.equal(false);
       expect(manager.hasVersion(undefined)).to.equal(false);
     });
 
     it("getVersionList", () => {
-      assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, 'final version']);
+      assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, finalVersion]);
     });
   });
 
   describe("Set APIs", () => {
+    const finalVersion = 'final version';
+
     beforeEach(() => {
       const finalRoot = new StateNode();
-      finalRoot.setValue('final value');
-      manager._setRoot('final version', finalRoot);
-      manager.finalizeVersion('final version');
+      finalRoot.setValue(finalVersion);
+      manager._setRoot(finalVersion, finalRoot);
+      manager.finalizeVersion(finalVersion);
     })
 
-    it("_setRoot", () => {
-      expect(manager.numVersions()).to.equal(2);
+    describe("_setRoot", () => {
+      it("_setRoot", () => {
+        expect(manager.numVersions()).to.equal(2);
 
-      const newRoot = new StateNode();
-      newRoot.setValue('some value');
-      manager._setRoot('new version', newRoot);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      assert.deepEqual(manager.getRoot('new version').toJsObject(), 'some value');
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        assert.deepEqual(manager.getRoot('new version').toJsObject(), 'some value');
+      });
+    })
+
+    describe("cloneFinalVersion", () => {
+      it("cloneFinalVersion", () => {
+        const finalRoot = manager.getFinalRoot();
+        finalRoot.setValue('final value');
+        assert.deepEqual(manager.getFinalRoot().toJsObject(), 'final value');
+        expect(manager.numVersions()).to.equal(2);
+
+        const clonedRoot = manager.cloneFinalVersion('new version');
+        expect(clonedRoot).to.not.equal(null);
+        assert.deepEqual(clonedRoot, manager.getRoot('new version'));
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        assert.deepEqual(clonedRoot.toJsObject(), 'final value');
+      });
     });
 
-    it("cloneFinalVersion", () => {
-      const finalizedRoot = manager.getFinalRoot();
-      finalizedRoot.setValue('final value');
-      assert.deepEqual(manager.getFinalRoot().toJsObject(), 'final value');
-      expect(manager.numVersions()).to.equal(2);
+    describe("cloneVersion", () => {
+      it("cloneVersion", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
 
-      const clonedRoot = manager.cloneFinalVersion('new version');
-      expect(clonedRoot).to.not.equal(null);
-      assert.deepEqual(clonedRoot, manager.getRoot('new version'));
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      assert.deepEqual(clonedRoot.toJsObject(), 'final value');
+        const clonedRoot = manager.cloneVersion('new version', 'new new version');
+        expect(clonedRoot).to.not.equal(null);
+        assert.deepEqual(clonedRoot, manager.getRoot('new new version'));
+        expect(manager.numVersions()).to.equal(4);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        expect(manager.hasVersion('new new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(),
+            [StateVersions.EMPTY, finalVersion, 'new version', 'new new version']);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        assert.deepEqual(clonedRoot.toJsObject(), 'some value');
+      });
     });
 
-    it("cloneVersion", () => {
-      const newRoot = new StateNode();
-      newRoot.setValue('some value');
-      manager._setRoot('new version', newRoot);
-      expect(manager.numVersions()).to.equal(3);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
+    describe("replaceVersion", () => {
+      it("replaceVersion w/ existing version", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
 
-      const clonedRoot = manager.cloneVersion('new version', 'new new version');
-      expect(clonedRoot).to.not.equal(null);
-      assert.deepEqual(clonedRoot, manager.getRoot('new new version'));
-      expect(manager.numVersions()).to.equal(4);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      expect(manager.hasVersion('new new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(),
-          [StateVersions.EMPTY, 'final version', 'new version', 'new new version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      assert.deepEqual(clonedRoot.toJsObject(), 'some value');
+        expect(manager.replaceVersion(finalVersion, 'new version')).to.equal(true);
+      });
+
+      it("replaceVersion w/ non-existing version", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+
+        expect(manager.replaceVersion(finalVersion, 'non-existing version')).to.equal(false);
+      });
+
+      it("replaceVersion w/ a version of null root", () => {
+        manager._setRoot('new version', null);
+        expect(manager.numVersions()).to.equal(3);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+
+        expect(manager.replaceVersion(finalVersion, 'new version')).to.equal(false);
+      });
     });
 
-    it("deleteVersion w/ non-finalized version", () => {
-      const newRoot = new StateNode();
-      newRoot.setValue('some value');
-      manager._setRoot('new version', newRoot);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
+    describe("deleteVersion", () => {
+      it("deleteVersion w/ non-final version", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
 
-      expect(manager.deleteVersion('new version')).to.not.equal(null);
-      expect(manager.numVersions()).to.equal(2);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(false);
-      assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, 'final version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
+        expect(manager.deleteVersion('new version')).to.not.equal(null);
+        expect(manager.numVersions()).to.equal(2);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(false);
+        assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, finalVersion]);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+      });
+
+      it("deleteVersion w/ final version", () => {
+        expect(manager.numVersions()).to.equal(2);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, finalVersion]);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+
+        expect(manager.deleteVersion(finalVersion)).to.equal(null);
+        expect(manager.numVersions()).to.equal(2);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, finalVersion]);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+      });
     });
 
-    it("deleteVersion w/ finalized version", () => {
-      expect(manager.numVersions()).to.equal(2);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, 'final version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
+    describe("finalizeVersion", () => {
+      it("finalizeVersion w/ non-final version", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        expect(manager.isFinalVersion('new version')).to.equal(false);
 
-      expect(manager.deleteVersion('final version')).to.equal(null);
-      expect(manager.numVersions()).to.equal(2);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, 'final version']);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-    });
+        expect(manager.finalizeVersion('new version')).to.equal(true);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(false);
+        expect(manager.isFinalVersion('new version')).to.equal(true);
+      });
 
-    it("finalizeVersion w/ non-finalized version", () => {
-      const newRoot = new StateNode();
-      newRoot.setValue('some value');
-      manager._setRoot('new version', newRoot);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      expect(manager.isFinalVersion('new version')).to.equal(false);
+      it("finalizeVersion w/ final version", () => {
+        const newRoot = new StateNode();
+        newRoot.setValue('some value');
+        manager._setRoot('new version', newRoot);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        expect(manager.isFinalVersion('new version')).to.equal(false);
 
-      expect(manager.finalizeVersion('new version')).to.equal(true);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
-      expect(manager.isFinalVersion('final version')).to.equal(false);
-      expect(manager.isFinalVersion('new version')).to.equal(true);
-    });
-
-    it("finalizeVersion w/ finalized version", () => {
-      const newRoot = new StateNode();
-      newRoot.setValue('some value');
-      manager._setRoot('new version', newRoot);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      expect(manager.isFinalVersion('new version')).to.equal(false);
-
-      expect(manager.finalizeVersion('final version')).to.equal(false);
-      expect(manager.numVersions()).to.equal(3);
-      expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
-      expect(manager.hasVersion('final version')).to.equal(true);
-      expect(manager.hasVersion('new version')).to.equal(true);
-      assert.deepEqual(
-          manager.getVersionList(), [StateVersions.EMPTY, 'final version', 'new version']);
-      expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
-      expect(manager.isFinalVersion('final version')).to.equal(true);
-      expect(manager.isFinalVersion('new version')).to.equal(false);
+        expect(manager.finalizeVersion(finalVersion)).to.equal(false);
+        expect(manager.numVersions()).to.equal(3);
+        expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
+        expect(manager.hasVersion(finalVersion)).to.equal(true);
+        expect(manager.hasVersion('new version')).to.equal(true);
+        assert.deepEqual(
+            manager.getVersionList(), [StateVersions.EMPTY, finalVersion, 'new version']);
+        expect(manager.isFinalVersion(StateVersions.EMPTY)).to.equal(false);
+        expect(manager.isFinalVersion(finalVersion)).to.equal(true);
+        expect(manager.isFinalVersion('new version')).to.equal(false);
+      });
     });
   });
 });

--- a/unittest/state-manager.test.js
+++ b/unittest/state-manager.test.js
@@ -209,7 +209,7 @@ describe("state-manager", () => {
         assert.deepEqual(manager.getVersionList(), [StateVersions.EMPTY, finalVersion]);
         expect(manager.isFinalVersion(finalVersion)).to.equal(true);
 
-        expect(manager.deleteVersion(finalVersion)).to.equal(null);
+        expect(manager.deleteVersion(finalVersion)).to.equal(false);
         expect(manager.numVersions()).to.equal(2);
         expect(manager.hasVersion(StateVersions.EMPTY)).to.equal(true);
         expect(manager.hasVersion(finalVersion)).to.equal(true);

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -7,7 +7,7 @@ const {
   isValidPathForStates,
   isValidJsObjectForStates,
   setStateTreeVersion,
-  replaceStateTreeVersion,
+  renameStateTreeVersion,
   deleteStateTree,
   deleteStateTreeVersion,
   makeCopyOfStateTree,
@@ -652,14 +652,14 @@ describe("state-util", () => {
     })
   })
 
-  describe("replaceStateTreeVersion", () => {
+  describe("renameStateTreeVersion", () => {
     it("leaf node w/ no version match", () => {
       const ver1 = 'ver1';
       const ver2 = 'ver2';
 
       const stateNode = StateNode.fromJsObject(true, ver1);
 
-      const numRenamed = replaceStateTreeVersion(stateNode, 'other version', ver2);
+      const numRenamed = renameStateTreeVersion(stateNode, 'other version', ver2);
       expect(numRenamed).to.equal(0);
       expect(stateNode.getVersion()).to.equal(ver1);
     })
@@ -670,7 +670,7 @@ describe("state-util", () => {
 
       const stateNode = StateNode.fromJsObject(true, ver1,);
 
-      const numRenamed = replaceStateTreeVersion(stateNode, ver1, ver2);
+      const numRenamed = renameStateTreeVersion(stateNode, ver1, ver2);
       expect(numRenamed).to.equal(1);
       expect(stateNode.getVersion()).to.equal(ver2);
     })
@@ -736,7 +736,7 @@ describe("state-util", () => {
         }
       });
 
-      const numNodes = replaceStateTreeVersion(stateTree, ver2, ver3);
+      const numNodes = renameStateTreeVersion(stateTree, ver2, ver3);
       expect(numNodes).to.equal(4);
       assert.deepEqual(stateTree.toJsObject(true), {
         ".numParents": 0,

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -7,6 +7,7 @@ const {
   isValidPathForStates,
   isValidJsObjectForStates,
   setStateTreeVersion,
+  replaceStateTreeVersion,
   deleteStateTree,
   deleteStateTreeVersion,
   makeCopyOfStateTree,
@@ -646,6 +647,133 @@ describe("state-util", () => {
           null: null,
           undef: undefined,
           empty_obj: null,
+        }
+      });
+    })
+  })
+
+  describe("replaceStateTreeVersion", () => {
+    it("leaf node w/ no version match", () => {
+      const ver1 = 'ver1';
+      const ver2 = 'ver2';
+
+      const stateNode = StateNode.fromJsObject(true, ver1);
+
+      const numRenamed = replaceStateTreeVersion(stateNode, 'other version', ver2);
+      expect(numRenamed).to.equal(0);
+      expect(stateNode.getVersion()).to.equal(ver1);
+    })
+
+    it("leaf node w/ version match", () => {
+      const ver1 = 'ver1';
+      const ver2 = 'ver2';
+
+      const stateNode = StateNode.fromJsObject(true, ver1,);
+
+      const numRenamed = replaceStateTreeVersion(stateNode, ver1, ver2);
+      expect(numRenamed).to.equal(1);
+      expect(stateNode.getVersion()).to.equal(ver2);
+    })
+
+    it("internal node", () => {
+      const ver1 = 'ver1';
+      const ver2 = 'ver2';
+      const ver3 = 'ver3';
+
+      const grandChild11 = new StateNode(ver1);
+      const grandChild12 = new StateNode(ver2);
+      const grandChild21 = new StateNode(ver2);
+      const grandChild22 = new StateNode(ver1);
+      grandChild11.setValue('value11');
+      grandChild12.setValue('value12');
+      grandChild21.setValue('value21');
+      grandChild22.setValue('value22');
+      const child1 = new StateNode(ver2);
+      child1.setChild('label11', grandChild11);
+      child1.setChild('label12', grandChild12);
+      const child2 = new StateNode(ver2);
+      child2.setChild('label21', grandChild21);
+      child2.setChild('label22', grandChild22);
+      const stateTree = new StateNode(ver3);
+      stateTree.setChild('label1', child1);
+      stateTree.setChild('label2', child2);
+      assert.deepEqual(stateTree.toJsObject(true), {
+        ".numParents": 0,
+        ".proofHash": null,
+        ".treeSize": 1,
+        ".version": "ver3",
+        "label1": {
+          ".numParents": 1,
+          ".numParents:label11": 1,
+          ".numParents:label12": 1,
+          ".proofHash": null,
+          ".proofHash:label11": null,
+          ".proofHash:label12": null,
+          ".treeSize": 1,
+          ".treeSize:label11": 1,
+          ".treeSize:label12": 1,
+          ".version": "ver2",
+          ".version:label11": "ver1",
+          ".version:label12": "ver2",
+          "label11": "value11",
+          "label12": "value12",
+        },
+        "label2": {
+          ".numParents": 1,
+          ".numParents:label21": 1,
+          ".numParents:label22": 1,
+          ".proofHash": null,
+          ".proofHash:label21": null,
+          ".proofHash:label22": null,
+          ".treeSize": 1,
+          ".treeSize:label21": 1,
+          ".treeSize:label22": 1,
+          ".version": "ver2",
+          ".version:label21": "ver2",
+          ".version:label22": "ver1",
+          "label21": "value21",
+          "label22": "value22",
+        }
+      });
+
+      const numNodes = replaceStateTreeVersion(stateTree, ver2, ver3);
+      expect(numNodes).to.equal(4);
+      assert.deepEqual(stateTree.toJsObject(true), {
+        ".numParents": 0,
+        ".proofHash": null,
+        ".treeSize": 1,
+        ".version": "ver3",
+        "label1": {
+          ".numParents": 1,
+          ".numParents:label11": 1,
+          ".numParents:label12": 1,
+          ".proofHash": null,
+          ".proofHash:label11": null,
+          ".proofHash:label12": null,
+          ".treeSize": 1,
+          ".treeSize:label11": 1,
+          ".treeSize:label12": 1,
+          ".version": "ver3",  // renamed
+          ".version:label11": "ver1",
+          ".version:label12": "ver3",  // renamed
+          "label11": "value11",
+          "label12": "value12",
+        },
+        "label2": {
+          ".numParents": 1,
+          ".numParents:label21": 1,
+          ".numParents:label22": 1,
+          ".proofHash": null,
+          ".proofHash:label21": null,
+          ".proofHash:label22": null,
+          ".treeSize": 1,
+          ".treeSize:label21": 1,
+          ".treeSize:label22": 1,
+          ".version": "ver3",  // renamed
+          ".version:label21": "ver3",  // renamed
+          ".version:label22": "ver1",
+          "label21": "value21",
+          "label22": "value22",
         }
       });
     })


### PR DESCRIPTION
Replace the state nodes' version of the temp state version to the final state version when it's finalized.

As a result block number is always included in the state version e.g. 
```
                    "8": {
                        "propose": {
                            "number": 8,
                            ".version:number": "FINAL:9",
                            ".numParents:number": 1,
                            ".proofHash:number": "0x93dcdffb943385548cf812346b8de04c65c676d0932386c47cf2232d3ff3b9f7",
                            ".treeSize:number": 1,
                            "epoch": 12190272,
                            ".version:epoch": "FINAL:9",
                            ".numParents:epoch": 1,
                            ".proofHash:epoch": "0xd3bfc0de72db8136e2ffdaa8f1c293a9811b4eb86d6302abc35cac50a0089c29",
                            ".treeSize:epoch": 1,
                            "validators": {
                                "0x00ADEc28B6a845a085e03591bE7550dd68673C1C": 250,
                                ".version:0x00ADEc28B6a845a085e03591bE7550dd68673C1C": "FINAL:9",
                                ".numParents:0x00ADEc28B6a845a085e03591bE7550dd68673C1C": 1,
                                ".proofHash:0x00ADEc28B6a845a085e03591bE7550dd68673C1C": "0x03da941110cda7c1e8057c2b76f5f00c33f48b0acdf863cd0fec19810636d573",
                                ".treeSize:0x00ADEc28B6a845a085e03591bE7550dd68673C1C": 1,
                                "0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204": 250,
                                ".version:0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204": "FINAL:9",
                                ".numParents:0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204": 1,
                                ".proofHash:0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204": "0x03da941110cda7c1e8057c2b76f5f00c33f48b0acdf863cd0fec19810636d573",
                                ".treeSize:0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204": 1,
                                ".version": "FINAL:9",
                                ".numParents": 1,
                                ".proofHash": "0xfb1451f73d34051559efcce7a436e63fbc0899e17bb7c75ec1d4094625fb61a8",
                                ".treeSize": 3
...
                            },
                            ".version": "FINAL:9",
                            ".numParents": 1,
                            ".proofHash": "0x903675663968f51a423cd01503ff61405e3f2119e7fc60b7e1a92bdfc6c0559e",
                            ".treeSize": 7
                        },
                        ".version": "FINAL:9",
                        ".numParents": 2,
                        ".proofHash": "0x9900166d7593d08728c9d593dd2e625159f6c5fc0419b3a7e0cdde68921c0d4e",
                        ".treeSize": 19
                    },
                    ".version": "FINAL:9",
                    ".numParents": 1,
                    ".proofHash": "0x6d52b88b16a32f61b5cea9681482dbfa91ee9fc599c3006b00ff71c14ce77082",
                    ".treeSize": 153
                },
                ".version": "FINAL:9",
                ".numParents": 1,
                ".proofHash": "0xcdf0b32abf6b63a6587af2e39f7dc506a803ed42ad9acdcb9c54ca365181b041",
                ".treeSize": 157
            },
```


#143 