### PR TITLE
Feature/service accounts

### DIFF
--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -68,6 +68,10 @@ class ChainUtil {
     return ruleUtil.isCksumAddr(addr);
   }
 
+  static isServAcntName(name) {
+    return ruleUtil.isServAcntName(name);
+  }
+
   static isValShardProto(value) {
     return ruleUtil.isValShardProto(value);
   }
@@ -90,6 +94,10 @@ class ChainUtil {
 
   static toCksumAddr(addr) {
     return ruleUtil.toCksumAddr(addr);
+  }
+
+  static toServiceAccountName(serviceType, serviceName, user) {
+    return `${serviceType}|${serviceName}|${user}`;
   }
 
   static toString(value) {
@@ -150,6 +158,10 @@ class ChainUtil {
       labels.push(...ChainUtil.parsePath(toAppend));
     }
     return ChainUtil.formatPath(labels);
+  }
+
+  static getBalancePath(addrOrServAcnt) {
+    return ruleUtil.getBalancePath(addrOrServAcnt);
   }
 
   static getJsObject(obj, path) {

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -96,6 +96,10 @@ class ChainUtil {
     return ruleUtil.toCksumAddr(addr);
   }
 
+  static parseServAcntName(accountName) {
+    return ruleUtil.parseServAcntName(accountName);
+  }
+
   static toServiceAccountName(serviceType, serviceName, user) {
     return `${serviceType}|${serviceName}|${user}`;
   }

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -100,8 +100,8 @@ class ChainUtil {
     return ruleUtil.parseServAcntName(accountName);
   }
 
-  static toServiceAccountName(serviceType, serviceName, user) {
-    return `${serviceType}|${serviceName}|${user}`;
+  static toServiceAccountName(serviceType, serviceName, key) {
+    return `${serviceType}|${serviceName}|${key}`;
   }
 
   static toString(value) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -86,6 +86,7 @@ const PredefinedDbPaths = {
   // Accounts & Transfer
   ACCOUNTS: 'accounts',
   SERVICE_ACCOUNTS: 'service_accounts',
+  SERVICE_ACCOUNTS_ADMIN: 'admin',
   BALANCE: 'balance',
   TRANSFER: 'transfer',
   TRANSFER_VALUE: 'value',

--- a/common/constants.js
+++ b/common/constants.js
@@ -85,6 +85,7 @@ const PredefinedDbPaths = {
   SAVE_LAST_TX_LAST_TX: '.last_tx',
   // Accounts & Transfer
   ACCOUNTS: 'accounts',
+  SERVICE_ACCOUNTS: 'service_accounts',
   BALANCE: 'balance',
   TRANSFER: 'transfer',
   TRANSFER_VALUE: 'value',

--- a/db/functions.js
+++ b/db/functions.js
@@ -252,23 +252,14 @@ class Functions {
    */
   setServiceAccountTransferOrLog(from, to, value, auth, timestamp, transaction) {
     const transferPath = this.getTransferValuePath(from, to, timestamp);
-    const transferResult = this.db.setValue(transferPath, value, auth, timestamp, transaction);
-    if (transferResult !== true) {
-      logger.error(
-          `  ==> Failed to setServiceAccountTransferOrLog on '${transferPath}' with error: ${JSON.stringify(transferResult)}`);
-    }
+    const transferResult = this.setValueOrLog(transferPath, value, auth, timestamp);
     if (ChainUtil.isServAcntName(to)) {
       const serviceAccountAdminPath = this.getServiceAccountAdminPath(to);
       const serviceAccountAdmin = this.db.getValue(serviceAccountAdminPath);
       if (serviceAccountAdmin === null) {
         // set admin as the from address of the original transaction
         const serviceAccountAdminAddrPath = this.getServiceAccountAdminAddrPath(to, transaction.address);
-        const serviceAccountAdminAddrPath = this._getServiceAccountAdminAddrPath(to, transaction.address);
-        const adminSetupResult = this.setValueOrLog(serviceAccountAdminAddrPath, true, auth, timestamp);
-        if (adminSetupResult !== true) {
-          logger.error(
-              ` ==> Failed to set admin for a service account ${to} with error: ${JSON.stringify(adminSetupResult)}`);
-        }
+        this.setValueOrLog(serviceAccountAdminAddrPath, true, auth, timestamp);
       }
     }
     return transferResult;

--- a/db/functions.js
+++ b/db/functions.js
@@ -673,9 +673,7 @@ class Functions {
   }
 
   getServiceAccountAdminAddrPath(accountName, adminAddr) {
-    const parsed = ChainUtil.parseServAcntName(accountName);
-    return `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/` +
-        `${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}/${adminAddr}`;
+    return `${this.getServiceAccountAdminPath(accountName)}/${adminAddr}`;
   }
 
   getTransferValuePath(from, to, key) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -259,7 +259,7 @@ class Functions {
         const serviceAccountAdminAddrPath = this.getServiceAccountAdminAddrPath(to, transaction.address);
         const adminSetupResult = this.setValueOrLog(serviceAccountAdminAddrPath, true, auth, timestamp);
         if (adminSetupResult !== true) {
-          return;
+          return adminSetupResult;
         }
       }
     }

--- a/db/functions.js
+++ b/db/functions.js
@@ -154,7 +154,8 @@ class Functions {
 
   /**
    * Returns a new function created by applying the function change to the current function.
-   * 
+   *
+   * @param {Object} curFunction current function (modified and returned by this function)
    * @param {Object} functionChange function change
    */
   static applyFunctionChange(curFunction, functionChange) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -665,13 +665,15 @@ class Functions {
   }
 
   getServiceAccountAdminPath(accountName) {
-    const parsed = accountName.split('|');
-    return `/service_accounts/${parsed[0]}/${parsed[1]}/${parsed[2]}/admin`;
+    const parsed = ChainUtil.parseServAcntName(accountName);
+    return `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/` +
+        `${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
   }
 
   getServiceAccountAdminAddrPath(accountName, adminAddr) {
-    const parsed = accountName.split('|');
-    return `/service_accounts/${parsed[0]}/${parsed[1]}/${parsed[2]}/admin/${adminAddr}`;
+    const parsed = ChainUtil.parseServAcntName(accountName);
+    return `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/` +
+        `${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}/${adminAddr}`;
   }
 
   getTransferValuePath(from, to, key) {

--- a/db/index.js
+++ b/db/index.js
@@ -406,7 +406,9 @@ class DB {
     const valueCopy = ChainUtil.isDict(value) ? JSON.parse(JSON.stringify(value)) : value;
     this.writeDatabase(fullPath, valueCopy);
     // NOTE(seo): As of now (2021-01), we don't allow recursive function triggering.
-    if (auth && auth.addr) {
+    // NOTE(lia): Allow recursive function triggering for service accounts. Should update this logic
+    // to prevent infinite recursion.
+    if (auth && (auth.addr || auth.fid)) {
       this.func.triggerFunctions(localPath, valueCopy, timestamp, Date.now(), transaction);
     }
 

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -87,7 +87,7 @@ class RuleUtil {
   getBalancePath(addrOrServAcnt) {
     const { PredefinedDbPaths } = require('../common/constants');
     if (this.isServAcntName(addrOrServAcnt)) {
-      const parsed = addrOrServAcnt.split('|');
+      const parsed = this.parseServAcntName(addrOrServAcnt);
       return `/${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/${PredefinedDbPaths.BALANCE}`;
     } else {
       return `/${PredefinedDbPaths.ACCOUNTS}/${addrOrServAcnt}/${PredefinedDbPaths.BALANCE}`;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -54,6 +54,10 @@ class RuleUtil {
     return this.isValAddr(addr) && addr === ainUtil.toChecksumAddress(addr);
   }
 
+  isServAcntName(name) {
+    return this.isString(name) && name.split('|').length === 3;
+  }
+
   isValShardProto(value) {
     const {ShardingProtocols} = require('../common/constants');
     return value === ShardingProtocols.NONE || value === ShardingProtocols.POA;
@@ -68,6 +72,15 @@ class RuleUtil {
       return ainUtil.toChecksumAddress(addr);
     } catch (e) {
       return '';
+    }
+  }
+
+  getBalancePath(addrOrServAcnt) {
+    if (this.isServAcntName(addrOrServAcnt)) {
+      const parsed = addrOrServAcnt.split('|');
+      return `/service_accounts/${parsed[0]}/${parsed[1]}/${parsed[2]}/balance`;
+    } else {
+      return `/accounts/${addrOrServAcnt}/balance`;
     }
   }
 

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -75,12 +75,22 @@ class RuleUtil {
     }
   }
 
+  parseServAcntName(accountName) {
+    if (this.isString(accountName)) {
+      const parsed = accountName.split('|');
+      return [_.get(parsed, '0', null), _.get(parsed, '1', null), _.get(parsed, '2', null)];
+    } else {
+      return [null, null, null];
+    }
+  }
+
   getBalancePath(addrOrServAcnt) {
+    const { PredefinedDbPaths } = require('../common/constants');
     if (this.isServAcntName(addrOrServAcnt)) {
       const parsed = addrOrServAcnt.split('|');
-      return `/service_accounts/${parsed[0]}/${parsed[1]}/${parsed[2]}/balance`;
+      return `/${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/${PredefinedDbPaths.BALANCE}`;
     } else {
-      return `/accounts/${addrOrServAcnt}/balance`;
+      return `/${PredefinedDbPaths.ACCOUNTS}/${addrOrServAcnt}/${PredefinedDbPaths.BALANCE}`;
     }
   }
 

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -106,6 +106,22 @@
       }
     }
   },
+  "service_accounts": {
+    "$service_type": {
+      "$service_name": {
+        "$key": {
+          "admin": {
+            "$admin_addr": {
+              ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
+            }
+          },
+          "balance": {
+            ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
+          }
+        }
+      }
+    }
+  },
   "sharding": {
     "shard": {
       ".write": false,
@@ -119,7 +135,7 @@
       "$to": {
         "$key": {
           "value": {
-            ".write": "auth.addr === $from && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.length($from) !== 42 || util.isCksumAddr($from)) && (util.length($to) !== 42 || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue('accounts/' + $from + '/balance') >= newData"
+            ".write": "(auth.addr === $from || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue(util.getBalancePath($from)) >= newData"
           },
           "result": {
             ".write": "auth.fid === '_transfer'"

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -2679,51 +2679,51 @@ describe('Blockchain Node', () => {
             }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
       });
-    });
 
-    it('claim amount > payment balance', () => {
-      const paymentBalance = parseOrLog(syncRequest('GET',
-          server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
-          .body.toString('utf-8')).result;
-      const paymentRef = `/payments/test_service/${serviceUser}/claims/key1`;
-      const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-        ref: paymentRef,
-        value: {
-          amount: paymentBalance + 1,
-          id: 'key1'
-        }
-      }}).body.toString('utf-8'));
-      waitUntilTxFinalized(serverList, body.result.tx_hash);
-      const paymentResult = parseOrLog(syncRequest('GET',
-          server1 + `/get_value?ref=${paymentRef}/result/code`).body.toString('utf-8')).result;
-      expect(paymentResult).to.equals(FunctionResultCode.INTERNAL_ERROR);
-    });
+      it('claim amount > payment balance', () => {
+        const paymentBalance = parseOrLog(syncRequest('GET',
+            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
+            .body.toString('utf-8')).result;
+        const paymentRef = `/payments/test_service/${serviceUser}/claims/key1`;
+        const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+          ref: paymentRef,
+          value: {
+            amount: paymentBalance + 1,
+            id: 'key1'
+          }
+        }}).body.toString('utf-8'));
+        waitUntilTxFinalized(serverList, body.result.tx_hash);
+        const paymentResult = parseOrLog(syncRequest('GET',
+            server1 + `/get_value?ref=${paymentRef}/result/code`).body.toString('utf-8')).result;
+        expect(paymentResult).to.equals(FunctionResultCode.INTERNAL_ERROR);
+      });
 
-    it('admin can claim payments', () => {
-      const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
-          `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-      const paymentClaimRef = `/payments/test_service/${serviceUser}/claims/key1`;
-      const paymentBalance = parseOrLog(syncRequest('GET',
-          server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
-          .body.toString('utf-8')).result;
-      const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-        ref: paymentClaimRef,
-        value: {
-          amount: paymentBalance,
-          id: 'key1'
-        }
-      }}).body.toString('utf-8'));
-      waitUntilTxFinalized(serverList, body.result.tx_hash);
-      const paymentResult = parseOrLog(syncRequest('GET', server1 +
-          `/get_value?ref=${paymentClaimRef}/result/code`).body.toString('utf-8')).result;
-      expect(paymentResult).to.equals(FunctionResultCode.SUCCESS);
-      const adminBalanceAfter = parseOrLog(syncRequest('GET', server1 +
-          `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-      expect(adminBalanceAfter).to.equals(adminBalanceBefore + paymentBalance);
-      const serviceAccountsBalance = parseOrLog(syncRequest('GET',
-          server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
-          .body.toString('utf-8')).result;
-      expect(serviceAccountsBalance).to.equals(0);
+      it('admin can claim payments', () => {
+        const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
+            `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
+        const paymentClaimRef = `/payments/test_service/${serviceUser}/claims/key2`;
+        const paymentBalance = parseOrLog(syncRequest('GET',
+            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
+            .body.toString('utf-8')).result;
+        const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+          ref: paymentClaimRef,
+          value: {
+            amount: paymentBalance,
+            id: 'key2'
+          }
+        }}).body.toString('utf-8'));
+        waitUntilTxFinalized(serverList, body.result.tx_hash);
+        const paymentResult = parseOrLog(syncRequest('GET', server1 +
+            `/get_value?ref=${paymentClaimRef}/result/code`).body.toString('utf-8')).result;
+        expect(paymentResult).to.equals(FunctionResultCode.SUCCESS);
+        const adminBalanceAfter = parseOrLog(syncRequest('GET', server1 +
+            `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
+        expect(adminBalanceAfter).to.equals(adminBalanceBefore + paymentBalance);
+        const serviceAccountsBalance = parseOrLog(syncRequest('GET',
+            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}/balance`)
+            .body.toString('utf-8')).result;
+        expect(serviceAccountsBalance).to.equals(0);
+      });
     });
   });
-})
+});

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -1203,7 +1203,7 @@ describe('Sharding', () => {
               .body.toString('utf-8')).result;
           assert.deepEqual(resultBefore, 100);
 
-          const request = {ref: 'test/test_value/some/path', value: "some value"};
+          const request = {ref: 'test/test_value/some/path', value: "some value", nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
           assert.deepEqual(body.result.result, true);
@@ -1211,7 +1211,7 @@ describe('Sharding', () => {
         })
 
         it('/set_value with is_global = false (explicit)', () => {
-          const request = {ref: 'test/test_value/some/path', value: "some value", is_global: false};
+          const request = {ref: 'test/test_value/some/path', value: "some value", is_global: false, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
           assert.deepEqual(body.result.result, true);
@@ -1220,7 +1220,7 @@ describe('Sharding', () => {
 
         it('/set_value with is_global = true', () => {
           const request = {
-            ref: 'apps/afan/test/test_value/some/path', value: "some value", is_global: true
+            ref: 'apps/afan/test/test_value/some/path', value: "some value", is_global: true, nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
@@ -1231,7 +1231,7 @@ describe('Sharding', () => {
 
       describe('/inc_value', () => {
         it('/inc_value with is_global = false', () => {
-          const request = {ref: 'test/test_value/some/path', value: 10};
+          const request = {ref: 'test/test_value/some/path', value: 10, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
               .body.toString('utf-8'));
           assert.deepEqual(body.result.result, true);
@@ -1240,7 +1240,7 @@ describe('Sharding', () => {
 
         it('/inc_value with is_global = true', () => {
           const request = {
-            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true, nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
               .body.toString('utf-8'));
@@ -1251,7 +1251,7 @@ describe('Sharding', () => {
 
       describe('/dec_value', () => {
         it('/dec_value with is_global = false', () => {
-          const request = {ref: 'test/test_value/some/path', value: 10};
+          const request = {ref: 'test/test_value/some/path', value: 10, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
               .body.toString('utf-8'));
           assert.deepEqual(body.result.result, true);
@@ -1260,7 +1260,7 @@ describe('Sharding', () => {
 
         it('/dec_value with is_global = true', () => {
           const request = {
-            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true
+            ref: 'apps/afan/test/test_value/some/path', value: 10, is_global: true, nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
               .body.toString('utf-8'));
@@ -1277,7 +1277,8 @@ describe('Sharding', () => {
               ".function": {
                 "fid": "some other function config"
               }
-            }
+            },
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_function', {json: request})
               .body.toString('utf-8'));
@@ -1294,6 +1295,7 @@ describe('Sharding', () => {
               }
             },
             is_global: true,
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_function', {json: request})
               .body.toString('utf-8'));
@@ -1308,7 +1310,8 @@ describe('Sharding', () => {
             ref: "test/test_rule/other/path",
             value: {
               ".write": "some other rule config"
-            }
+            },
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
               .body.toString('utf-8'));
@@ -1323,6 +1326,7 @@ describe('Sharding', () => {
               ".write": "some other rule config"
             },
             is_global: true,
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
               .body.toString('utf-8'));
@@ -1337,7 +1341,8 @@ describe('Sharding', () => {
             ref: "test/test_owner/other/path",
             value: {
               ".owner": "some other owner config"
-            }
+            },
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
               .body.toString('utf-8'));
@@ -1352,6 +1357,7 @@ describe('Sharding', () => {
               ".owner": "some other2 owner config"
             },
             is_global: true,
+            nonce: -1,
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
               .body.toString('utf-8'));
@@ -1400,7 +1406,8 @@ describe('Sharding', () => {
                   ".owner": "some other3 owner config"
                 }
               }
-            ]
+            ],
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
               .body.toString('utf-8'));
@@ -1453,7 +1460,8 @@ describe('Sharding', () => {
                 },
                 is_global: true,
               }
-            ]
+            ],
+            nonce: -1
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
               .body.toString('utf-8'));


### PR DESCRIPTION
DONE
- Added some initial code for /service_accounts feature
  - /service_accounts/\<service type>/\<service name>/\<key>: { admin: { \<address>: true }, balance: \<number> }
    - Example: `/service_accounts/payments/collaborative_ai/0xUSER...ADDR: { admin: { 0xADMIN...ADDR: true }, balance: 100 }`
  - Admin is set when a first transfer is made to the service account
  - When transferring from and/or to a service account, it should be encoded as follows: `<service type>|<service name>|<key>`
    - Example: `/transfer/0xADMIN...ADDR/payments|collaborative_ai|0xUSER...ADDR/123/value` will transfer AIN from `/accounts/0xADMIN...ADDR/balance` to `/service_accounts/payments/collaborative_ai/0xUSER...ADDR/balance`
- Replaced balances for payments service with service accounts
- Added tests for payments (_pay, _claim)
- Added { nonce: -1 } to some requests in ./integration/sharding.test.js.

TODO
- Deprecate deposit_accounts and use service_accounts instead
- Prevent infinite recursion of native function calls
- Decide on service name policy (additional restrictions, etc.)