### PR TITLE
Feature/platfowner/new feature

### DIFF
--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -174,13 +174,13 @@ class Blockchain {
       return false;
     }
     // TODO (lia): Check if the tx nonces are correct.
-    return Blockchain.isValidChainSubsection(chain);
+    return Blockchain.isValidChainSegment(chain);
   }
 
-  static isValidChainSubsection(chainSubsection) {
-    for (let i = 1; i < chainSubsection.length; i++) {
-      const block = chainSubsection[i];
-      const lastBlock = Block.parse(chainSubsection[i - 1]);
+  static isValidChainSegment(chainSegment) {
+    for (let i = 1; i < chainSegment.length; i++) {
+      const block = chainSegment[i];
+      const lastBlock = Block.parse(chainSegment[i - 1]);
       if (block.last_hash !== lastBlock.hash || !Block.validateHashes(block)) {
         return false;
       }
@@ -252,19 +252,19 @@ class Blockchain {
       return [this.lastBlock()];
     }
 
-    const chainSubsection = [];
+    const chainSegment = [];
     blockFiles.forEach((blockFile) => {
-      chainSubsection.push(Block.loadBlock(blockFile));
+      chainSegment.push(Block.loadBlock(blockFile));
     });
-    return chainSubsection.length > 0 ? chainSubsection : [];
+    return chainSegment.length > 0 ? chainSegment : [];
   }
 
-  merge(chainSubsection, db) {
+  merge(chainSegment, db) {
     logger.info(`Last block number before merge: ${this.lastBlockNumber()}`);
-    const firstBlock = Block.parse(chainSubsection[0]);
+    const firstBlock = Block.parse(chainSegment[0]);
     const lastBlockHash = this.lastBlockNumber() >= 0 ? this.lastBlock().hash : null;
     const overlap = lastBlockHash ?
-        chainSubsection.filter((block) => block.number === this.lastBlockNumber()) : null;
+        chainSegment.filter((block) => block.number === this.lastBlockNumber()) : null;
     const overlappingBlock = overlap ? overlap[0] : null;
     if (lastBlockHash) {
       // Case 1: Not a cold start.
@@ -281,12 +281,12 @@ class Blockchain {
         return false;
       }
     }
-    if (!Blockchain.isValidChainSubsection(chainSubsection)) {
-      logger.error(`Invalid chain subsection`);
+    if (!Blockchain.isValidChainSegment(chainSegment)) {
+      logger.error(`Invalid chain segment`);
       return false;
     }
-    for (let i = 0; i < chainSubsection.length; i++) {
-      const block = chainSubsection[i];
+    for (let i = 0; i < chainSegment.length; i++) {
+      const block = chainSegment[i];
 
       if (block.number <= this.lastBlockNumber()) {
         continue;

--- a/client/index.js
+++ b/client/index.js
@@ -249,6 +249,14 @@ app.post('/batch', (req, res, next) => {
     .end();
 });
 
+app.get('/node_status', (req, res, next) => {
+  const result = node.status;
+  res.status(200)
+    .set('Content-Type', 'application/json')
+    .send({code: 0, result})
+    .end();
+});
+
 app.get('/blocks', (req, res, next) => {
   const blockEnd = node.bc.lastBlockNumber() + 1;
   const blockBegin = Math.max(blockEnd - MAX_BLOCKS, 0);

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -206,6 +206,11 @@ class ChainUtil {
   static checkForTransactionErrorCode(result) {
     return result === null || (result.code !== undefined && result.code !== 0);
   }
+
+  static logAndReturnError(logger, code, message) {
+    logger.info(message);
+    return { code, error_message: message };
+  }
 }
 
 module.exports = ChainUtil;

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -211,8 +211,22 @@ class ChainUtil {
     return { code, error_message: message };
   }
 
-  static logAndReturnError(logger, code, message) {
-    logger.info(message);
+  /**
+   * Logs and returns error.
+   * 
+   * @param {*} logger logger to log with
+   * @param {*} code error code
+   * @param {*} message error message
+   * @param {*} level level to log with
+   */
+  static logAndReturnError(logger, code, message, level = 1) {
+    if (level === 0) {
+      logger.error(message);
+    } else if (level === 1) {
+      logger.info(message);
+    } else {
+      logger.debug(message);
+    }
     return ChainUtil.returnError(code, message);
   }
 }

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -207,9 +207,13 @@ class ChainUtil {
     return result === null || (result.code !== undefined && result.code !== 0);
   }
 
+  static returnError(code, message) {
+    return { code, error_message: message };
+  }
+
   static logAndReturnError(logger, code, message) {
     logger.info(message);
-    return { code, error_message: message };
+    return ChainUtil.returnError(code, message);
   }
 }
 

--- a/common/constants.js
+++ b/common/constants.js
@@ -44,7 +44,8 @@ function getPortNumber(defaultValue, baseValue) {
 }
 
 /**
- * Message types for communication between nodes
+ * Message types for communication between nodes.
+ * 
  * @enum {string}
  */
 const MessageTypes = {
@@ -56,7 +57,18 @@ const MessageTypes = {
 };
 
 /**
- * Predefined database paths
+ * Status of blockchain nodes.
+ * 
+ * @enum {string}
+ */
+const BlockchainNodeStatus = {
+  STARTUP: 'STARTUP',
+  SYNCING: 'SYNCING',
+  SERVING: 'SERVING',
+};
+
+/**
+ * Predefined database paths.
  * @enum {string}
  */
 // TODO (lia): Pick one convention: full-paths (e.g. /deposit/consensus) or keys (e.g. token)
@@ -110,7 +122,8 @@ const PredefinedDbPaths = {
 };
 
 /**
- * Properties of token configs
+ * Properties of token configs.
+ * 
  * @enum {string}
  */
 const TokenProperties = {
@@ -120,7 +133,8 @@ const TokenProperties = {
 };
 
 /**
- * Properties of account configs
+ * Properties of account configs.
+ * 
  * @enum {string}
  */
 const AccountProperties = {
@@ -134,7 +148,8 @@ const AccountProperties = {
 };
 
 /**
- * Properties of owner configs
+ * Properties of owner configs.
+ * 
  * @enum {string}
  */
 const OwnerProperties = {
@@ -148,7 +163,8 @@ const OwnerProperties = {
 };
 
 /**
- * Properties of rule configs
+ * Properties of rule configs.
+ * 
  * @enum {string}
  */
 const RuleProperties = {
@@ -156,7 +172,8 @@ const RuleProperties = {
 };
 
 /**
- * Properties of function configs
+ * Properties of function configs.
+ * 
  * @enum {string}
  */
 const FunctionProperties = {
@@ -168,7 +185,8 @@ const FunctionProperties = {
 };
 
 /**
- * Types of functions
+ * Types of functions.
+ * 
  * @enum {string}
  */
 const FunctionTypes = {
@@ -177,7 +195,8 @@ const FunctionTypes = {
 };
 
 /**
- * Properties of proof configs
+ * Properties of proof configs.
+ * 
  * @enum {string}
  */
 const ProofProperties = {
@@ -185,7 +204,8 @@ const ProofProperties = {
 };
 
 /**
- * IDs of native functions
+ * IDs of native functions.
+ * 
  * @enum {string}
  */
 const NativeFunctionIds = {
@@ -198,7 +218,8 @@ const NativeFunctionIds = {
 };
 
 /**
- * Properties of sharding configs
+ * Properties of sharding configs.
+ * 
  * @enum {string}
  */
 const ShardingProperties = {
@@ -219,7 +240,8 @@ const ShardingProperties = {
 };
 
 /**
- * Sharding protocols
+ * Sharding protocols.
+ * 
  * @enum {string}
  */
 const ShardingProtocols = {
@@ -228,7 +250,8 @@ const ShardingProtocols = {
 };
 
 /**
- * Token exchange schemes
+ * Token exchange schemes.
+ * 
  * @enum {string}
  */
 const TokenExchangeSchemes = {
@@ -237,7 +260,8 @@ const TokenExchangeSchemes = {
 };
 
 /**
- * Types of read database operations
+ * Types of read database operations.
+ * 
  * @enum {string}
  */
 const ReadDbOperations = {
@@ -255,7 +279,8 @@ const ReadDbOperations = {
 };
 
 /**
- * Types of write database operations
+ * Types of write database operations.
+ * 
  * @enum {string}
  */
 const WriteDbOperations = {
@@ -269,7 +294,8 @@ const WriteDbOperations = {
 };
 
 /**
- * Function result code
+ * Function result code.
+ * 
  * @enum {string}
  */
 const FunctionResultCode = {
@@ -280,7 +306,8 @@ const FunctionResultCode = {
 };
 
 /**
- * Constant values for transactionTracker
+ * Constant values for transactionTracker.
+ * 
  * @enum {string}
  */
 const TransactionStatus = {
@@ -299,6 +326,7 @@ const DefaultValues = {
 
 /**
  * State versions.
+ * 
  * @enum {string}
  */
 const StateVersions = {
@@ -491,6 +519,7 @@ module.exports = {
   LIGHTWEIGHT,
   HASH_DELIMITER,
   MessageTypes,
+  BlockchainNodeStatus,
   PredefinedDbPaths,
   TokenProperties,
   AccountProperties,

--- a/common/constants.js
+++ b/common/constants.js
@@ -62,7 +62,7 @@ const MessageTypes = {
  * @enum {string}
  */
 const BlockchainNodeStatus = {
-  STARTUP: 'STARTUP',
+  STARTING: 'STARTING',
   SYNCING: 'SYNCING',
   SERVING: 'SERVING',
 };

--- a/common/constants.js
+++ b/common/constants.js
@@ -49,11 +49,11 @@ function getPortNumber(defaultValue, baseValue) {
  * @enum {string}
  */
 const MessageTypes = {
-  TRANSACTION: 'transaction',
-  CHAIN_SUBSECTION: 'chain_subsection',
-  CHAIN_SUBSECTION_REQUEST: 'chain_subsection_request',
-  CONSENSUS: 'consensus',
-  HEARTBEAT: 'heartbeat'
+  TRANSACTION: 'TRANSACTION',
+  CHAIN_SEGMENT: 'CHAIN_SEGMENT',
+  CHAIN_SEGMENT_REQUEST: 'CHAIN_SEGMENT_REQUEST',
+  CONSENSUS: 'CONSENSUS',
+  HEARTBEAT: 'HEARTBEAT'
 };
 
 /**

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -229,7 +229,7 @@ class Consensus {
         // prevent the node from getting/handling messages properly.
         // this.node.status = BlockchainNodeStatus.SYNCING;
 
-        this.server.requestChainSubsection(this.node.bc.lastBlock());
+        this.server.requestChainSegment(this.node.bc.lastBlock());
         return;
       }
       if (Consensus.isValidConsensusTx(proposalTx) &&

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -227,7 +227,7 @@ class Consensus {
         // FIXME(lia): This has a possibility of being exploited by an attacker. The attacker
         // can keep sending messages with higher numbers, making the node's status unsynced, and
         // prevent the node from getting/handling messages properly.
-        // this.node.bc.syncedAfterStartup = false;
+        // this.node.status = BlockchainNodeStatus.SYNCING;
 
         this.server.requestChainSubsection(this.node.bc.lastBlock());
         return;

--- a/db/index.js
+++ b/db/index.js
@@ -382,12 +382,12 @@ class DB {
   setValue(valuePath, value, address, timestamp, transaction, isGlobal) {
     const isValidObj = isValidJsObjectForStates(value);
     if (!isValidObj.isValid) {
-      return {code: 6, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return {code: 101, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
     }
     const parsedPath = ChainUtil.parsePath(valuePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return {code: 102, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -395,7 +395,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForValue(localPath, value, address, timestamp)) {
-      return {code: 2, error_message: `No .write permission on: ${valuePath}`};
+      return {code: 103, error_message: `No .write permission on: ${valuePath}`};
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.VALUES_ROOT);
     const isWritablePath = isWritablePathWithSharding(fullPath, this.stateRoot);
@@ -405,7 +405,7 @@ class DB {
         return true;
       } else {
         return {
-          code: 8,
+          code: 104,
           error_message: `Non-writable path with shard config: ${isWritablePath.invalidPath}`
         };
       }
@@ -413,6 +413,7 @@ class DB {
     const valueCopy = ChainUtil.isDict(value) ? JSON.parse(JSON.stringify(value)) : value;
     this.writeDatabase(fullPath, valueCopy);
     this.func.triggerFunctions(localPath, valueCopy, timestamp, Date.now(), transaction);
+
     return true;
   }
 
@@ -420,7 +421,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return {code: 1, error_message: `Not a number type: ${valueBefore} or ${delta}`};
+      return {code: 201, error_message: `Not a number type: ${valueBefore} or ${delta}`};
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) + delta;
     return this.setValue(valuePath, valueAfter, address, timestamp, transaction, isGlobal);
@@ -430,7 +431,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return {code: 1, error_message: `Not a number type: ${valueBefore} or ${delta}`};
+      return {code: 301, error_message: `Not a number type: ${valueBefore} or ${delta}`};
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) - delta;
     return this.setValue(valuePath, valueAfter, address, timestamp, transaction, isGlobal);
@@ -439,12 +440,12 @@ class DB {
   setFunction(functionPath, functionInfo, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(functionInfo);
     if (!isValidObj.isValid) {
-      return {code: 6, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return {code: 401, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
     }
     const parsedPath = ChainUtil.parsePath(functionPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return {code: 402, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -452,12 +453,13 @@ class DB {
       return true;
     }
     if (!this.getPermissionForFunction(localPath, address)) {
-      return {code: 3, error_message: `No write_function permission on: ${functionPath}`};
+      return {code: 403, error_message: `No write_function permission on: ${functionPath}`};
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     const functionInfoCopy = ChainUtil.isDict(functionInfo) ?
         JSON.parse(JSON.stringify(functionInfo)) : functionInfo;
     this.writeDatabase(fullPath, functionInfoCopy);
+
     return true;
   }
 
@@ -466,12 +468,12 @@ class DB {
   setRule(rulePath, rule, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(rule);
     if (!isValidObj.isValid) {
-      return {code: 6, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return {code: 501, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
     }
     const parsedPath = ChainUtil.parsePath(rulePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return {code: 502, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -479,11 +481,12 @@ class DB {
       return true;
     }
     if (!this.getPermissionForRule(localPath, address)) {
-      return {code: 3, error_message: `No write_rule permission on: ${rulePath}`};
+      return {code: 503, error_message: `No write_rule permission on: ${rulePath}`};
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
     const ruleCopy = ChainUtil.isDict(rule) ? JSON.parse(JSON.stringify(rule)) : rule;
     this.writeDatabase(fullPath, ruleCopy);
+
     return true;
   }
 
@@ -491,12 +494,12 @@ class DB {
   setOwner(ownerPath, owner, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(owner);
     if (!isValidObj.isValid) {
-      return {code: 6, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return {code: 601, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
     }
     const parsedPath = ChainUtil.parsePath(ownerPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 7, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return {code: 602, error_message: `Invalid path: ${isValidPath.invalidPath}`};
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -505,13 +508,14 @@ class DB {
     }
     if (!this.getPermissionForOwner(localPath, address)) {
       return {
-        code: 4,
+        code: 603,
         error_message: `No write_owner or branch_owner permission on: ${ownerPath}`
       };
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     const ownerCopy = ChainUtil.isDict(owner) ? JSON.parse(JSON.stringify(owner)) : owner;
     this.writeDatabase(fullPath, ownerCopy);
+
     return true;
   }
 
@@ -551,7 +555,7 @@ class DB {
         }
       } else {
         // Invalid Operation
-        return {code: 5, error_message: `Invalid opeartion type: ${op.type}`};
+        return {code: 701, error_message: `Invalid opeartion type: ${op.type}`};
       }
     }
     return ret;
@@ -563,14 +567,14 @@ class DB {
       const txBody = tx.tx_body;
       if (!txBody) {
         const message = 'No tx_body';
-        resultList.push({code: 1, error_message: message});
+        resultList.push({code: 801, error_message: message});
         logger.info(message);
         continue;
       }
       const operation = txBody.operation;
       if (!operation) {
         const message = 'No operation';
-        resultList.push({code: 2, error_message: message});
+        resultList.push({code: 802, error_message: message});
         logger.info(message);
         continue;
       }
@@ -587,7 +591,7 @@ class DB {
           break;
         default:
           const message = `Invalid operation type: ${operation.type}`;
-          resultList.push({code: 3, error_message: message});
+          resultList.push({code: 803, error_message: message});
           logger.info(message);
       }
     }

--- a/db/index.js
+++ b/db/index.js
@@ -382,12 +382,12 @@ class DB {
   setValue(valuePath, value, address, timestamp, transaction, isGlobal) {
     const isValidObj = isValidJsObjectForStates(value);
     if (!isValidObj.isValid) {
-      return {code: 101, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return ChainUtil.returnError(101, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(valuePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 102, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return ChainUtil.returnError(102, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -395,7 +395,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForValue(localPath, value, address, timestamp)) {
-      return {code: 103, error_message: `No .write permission on: ${valuePath}`};
+      return ChainUtil.returnError(103, `No .write permission on: ${valuePath}`);
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.VALUES_ROOT);
     const isWritablePath = isWritablePathWithSharding(fullPath, this.stateRoot);
@@ -404,10 +404,8 @@ class DB {
         // There is nothing to do.
         return true;
       } else {
-        return {
-          code: 104,
-          error_message: `Non-writable path with shard config: ${isWritablePath.invalidPath}`
-        };
+        return ChainUtil.returnError(
+            104, `Non-writable path with shard config: ${isWritablePath.invalidPath}`);
       }
     }
     const valueCopy = ChainUtil.isDict(value) ? JSON.parse(JSON.stringify(value)) : value;
@@ -421,7 +419,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return {code: 201, error_message: `Not a number type: ${valueBefore} or ${delta}`};
+      return ChainUtil.returnError(201, `Not a number type: ${valueBefore} or ${delta}`);
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) + delta;
     return this.setValue(valuePath, valueAfter, address, timestamp, transaction, isGlobal);
@@ -431,7 +429,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return {code: 301, error_message: `Not a number type: ${valueBefore} or ${delta}`};
+      return ChainUtil.returnError(301, `Not a number type: ${valueBefore} or ${delta}`);
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) - delta;
     return this.setValue(valuePath, valueAfter, address, timestamp, transaction, isGlobal);
@@ -440,12 +438,12 @@ class DB {
   setFunction(functionPath, functionInfo, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(functionInfo);
     if (!isValidObj.isValid) {
-      return {code: 401, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return ChainUtil.returnError(401, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(functionPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 402, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return ChainUtil.returnError(402, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -453,7 +451,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForFunction(localPath, address)) {
-      return {code: 403, error_message: `No write_function permission on: ${functionPath}`};
+      return ChainUtil.returnError(403, `No write_function permission on: ${functionPath}`);
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     const functionInfoCopy = ChainUtil.isDict(functionInfo) ?
@@ -468,12 +466,12 @@ class DB {
   setRule(rulePath, rule, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(rule);
     if (!isValidObj.isValid) {
-      return {code: 501, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return ChainUtil.returnError(501, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(rulePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 502, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return ChainUtil.returnError(502, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -481,7 +479,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForRule(localPath, address)) {
-      return {code: 503, error_message: `No write_rule permission on: ${rulePath}`};
+      return ChainUtil.returnError(503, `No write_rule permission on: ${rulePath}`);
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
     const ruleCopy = ChainUtil.isDict(rule) ? JSON.parse(JSON.stringify(rule)) : rule;
@@ -494,12 +492,12 @@ class DB {
   setOwner(ownerPath, owner, address, isGlobal) {
     const isValidObj = isValidJsObjectForStates(owner);
     if (!isValidObj.isValid) {
-      return {code: 601, error_message: `Invalid object for states: ${isValidObj.invalidPath}`};
+      return ChainUtil.returnError(601, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(ownerPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return {code: 602, error_message: `Invalid path: ${isValidPath.invalidPath}`};
+      return ChainUtil.returnError(602, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? this.toLocalPath(parsedPath) : parsedPath;
     if (localPath === null) {
@@ -507,10 +505,8 @@ class DB {
       return true;
     }
     if (!this.getPermissionForOwner(localPath, address)) {
-      return {
-        code: 603,
-        error_message: `No write_owner or branch_owner permission on: ${ownerPath}`
-      };
+      return ChainUtil.returnError(
+          603, `No write_owner or branch_owner permission on: ${ownerPath}`);
     }
     const fullPath = this.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     const ownerCopy = ChainUtil.isDict(owner) ? JSON.parse(JSON.stringify(owner)) : owner;
@@ -555,7 +551,7 @@ class DB {
         }
       } else {
         // Invalid Operation
-        return {code: 701, error_message: `Invalid opeartion type: ${op.type}`};
+        return ChainUtil.returnError(701, `Invalid opeartion type: ${op.type}`);
       }
     }
     return ret;
@@ -566,16 +562,12 @@ class DB {
     for (const tx of txList) {
       const txBody = tx.tx_body;
       if (!txBody) {
-        const message = 'No tx_body';
-        resultList.push({code: 801, error_message: message});
-        logger.info(message);
+        resultList.push(ChainUtil.returnError(801, 'No tx_body'));
         continue;
       }
       const operation = txBody.operation;
       if (!operation) {
-        const message = 'No operation';
-        resultList.push({code: 802, error_message: message});
-        logger.info(message);
+        resultList.push(ChainUtil.returnError(802, 'No operation'));
         continue;
       }
       switch (operation.type) {
@@ -590,9 +582,7 @@ class DB {
           resultList.push(this.executeOperation(operation, tx.address, tx.timestamp, tx));
           break;
         default:
-          const message = `Invalid operation type: ${operation.type}`;
-          resultList.push({code: 803, error_message: message});
-          logger.info(message);
+          resultList.push(ChainUtil.returnError(803, `Invalid operation type: ${operation.type}`));
       }
     }
     return resultList;

--- a/integration/blockchain.test.js
+++ b/integration/blockchain.test.js
@@ -199,7 +199,7 @@ function sendTransactions(sentOperations) {
   }
 }
 
-describe('Blockchain', () => {
+describe('Blockchain Cluster', () => {
   let trackerProc;
   let numNewBlocks = 0;
   let numBlocksOnStartup;

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -654,7 +654,7 @@ describe('Blockchain Node', () => {
           .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 2,
+          "code": 103,
           "error_message": "No .write permission on: some/wrong/path"
         });
 
@@ -701,7 +701,7 @@ describe('Blockchain Node', () => {
           .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 2,
+          "code": 103,
           "error_message": "No .write permission on: some/wrong/path2"
         });
 
@@ -748,7 +748,7 @@ describe('Blockchain Node', () => {
           .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 2,
+          "code": 103,
           "error_message": "No .write permission on: some/wrong/path3"
         });
 
@@ -811,7 +811,7 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 3,
+          "code": 403,
           "error_message": "No write_function permission on: /some/wrong/path"
         });
 
@@ -872,7 +872,7 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 3,
+          "code": 503,
           "error_message": "No write_rule permission on: /some/wrong/path"
         });
 
@@ -960,7 +960,7 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 4,
+          "code": 603,
           "error_message": "No write_owner or branch_owner permission on: /some/wrong/path"
         });
 
@@ -1090,7 +1090,7 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8'));
         expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
-          "code": 2,
+          "code": 103,
           "error_message": "No .write permission on: some/wrong/path"
         });
 
@@ -1413,7 +1413,7 @@ describe('Blockchain Node', () => {
           },
           {
             "result": {
-              "code": 2,
+              "code": 103,
               "error_message": "No .write permission on: some/wrong/path"
             },
             "tx_hash": "erased"

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -4,11 +4,12 @@ const semver = require('semver');
 const sizeof = require('object-sizeof');
 const ainUtil = require('@ainblockchain/ain-util');
 const {
+  BlockchainNodeStatus,
   ReadDbOperations,
   PredefinedDbPaths,
   TransactionStatus,
   MAX_TX_BYTES,
-  NETWORK_ID
+  NETWORK_ID,
 } = require('../common/constants');
 const {
   ConsensusConsts
@@ -375,7 +376,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     net_syncing: function(args, done) {
       // TODO (lia): return { starting, latest } with block numbers if the node
       // is currently syncing.
-      done(null, addProtocolVersion({result: !node.bc.syncedAfterStartup}));
+      done(null, addProtocolVersion({result: node.status === BlockchainNodeStatus.SYNCING}));
     },
 
     net_getNetworkId: function(args, done) {

--- a/logger/winston-util.js
+++ b/logger/winston-util.js
@@ -10,7 +10,7 @@ const {DEBUG, PORT, ACCOUNT_INDEX, HOSTING_ENV, LIGHTWEIGHT} = require('../commo
 const {combine, timestamp, label, printf, colorize} = winston.format;
 
 const logDir = path.join(__dirname, '.', 'logs', String(PORT));
-const prefix = `node-${ACCOUNT_INDEX}-${PORT}`;
+const prefix = ACCOUNT_INDEX ? `node-${ACCOUNT_INDEX}-${PORT}` : `tracker-${PORT}`;
 const logFormat = printf(({level, message, label, timestamp}) => {
   return `${timestamp} [${label}] ${level}: ${message}`;
 });

--- a/node/index.js
+++ b/node/index.js
@@ -319,22 +319,22 @@ class BlockchainNode {
     return false;
   }
 
-  mergeChainSubsection(chainSubsection) {
-    const LOG_HEADER = 'mergeChainSubsection';
+  mergeChainSegment(chainSegment) {
+    const LOG_HEADER = 'mergeChainSegment';
 
     if (this.status !== BlockchainNodeStatus.SYNCING) {
       logger.info(`Blockchain node is NOT in SYNCING status: ${this.status}`);
       return false;
     }
-    if (!chainSubsection || chainSubsection.length === 0) {
-      logger.info(`Empty chain sub section`);
+    if (!chainSegment || chainSegment.length === 0) {
+      logger.info(`Empty chain segment`);
       return false;
     }
-    if (chainSubsection[chainSubsection.length - 1].number < this.bc.lastBlockNumber()) {
+    if (chainSegment[chainSegment.length - 1].number < this.bc.lastBlockNumber()) {
       logger.info(`Received chain is of lower block number than current last block number`);
       return false;
     }
-    if (chainSubsection[chainSubsection.length - 1].number === this.bc.lastBlockNumber()) {
+    if (chainSegment[chainSegment.length - 1].number === this.bc.lastBlockNumber()) {
       logger.info(`Received chain is at the same block number`);
       return false;
     }
@@ -342,15 +342,15 @@ class BlockchainNode {
     const tempVersion = StateManager.createRandomVersion(`${StateVersions.TEMP}`);
     const tempDb = this.createTempDb(
         this.stateManager.getFinalVersion(), tempVersion, this.bc.lastBlockNumber());
-    if (!this.bc.merge(chainSubsection, tempDb)) {
-      logger.error(`[${LOG_HEADER}] Failed to merge chain subsection: ` +
-          `${JSON.stringify(chainSubsection, null, 2)}`);
+    if (!this.bc.merge(chainSegment, tempDb)) {
+      logger.error(`[${LOG_HEADER}] Failed to merge chain segment: ` +
+          `${JSON.stringify(chainSegment, null, 2)}`);
       this.destroyDb(tempDb);
       return false;
     }
     const lastBlockNumber = this.bc.lastBlockNumber();
     this.cloneAndFinalizeVersion(tempDb.stateVersion, lastBlockNumber);
-    chainSubsection.forEach((block) => {
+    chainSegment.forEach((block) => {
       this.tp.cleanUpForNewBlock(block);
       this.tp.updateNonceTrackers(block.transactions);
     });

--- a/node/index.js
+++ b/node/index.js
@@ -44,7 +44,7 @@ class BlockchainNode {
     const initialVersion = `${StateVersions.NODE}:${this.bc.lastBlockNumber()}}`;
     this.db = this.createDb(StateVersions.EMPTY, initialVersion, this.bc, this.tp, false, true);
     this.nonce = null;
-    this.status = BlockchainNodeStatus.STARTUP;
+    this.status = BlockchainNodeStatus.STARTING;
   }
 
   // For testing purpose only.
@@ -256,7 +256,8 @@ class BlockchainNode {
     const backupRoot = this.stateManager.cloneVersion(this.db.stateVersion, backupVersion);
     if (!backupRoot) {
       return ChainUtil.logAndReturnError(
-          logger, 11, `[${LOG_HEADER}] Failed to clone state version: ${this.db.stateVersion}`);
+          logger, 11, `[${LOG_HEADER}] Failed to clone state version: ${this.db.stateVersion}`,
+          0);
     }
     const result = this.db.executeTransaction(tx);
     if (ChainUtil.transactionFailed(result)) {
@@ -285,11 +286,13 @@ class BlockchainNode {
     logger.debug(`[${LOG_HEADER}] EXECUTING TRANSACTION: ${JSON.stringify(tx, null, 2)}`);
     if (this.status !== BlockchainNodeStatus.SERVING) {
       return ChainUtil.logAndReturnError(
-          logger, 1, `[${LOG_HEADER}] Blockchain node is NOT in SERVING mode: ${this.status}`);
+          logger, 1, `[${LOG_HEADER}] Blockchain node is NOT in SERVING mode: ${this.status}`,
+          0);
     }
     if (this.tp.isTimedOutFromPool(tx.tx_body.timestamp, this.bc.lastBlockTimestamp())) {
       return ChainUtil.logAndReturnError(
-          logger, 2, `[${LOG_HEADER}] Timeouted transaction: ${JSON.stringify(tx, null, 2)}`);
+          logger, 2, `[${LOG_HEADER}] Timeouted transaction: ${JSON.stringify(tx, null, 2)}`,
+          0);
     }
     if (this.tp.isNotEligibleTransaction(tx)) {
       return ChainUtil.logAndReturnError(

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test_blockchain": "./node_modules/mocha/bin/mocha --timeout 160000 integration/blockchain.test.js",
     "test_dapp": "./node_modules/mocha/bin/mocha --timeout 160000 integration/afan_dapp.test.js",
     "test_sharding": "./node_modules/mocha/bin/mocha --timeout 320000 integration/sharding.test.js",
-    "test_integration": "./node_modules/mocha/bin/mocha --timeout 320000 \"integration/**/*.test.js\"",
+    "test_integration": "./node_modules/mocha/bin/mocha --timeout 640000 \"integration/**/*.test.js\"",
     "loadtest": "sh loadtest/load_tester.sh",
     "lint": "eslint --ext js -c .eslintrc.json ."
   },

--- a/server/index.js
+++ b/server/index.js
@@ -408,8 +408,10 @@ class P2pServer {
               if (this.consensus.status === ConsensusStatus.STARTING) {
                 // XXX(minsu): need to be investigated
                 // ref: https://eslint.org/docs/rules/no-mixed-operators
-                if ((!data.chainSubsection || chainSubSection.length === 0) && !data.catchUpInfo ||
+                if (!data.chainSubsection && !data.catchUpInfo ||
                     data.number === this.node.bc.lastBlockNumber()) {
+                  // Regard this situation as if you're synced.
+                  // TODO (lia): ask the tracker server for another peer.
                   logger.info(`Blockchain Node is now synced!`);
                   this.node.status = BlockchainNodeStatus.SERVING;
                   this.consensus.init();
@@ -427,6 +429,8 @@ class P2pServer {
               if (data.number === this.node.bc.lastBlockNumber()) {
                 // All caught up with the peer
                 if (this.node.status === BlockchainNodeStatus.SYNCING) {
+                  // Regard this situation as if you're synced.
+                  // TODO (lia): ask the tracker server for another peer.
                   logger.info(`Blockchain Node is now synced!`);
                   this.node.status = BlockchainNodeStatus.SERVING;
                 }

--- a/server/index.js
+++ b/server/index.js
@@ -217,7 +217,7 @@ class P2pServer {
           logger.info(`Updated managed peers info: ` +
                       `${JSON.stringify(this.managedPeersInfo, null, 2)}`);
         }
-        if (this.node.status === BlockchainNodeStatus.STARTUP) {
+        if (this.node.status === BlockchainNodeStatus.STARTING) {
           this.node.status = BlockchainNodeStatus.SYNCING;
           if (parsedMsg.numLivePeers === 0) {
             const lastBlockWithoutProposal = this.node.init(true);

--- a/server/index.js
+++ b/server/index.js
@@ -265,16 +265,20 @@ class P2pServer {
                 this.consensus.blockPool.longestNotarizedChainTips.length : 0
           }
       ),
-      shardingStatus: this.node.getSharding(),
-      dbStatus: {
-        treeSize: this.node.db.getTreeSize('/'),
-        proof: this.node.db.getProof('/'),
+      nodeStatus: {
+        status: this.node.status,
+        nonce: this.node.nonce,
       },
+      shardingStatus: this.node.getSharding(),
       txStatus: {
         txPoolSize: this.node.tp.getPoolSize(),
         txTrackerSize: Object.keys(this.node.tp.transactionTracker).length,
         committedNonceTrackerSize: Object.keys(this.node.tp.committedNonceTracker).length,
         pendingNonceTrackerSize: Object.keys(this.node.tp.pendingNonceTracker).length,
+      },
+      dbStatus: {
+        treeSize: this.node.db.getTreeSize('/'),
+        proof: this.node.db.getProof('/'),
       },
       managedPeersInfo: this.managedPeersInfo,
     };

--- a/server/index.js
+++ b/server/index.js
@@ -343,7 +343,7 @@ class P2pServer {
   setSocket(socket, address) {
     this.sockets.push(socket);
     this.setPeerEventHandlers(socket, address);
-    this.requestChainSubsection(this.node.bc.lastBlock());
+    this.requestChainSegment(this.node.bc.lastBlock());
     if (this.consensus.stakeTx) {
       this.broadcastTransaction(this.consensus.stakeTx);
       this.consensus.stakeTx = null;
@@ -405,14 +405,14 @@ class P2pServer {
               }
             }
             break;
-          case MessageTypes.CHAIN_SUBSECTION:
-            logger.debug(`Receiving a chain subsection: ` +
-                `${JSON.stringify(data.chainSubsection, null, 2)}`);
+          case MessageTypes.CHAIN_SEGMENT:
+            logger.debug(`Receiving a chain segment: ` +
+                `${JSON.stringify(data.chainSegment, null, 2)}`);
             if (data.number <= this.node.bc.lastBlockNumber()) {
               if (this.consensus.status === ConsensusStatus.STARTING) {
                 // XXX(minsu): need to be investigated
                 // ref: https://eslint.org/docs/rules/no-mixed-operators
-                if (!data.chainSubsection && !data.catchUpInfo ||
+                if (!data.chainSegment && !data.catchUpInfo ||
                     data.number === this.node.bc.lastBlockNumber()) {
                   // Regard this situation as if you're synced.
                   // TODO (lia): ask the tracker server for another peer.
@@ -427,9 +427,9 @@ class P2pServer {
               return;
             }
 
-            // Check if chain subsection is valid and can be
+            // Check if chain segment is valid and can be
             // merged ontop of your local blockchain
-            if (this.node.mergeChainSubsection(data.chainSubsection)) {
+            if (this.node.mergeChainSegment(data.chainSegment)) {
               if (data.number === this.node.bc.lastBlockNumber()) {
                 // All caught up with the peer
                 if (this.node.status === BlockchainNodeStatus.SYNCING) {
@@ -450,13 +450,13 @@ class P2pServer {
                 this.consensus.blockPool.addSeenBlock(this.node.bc.lastBlock());
                 this.consensus.catchUp(data.catchUpInfo);
               }
-              // Continuously request the blockchain in subsections until
+              // Continuously request the blockchain segments until
               // your local blockchain matches the height of the consensus blockchain.
               if (data.number > this.node.bc.lastBlockNumber()) {
-                setTimeout(() => this.requestChainSubsection(this.node.bc.lastBlock()), 1000);
+                setTimeout(() => this.requestChainSegment(this.node.bc.lastBlock()), 1000);
               }
             } else {
-              logger.info(`Failed to merge incoming chain subsection.`);
+              logger.info(`Failed to merge incoming chain segment.`);
               // FIXME: Could be that I'm on a wrong chain.
               if (data.number <= this.node.bc.lastBlockNumber()) {
                 logger.info(`I am ahead(${data.number} > ${this.node.bc.lastBlockNumber()}).`);
@@ -468,34 +468,34 @@ class P2pServer {
                 }
               } else {
                 logger.info(`I am behind (${data.number} < ${this.node.bc.lastBlockNumber()}).`);
-                setTimeout(() => this.requestChainSubsection(this.node.bc.lastBlock()), 1000);
+                setTimeout(() => this.requestChainSegment(this.node.bc.lastBlock()), 1000);
               }
             }
             break;
-          case MessageTypes.CHAIN_SUBSECTION_REQUEST:
-            logger.debug(`Receiving a chain subsection request: ${JSON.stringify(data.lastBlock)}`);
+          case MessageTypes.CHAIN_SEGMENT_REQUEST:
+            logger.debug(`Receiving a chain segment request: ${JSON.stringify(data.lastBlock)}`);
             if (this.node.bc.chain.length === 0) {
               return;
             }
             // Send a chunk of 20 blocks from your blockchain to the requester.
             // Requester will continue to request blockchain chunks
             // until their blockchain height matches the consensus blockchain height
-            const chainSubsection = this.node.bc.requestBlockchainSection(
+            const chainSegment = this.node.bc.requestBlockchainSection(
                 data.lastBlock ? Block.parse(data.lastBlock) : null);
-            if (chainSubsection) {
+            if (chainSegment) {
               const catchUpInfo = this.consensus.getCatchUpInfo();
               logger.debug(
-                  `Sending a chain subsection ${JSON.stringify(chainSubsection, null, 2)}` +
+                  `Sending a chain segment ${JSON.stringify(chainSegment, null, 2)}` +
                   `along with catchUpInfo ${JSON.stringify(catchUpInfo, null, 2)}`);
-              this.sendChainSubsection(
+              this.sendChainSegment(
                   socket,
-                  chainSubsection,
+                  chainSegment,
                   this.node.bc.lastBlockNumber(),
                   catchUpInfo
               );
             } else {
-              logger.info(`No chainSubsection to send`);
-              this.sendChainSubsection(
+              logger.info(`No chain segment to send`);
+              this.sendChainSegment(
                   socket,
                   null,
                   this.node.bc.lastBlockNumber(),
@@ -544,28 +544,28 @@ class P2pServer {
     return false;
   }
 
-  sendChainSubsection(socket, chainSubsection, number, catchUpInfo) {
+  sendChainSegment(socket, chainSegment, number, catchUpInfo) {
     socket.send(JSON.stringify({
-      type: MessageTypes.CHAIN_SUBSECTION,
-      chainSubsection,
+      type: MessageTypes.CHAIN_SEGMENT,
+      chainSegment,
       number,
       catchUpInfo,
       protoVer: CURRENT_PROTOCOL_VERSION
     }));
   }
 
-  requestChainSubsection(lastBlock) {
+  requestChainSegment(lastBlock) {
     this.sockets.forEach((socket) => {
       socket.send(JSON.stringify({
-        type: MessageTypes.CHAIN_SUBSECTION_REQUEST,
+        type: MessageTypes.CHAIN_SEGMENT_REQUEST,
         lastBlock,
         protoVer: CURRENT_PROTOCOL_VERSION
       }));
     });
   }
 
-  broadcastChainSubsection(chainSubsection) {
-    this.sockets.forEach((socket) => this.sendChainSubsection(socket, chainSubsection));
+  broadcastChainSegment(chainSegment) {
+    this.sockets.forEach((socket) => this.sendChainSegment(socket, chainSegment));
   }
 
   broadcastTransaction(transaction) {

--- a/unittest/consensus.test.js
+++ b/unittest/consensus.test.js
@@ -42,7 +42,7 @@ describe("Consensus", () => {
           }
         }
       );
-    expect(node1.db.executeTransaction(voteTx).code).to.equal(2);
+    expect(node1.db.executeTransaction(voteTx).code).to.equal(103);
   });
 
   it("Staked nodes can vote", () => {

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -956,31 +956,31 @@ describe("DB operations", () => {
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {array: []}), {
-        "code": 6,
+        "code": 101,
         "error_message": "Invalid object for states: /array"
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'.': 'x'}), {
-        "code": 6,
+        "code": 101,
         "error_message": "Invalid object for states: /."
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'$': 'x'}), {
-        "code": 6,
+        "code": 101,
         "error_message": "Invalid object for states: /$"
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'*a': 'x'}), {
-        "code": 6,
+        "code": 101,
         "error_message": "Invalid object for states: /*a"
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setValue("test/unchartered/nested/path2", {'a*': 'x'}), {
-        "code": 6,
+        "code": 101,
         "error_message": "Invalid object for states: /a*"
       });
       expect(node.db.getValue("test/unchartered/nested/path2")).to.equal(null)
@@ -988,62 +988,62 @@ describe("DB operations", () => {
 
     it("when writing with invalid path", () => {
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/.", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/."
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/$", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/$"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/a*", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/a*"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/*a", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/*a"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/#", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/#"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/{", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/{"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/}", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/}"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/[", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/["
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/]", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/]"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/\x00", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/\x00"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/\x1F", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/\x1F"
       });
       assert.deepEqual(node.db.setValue("test/new/unchartered/nested/\x7F", 12345), {
-        "code": 7,
+        "code": 102,
         "error_message": "Invalid path: /test/new/unchartered/nested/\x7F"
       });
     })
 
     it("when writing with non-writable path with sharding", () => {
       assert.deepEqual(node.db.setValue("test/shards/enabled_shard", 20), {
-        "code": 8,
+        "code": 104,
         "error_message": "Non-writable path with shard config: /values/test/shards/enabled_shard"
       });
       assert.deepEqual(node.db.setValue("test/shards/enabled_shard/path", 20), {
-        "code": 8,
+        "code": 104,
         "error_message": "Non-writable path with shard config: /values/test/shards/enabled_shard"
       });
     })
@@ -1063,12 +1063,12 @@ describe("DB operations", () => {
     })
 
     it("returning error code and leaving value unchanged if delta is not numerical", () => {
-      expect(node.db.incValue("test/increment/value", '10').code).to.equal(1)
+      expect(node.db.incValue("test/increment/value", '10').code).to.equal(201)
       expect(node.db.getValue("test/increment/value")).to.equal(20)
     })
 
     it("returning error code and leaving value unchanged if path is not numerical", () => {
-      expect(node.db.incValue("test/ai/foo", 10).code).to.equal(1)
+      expect(node.db.incValue("test/ai/foo", 10).code).to.equal(201)
       expect(node.db.getValue("test/ai/foo")).to.equal("bar")
     })
 
@@ -1079,7 +1079,7 @@ describe("DB operations", () => {
 
     it("returning error code with non-writable path with sharding", () => {
       assert.deepEqual(node.db.incValue("test/shards/enabled_shard/path", 5), {
-        "code": 8,
+        "code": 104,
         "error_message": "Non-writable path with shard config: /values/test/shards/enabled_shard"
       });
     })
@@ -1097,12 +1097,12 @@ describe("DB operations", () => {
     })
 
     it("returning error code and leaving value unchanged if delta is not numerical", () => {
-      expect(node.db.decValue("test/decrement/value", '10').code).to.equal(1)
+      expect(node.db.decValue("test/decrement/value", '10').code).to.equal(301)
       expect(node.db.getValue("test/decrement/value")).to.equal(20)
     })
 
     it("returning error code and leaving value unchanged if path is not numerical", () => {
-      expect(node.db.decValue("test/ai/foo", 10).code).to.equal(1)
+      expect(node.db.decValue("test/ai/foo", 10).code).to.equal(301)
       expect(node.db.getValue("test/ai/foo")).to.equal("bar")
     })
 
@@ -1113,7 +1113,7 @@ describe("DB operations", () => {
 
     it("returning error code with non-writable path with sharding", () => {
       assert.deepEqual(node.db.decValue("test/shards/enabled_shard/path", 5), {
-        "code": 8,
+        "code": 104,
         "error_message": "Non-writable path with shard config: /values/test/shards/enabled_shard"
       });
     })
@@ -1141,21 +1141,22 @@ describe("DB operations", () => {
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setFunction("/test/test_function/some/path2", {array: []}), {
-        "code": 6,
+        "code": 401,
         "error_message": "Invalid object for states: /array"
       });
       expect(node.db.getFunction("test/new2/unchartered/nested/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setFunction("/test/test_function/some/path2", {'.': 'x'}), {
-        "code": 6,
+        "code": 401,
         "error_message": "Invalid object for states: /."
       });
       expect(node.db.getFunction("test/new2/unchartered/nested/path2")).to.equal(null)
     })
 
     it("when writing with invalid path", () => {
-      assert.deepEqual(node.db.setRule("/test/test_function/some/path/.", "some function config"), {
-        "code": 7,
+      assert.deepEqual(node.db.setFunction(
+          "/test/test_function/some/path/.", "some function config"), {
+        "code": 402,
         "error_message": "Invalid path: /test/test_function/some/path/."
       });
     })
@@ -1176,13 +1177,13 @@ describe("DB operations", () => {
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setRule("/test/test_rule/some/path2", {array: []}), {
-        "code": 6,
+        "code": 501,
         "error_message": "Invalid object for states: /array"
       });
       expect(node.db.getRule("/test/test_rule/some/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setRule("/test/test_rule/some/path2", {'.': 'x'}), {
-        "code": 6,
+        "code": 501,
         "error_message": "Invalid object for states: /."
       });
       expect(node.db.getRule("/test/test_rule/some/path2")).to.equal(null)
@@ -1190,7 +1191,7 @@ describe("DB operations", () => {
 
     it("when writing with invalid path", () => {
       assert.deepEqual(node.db.setRule("/test/test_rule/some/path/.", "some rule config"), {
-        "code": 7,
+        "code": 502,
         "error_message": "Invalid path: /test/test_rule/some/path/."
       });
     })
@@ -1206,21 +1207,21 @@ describe("DB operations", () => {
 
     it("when writing invalid object", () => {
       assert.deepEqual(node.db.setOwner("/test/test_owner/some/path2", {array: []}), {
-        "code": 6,
+        "code": 601,
         "error_message": "Invalid object for states: /array"
       });
       expect(node.db.getOwner("/test/test_owner/some/path2")).to.equal(null)
 
       assert.deepEqual(node.db.setOwner("/test/test_owner/some/path2", {'.': 'x'}), {
-        "code": 6,
+        "code": 601,
         "error_message": "Invalid object for states: /."
       });
       expect(node.db.getOwner("/test/test_owner/some/path2")).to.equal(null)
     })
 
     it("when writing with invalid path", () => {
-      assert.deepEqual(node.db.setRule("/test/test_owner/some/path/.", "some owner config"), {
-        "code": 7,
+      assert.deepEqual(node.db.setOwner("/test/test_owner/some/path/.", "some owner config"), {
+        "code": 602,
         "error_message": "Invalid path: /test/test_owner/some/path/."
       });
     })
@@ -1298,7 +1299,7 @@ describe("DB operations", () => {
           ref: "test/decrement/value",
           value: 10
         },
-      ]).code).to.equal(1)
+      ]).code).to.equal(201)
       expect(node.db.getValue("test/ai/foo")).to.equal("bar")
     })
 
@@ -1321,7 +1322,7 @@ describe("DB operations", () => {
           ref: "test/increment/value",
           value: 10
         }
-      ]).code).to.equal(1)
+      ]).code).to.equal(301)
       expect(node.db.getValue("test/ai/foo")).to.equal("bar")
     })
   })
@@ -1424,11 +1425,11 @@ describe("DB operations", () => {
       ]), [
         true,
         {
-          "code": 1,
+          "code": 801,
           "error_message": "No tx_body"
         },
         {
-          "code": 2,
+          "code": 802,
           "error_message": "No operation"
         }
       ])
@@ -1470,7 +1471,7 @@ describe("DB operations", () => {
       ]), [
         true,
         {
-          "code": 3,
+          "code": 803,
           "error_message": "Invalid operation type: GET_VALUE"
         },
         true])
@@ -1511,7 +1512,7 @@ describe("DB operations", () => {
       ]), [
         true,
         {
-          "code": 1,
+          "code": 201,
           "error_message": "Not a number type: bar or 10"
         },
         true])
@@ -1552,7 +1553,7 @@ describe("DB operations", () => {
       ]), [
         true,
         {
-          "code": 1,
+          "code": 301,
           "error_message": "Not a number type: bar or 10"
         },
         true])
@@ -2331,7 +2332,7 @@ describe("DB sharding config", () => {
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
       assert.deepEqual(node.db.setValue("test/test_sharding/shards/enabled_shard/path", 20), {
-        "code": 8,
+        "code": 104,
         "error_message":
             "Non-writable path with shard config: /values/test/test_sharding/shards/enabled_shard"
       });
@@ -2381,7 +2382,7 @@ describe("DB sharding config", () => {
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
       assert.deepEqual(node.db.incValue("test/test_sharding/shards/enabled_shard/path", 5), {
-        "code": 8,
+        "code": 104,
         "error_message":
             "Non-writable path with shard config: /values/test/test_sharding/shards/enabled_shard"
       });
@@ -2432,7 +2433,7 @@ describe("DB sharding config", () => {
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
       assert.deepEqual(node.db.decValue("test/test_sharding/shards/enabled_shard/path", 5), {
-        "code": 8,
+        "code": 104,
         "error_message":
             "Non-writable path with shard config: /values/test/test_sharding/shards/enabled_shard"
       });


### PR DESCRIPTION
Summary:
- Simplify node status by adopting BlockchainNodeStatus which replaces server.isStarting, node.initialized, and bc.syncedAfterStartup
- Reject transactions when the node is not in BlockchainNodeStatus.SERVING status
- Report node status to tracker server
- Add /node_status client API
- Fix log prefix of tracker server
- Use ChainUtil.returnError() and ChainUtil.logAndReturnError() util functions
- Rename chain subsection chain segment

Code snippet:
```
const BlockchainNodeStatus = {
  STARTING: 'STARTING',
  SYNCING: 'SYNCING',
  SERVING: 'SERVING',
}
```

State transition:
STARTING (server.isStarting=true) -> SYNCING (node.initialized=true) -> SERVING (bc.syncedAfterStartup=true)
