### PR TITLE
Handle deleted nodes properly in updateProofhashForAllRootPaths()

### DIFF
--- a/db/state-util.js
+++ b/db/state-util.js
@@ -297,10 +297,10 @@ function updateProofHashForAllRootPaths(fullPath, root) {
     const label = fullPath[i];
     const child = node.getChild(label);
     if (child === null) {
-      logger.error(
+      logger.info(
           `[${LOG_HEADER}] Trying to update proof hash for non-existing path: ` +
           `${ChainUtil.formatPath(fullPath.slice(0, i + 1))}.`);
-      return 0;
+      break;
     }
     node = child;
   }

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -1225,7 +1225,7 @@ describe("state-util", () => {
   });
 
   describe("updateProofHashForAllRootPaths", () => {
-    it("updates proof hashes for a single path to a root", () => {
+    it("updates proof hashes for a single root path", () => {
       const jsObject = {
         level0: {
           level1: {
@@ -1264,7 +1264,7 @@ describe("state-util", () => {
       expect(rootNode.getTreeSize()).to.equal(5);
     });
 
-    it("updates proof hashes for multiple paths to roots", () => {
+    it("updates proof hashes for multiple root paths", () => {
       const jsObject = {
         level0: {
           level1: {
@@ -1314,7 +1314,7 @@ describe("state-util", () => {
       expect(rootClone.getProofHash()).to.equal(rootNode.getProofHash());
     });
 
-    it("updates proof hashes for multiple paths to roots with deleted nodes", () => {
+    it("updates proof hashes for multiple root paths with deleted nodes", () => {
       const jsObject = {
         level0: {
           level1: {

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -1264,7 +1264,7 @@ describe("state-util", () => {
       expect(rootNode.getTreeSize()).to.equal(5);
     });
 
-    it("updates proof hashes for multiple paths to all the roots", () => {
+    it("updates proof hashes for multiple paths to roots", () => {
       const jsObject = {
         level0: {
           level1: {
@@ -1290,6 +1290,57 @@ describe("state-util", () => {
       const anotherClone = anotherNode.clone();
 
       const numAffectedNodes = updateProofHashForAllRootPaths(['level0', 'level1'], rootNode);
+      expect(numAffectedNodes).to.equal(5);
+
+      // Checks proof hashes.
+      expect(level2Node.getChild('foo').getProofHash()).to.equal(null);
+      expect(level2Node.getChild('baz').getProofHash()).to.equal(null);
+      expect(level2Node.getProofHash()).to.equal(null);
+      expect(level2Clone.getProofHash()).to.equal(null);
+
+      expect(anotherNode.getChild('test').getProofHash()).to.equal(null);
+      expect(anotherNode.getProofHash()).to.equal(null);
+      expect(anotherClone.getProofHash()).to.equal(null);
+
+      expect(level1Node.getProofHash()).to.equal(level1Node.buildProofHash());
+      expect(level1Clone.getProofHash()).to.equal(null);
+
+      expect(level0Node.getProofHash()).to.equal(level0Node.buildProofHash());
+      expect(level0Clone.getProofHash()).to.equal(level0Clone.buildProofHash());
+      expect(level0Clone.getProofHash()).to.equal(level0Node.getProofHash());
+
+      expect(rootNode.getProofHash()).to.equal(rootNode.buildProofHash());
+      expect(rootClone.getProofHash()).to.equal(rootClone.buildProofHash());
+      expect(rootClone.getProofHash()).to.equal(rootNode.getProofHash());
+    });
+
+    it("updates proof hashes for multiple paths to roots with deleted nodes", () => {
+      const jsObject = {
+        level0: {
+          level1: {
+            level2: {
+              foo: 'bar',
+              baz: 'caz'
+            }
+          },
+          another_route: {
+            test: -1000
+          }
+        }
+      };
+      const rootNode = StateNode.fromJsObject(jsObject);
+      const level0Node = rootNode.getChild('level0');
+      const level1Node = level0Node.getChild('level1');
+      const level2Node = level1Node.getChild('level2');
+      const anotherNode = level0Node.getChild('another_route');
+      const rootClone = rootNode.clone();
+      const level0Clone = level0Node.clone();
+      const level1Clone = level1Node.clone();
+      const level2Clone = level2Node.clone();
+      const anotherClone = anotherNode.clone();
+
+      const numAffectedNodes = updateProofHashForAllRootPaths(
+          ['level0', 'level1', 'deleted1', 'deleted2'], rootNode);  // with deleted nodes
       expect(numAffectedNodes).to.equal(5);
 
       // Checks proof hashes.


### PR DESCRIPTION
Summary:
- Handle deleted nodes properly in updateProofhashForAllRootPaths()

#215 