### PR TITLE
Feature/escrow

### DIFF
--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -120,7 +120,11 @@ class ChainUtil {
   }
 
   static toServiceAccountName(serviceType, serviceName, key) {
-    return `${serviceType}|${serviceName}|${key}`;
+    return ruleUtil.toServiceAccountName(serviceType, serviceName, key);
+  }
+
+  static toEscrowAccountName(source, target, escrowKey) {
+    return ruleUtil.toEscrowAccountName(source, target, escrowKey);
   }
 
   static toString(value) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -114,6 +114,13 @@ const PredefinedDbPaths = {
   PAYMENTS_CONFIG: 'config',
   PAYMENTS_PAY: 'pay',
   PAYMENTS_RESULT: 'result',
+  // Escrow
+  ESCROW: 'escrow',
+  ESCROW_ADMIN: 'admin',
+  ESCROW_HOLD: 'hold',
+  ESCROW_OPEN: 'open',
+  ESCROW_RELEASE: 'release',
+  ESCROW_RESULT: 'result',
   // Remote transaction action
   REMOTE_TX_ACTION_RESULT: 'result',
   // Sharding
@@ -219,8 +226,11 @@ const NativeFunctionIds = {
   CLAIM: '_claim',
   CLOSE_CHECKIN: '_closeCheckin',
   DEPOSIT: '_deposit',
+  HOLD: '_hold',
   OPEN_CHECKIN: '_openCheckin',
+  OPEN_ESCROW: '_openEscrow',
   PAY: '_pay',
+  RELEASE: '_release',
   SAVE_LAST_TX: '_saveLastTx',
   TRANSFER: '_transfer',
   UPDATE_LATEST_SHARD_REPORT: '_updateLatestShardReport',

--- a/db/functions.js
+++ b/db/functions.js
@@ -583,6 +583,7 @@ class Functions {
         return this.setValueOrLog(payPath, { amount, source: escrowAccount }, auth, timestamp, transaction);
       } else {
         // other service types not yet supported
+        logger.debug(`  ==> Service type not supported: ${parsed[0]}`);
         return false;
       }
     } else {

--- a/db/functions.js
+++ b/db/functions.js
@@ -503,6 +503,8 @@ class Functions {
     let result;
     const userServiceAccountName = ChainUtil.toServiceAccountName(
         PredefinedDbPaths.PAYMENTS, service, `${user}|${paymentKey}`);
+    // NOTE: By specifying `escrow_key`, the claimed payment is held in escrow instead of being
+    // transferred directly to the admin account
     if (value.escrow_key !== undefined) {
       const escrowHoldPath = this.getEscrowHoldRecordPath(
           userServiceAccountName, value.target, value.escrow_key, timestamp);

--- a/db/functions.js
+++ b/db/functions.js
@@ -542,7 +542,10 @@ class Functions {
     const serviceAccountPath = this.getServiceAccountPath(serviceAccountName);
     const serviceAccountSetupResult = this.setValueOrLog(serviceAccountPath, value, auth, timestamp);
     if (serviceAccountSetupResult !== true) {
-      return serviceAccountSetupResult;
+      logger.error(`  ==> Failed to open escrow`);
+      this.setExecutionResult(context, FunctionResultCode.FAILURE);
+    } else {
+      this.setExecutionResult(context, FunctionResultCode.SUCCESS);
     }
   }
 
@@ -561,7 +564,7 @@ class Functions {
     const escrowServiceAccountName = ChainUtil.toServiceAccountName(
         PredefinedDbPaths.ESCROW, PredefinedDbPaths.ESCROW, accountKey);
     const transferResult = this.setServiceAccountTransferOrLog(
-        sourceAccount, escrowServiceAccountName, value.amount, auth, timestamp, transaction);
+        sourceAccount, escrowServiceAccountName, amount, auth, timestamp, transaction);
     if (transferResult === true) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {

--- a/db/functions.js
+++ b/db/functions.js
@@ -44,8 +44,11 @@ class Functions {
       [NativeFunctionIds.CLAIM]: this._claim.bind(this),
       [NativeFunctionIds.CLOSE_CHECKIN]: this._closeCheckin.bind(this),
       [NativeFunctionIds.DEPOSIT]: this._deposit.bind(this),
+      [NativeFunctionIds.HOLD]: this._hold.bind(this),
       [NativeFunctionIds.OPEN_CHECKIN]: this._openCheckin.bind(this),
+      [NativeFunctionIds.OPEN_ESCROW]: this._openEscrow.bind(this),
       [NativeFunctionIds.PAY]: this._pay.bind(this),
+      [NativeFunctionIds.RELEASE]: this._release.bind(this),
       [NativeFunctionIds.SAVE_LAST_TX]: this._saveLastTx.bind(this),
       [NativeFunctionIds.TRANSFER]: this._transfer.bind(this),
       [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: this._updateLatestShardReport.bind(this),
@@ -462,16 +465,18 @@ class Functions {
     const transaction = context.transaction;
     const execTime = context.execTime;
     const auth = context.auth;
-    const resultPath = this.getPaymentPayRecordsResultPath(service, user, paymentKey, recordId);
+    const resultPath = this.getPaymentPayRecordResultPath(service, user, paymentKey, recordId);
 
     if (!this.validatePaymentRecord(transaction.address, value, timestamp, execTime)) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
       return;
     }
 
-    const userServiceAccountName = ChainUtil.toServiceAccountName('payments', service, `${user}|${paymentKey}`);
+    const userServiceAccountName = ChainUtil.toServiceAccountName(
+        PredefinedDbPaths.PAYMENTS, service, `${user}|${paymentKey}`);
     const transferResult = this.setServiceAccountTransferOrLog(
-      transaction.address, userServiceAccountName, value.amount, auth, timestamp, transaction);
+        value.source ? value.source : transaction.address, userServiceAccountName, value.amount,
+        auth, timestamp, transaction);
     if (transferResult === true) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
@@ -488,17 +493,25 @@ class Functions {
     const timestamp = context.timestamp;
     const execTime = context.execTime;
     const auth = context.auth;
-    const resultPath = this.getPaymentClaimRecordsResultPath(service, user, paymentKey, recordId);
+    const resultPath = this.getPaymentClaimRecordResultPath(service, user, paymentKey, recordId);
 
     if (!this.validatePaymentRecord(transaction.address, value, timestamp, execTime)) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
       return;
     }
 
-    const userServiceAccountName = ChainUtil.toServiceAccountName('payments', service, `${user}|${paymentKey}`);
-    const transferResult = this.setServiceAccountTransferOrLog(
-        userServiceAccountName, value.target, value.amount, auth, timestamp, transaction);
-    if (transferResult === true) {
+    let result;
+    const userServiceAccountName = ChainUtil.toServiceAccountName(
+        PredefinedDbPaths.PAYMENTS, service, `${user}|${paymentKey}`);
+    if (value.escrow_key !== undefined) {
+      const escrowHoldPath = this.getEscrowHoldRecordPath(
+          userServiceAccountName, value.target, value.escrow_key, timestamp);
+      result = this.setValueOrLog(escrowHoldPath, { amount: value.amount }, auth, timestamp, transaction);
+    } else {
+      result = this.setServiceAccountTransferOrLog(
+          userServiceAccountName, value.target, value.amount, auth, timestamp, transaction);
+    }
+    if (result === true) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -516,6 +529,104 @@ class Functions {
       return false;
     }
     return true;
+  }
+
+  _openEscrow(value, context) {
+    const sourceAccount = context.params.source_account;
+    const targetAccount = context.params.target_account;
+    const escrowKey = context.params.escrow_key;
+    const { timestamp, auth } = context;
+    const accountKey = ChainUtil.toEscrowAccountName(sourceAccount, targetAccount, escrowKey);
+    const serviceAccountName = ChainUtil.toServiceAccountName(
+        PredefinedDbPaths.ESCROW, PredefinedDbPaths.ESCROW, accountKey);
+    const serviceAccountPath = this.getServiceAccountPath(serviceAccountName);
+    const serviceAccountSetupResult = this.setValueOrLog(serviceAccountPath, value, auth, timestamp);
+    if (serviceAccountSetupResult !== true) {
+      return serviceAccountSetupResult;
+    }
+  }
+
+  _hold(value, context) {
+    const sourceAccount = context.params.source_account;
+    const targetAccount = context.params.target_account;
+    const escrowKey = context.params.escrow_key;
+    const recordId = context.params.record_id;
+    const { transaction, timestamp, auth } = context;
+    const amount = _.get(value, 'amount');
+    const resultPath = this.getEscrowHoldRecordResultPath(sourceAccount, targetAccount, escrowKey, recordId);
+    if (!ChainUtil.isNumber(amount)) {
+      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
+    }
+    const accountKey = ChainUtil.toEscrowAccountName(sourceAccount, targetAccount, escrowKey);
+    const escrowServiceAccountName = ChainUtil.toServiceAccountName(
+        PredefinedDbPaths.ESCROW, PredefinedDbPaths.ESCROW, accountKey);
+    const transferResult = this.setServiceAccountTransferOrLog(
+        sourceAccount, escrowServiceAccountName, value.amount, auth, timestamp, transaction);
+    if (transferResult === true) {
+      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
+    } else {
+      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
+    }
+  }
+
+  releaseInternal(escrowAccount, recipient, amount, auth, timestamp, transaction) {
+    if (ChainUtil.isServAcntName(recipient)) {
+      const parsed = ChainUtil.parseServAcntName(recipient);
+      if (parsed[0] === PredefinedDbPaths.PAYMENTS) {
+        // trigger _pay
+        const paymentAccountNameParsed = parsed[2].split('|');
+        const payPath = this.getPaymentPayRecordPath(
+            parsed[1], paymentAccountNameParsed[0], paymentAccountNameParsed[1], timestamp);
+        return this.setValueOrLog(payPath, { amount, source: escrowAccount }, auth, timestamp, transaction);
+      } else {
+        // other service types not yet supported
+        return false;
+      }
+    } else {
+      // transfer to regular accounts
+      return this.setServiceAccountTransferOrLog(
+          escrowAccount, recipient, amount, auth, timestamp, transaction);
+    }
+  }
+
+  _release(value, context) {
+    const sourceAccount = context.params.source_account;
+    const targetAccount = context.params.target_account;
+    const escrowKey = context.params.escrow_key;
+    const recordId = context.params.record_id;
+    const { transaction, timestamp, auth } = context;
+    const ratio = _.get(value, 'ratio');
+    const resultPath = this.getEscrowReleaseRecordResultPath(sourceAccount, targetAccount, escrowKey, recordId);
+    if (!ChainUtil.isNumber(ratio) || ratio < 0 || ratio > 1) {
+      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
+    }
+    const accountKey = ChainUtil.toEscrowAccountName(sourceAccount, targetAccount, escrowKey);
+    const escrowServiceAccountName = ChainUtil.toServiceAccountName(
+        PredefinedDbPaths.ESCROW, PredefinedDbPaths.ESCROW, accountKey);
+    const serviceAccountBalancePath = this.getServiceAccountBalancePath(escrowServiceAccountName);
+    const escrowAmount = this.db.getValue(serviceAccountBalancePath);
+    const targetAmount = escrowAmount * ratio;
+    const sourceAmount = escrowAmount - targetAmount;
+    logger.debug(`  =>> escrowAmount: ${escrowAmount}, ratio: ${ratio}, ` +
+        `targetAmount: ${targetAmount}, sourceAmount: ${sourceAmount}`);
+    if (targetAmount > 0) {
+      const result = this.releaseInternal(
+          escrowServiceAccountName, targetAccount, targetAmount, auth, timestamp, transaction);
+      if (result !== true) {
+        this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
+        return;
+      }
+    }
+    if (sourceAmount > 0) {
+      const result = this.releaseInternal(
+          escrowServiceAccountName, sourceAccount, sourceAmount, auth, timestamp, transaction);
+      if (result !== true) {
+        this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
+        // TODO(lia): revert the release to target_account if there was any
+        return;
+      }
+    }
+    this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
   }
 
   getLatestShardReportPathFromValuePath(valuePath) {
@@ -729,14 +840,21 @@ class Functions {
     return true;
   }
 
-  getServiceAccountAdminPath(accountName) {
+  getServiceAccountPath(accountName) {
     const parsed = ChainUtil.parseServAcntName(accountName);
-    return `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/` +
-        `${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
+    return `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}`;
+  }
+
+  getServiceAccountAdminPath(accountName) {
+    return `${this.getServiceAccountPath(accountName)}/${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
   }
 
   getServiceAccountAdminAddrPath(accountName, adminAddr) {
     return `${this.getServiceAccountAdminPath(accountName)}/${adminAddr}`;
+  }
+
+  getServiceAccountBalancePath(accountName) {
+    return `${this.getServiceAccountPath(accountName)}/${PredefinedDbPaths.BALANCE}`;
   }
 
   getTransferValuePath(from, to, key) {
@@ -788,14 +906,39 @@ class Functions {
         `${PredefinedDbPaths.PAYMENTS_ADMIN}`);
   }
 
-  getPaymentPayRecordsResultPath(service, user, paymentKey, recordId) {
+  getPaymentPayRecordPath(service, user, paymentKey, recordId) {
     return (`${PredefinedDbPaths.PAYMENTS}/${service}/${user}/${paymentKey}/` +
-        `${PredefinedDbPaths.PAYMENTS_PAY}/${recordId}/${PredefinedDbPaths.PAYMENTS_RESULT}`);
+        `${PredefinedDbPaths.PAYMENTS_PAY}/${recordId}`);
   }
 
-  getPaymentClaimRecordsResultPath(service, user, paymentKey, recordId) {
+  getPaymentClaimRecordPath(service, user, paymentKey, recordId) {
     return (`${PredefinedDbPaths.PAYMENTS}/${service}/${user}/${paymentKey}/` +
-        `${PredefinedDbPaths.PAYMENTS_CLAIM}/${recordId}/${PredefinedDbPaths.PAYMENTS_RESULT}`);
+        `${PredefinedDbPaths.PAYMENTS_CLAIM}/${recordId}`);
+  }
+
+  getPaymentPayRecordResultPath(service, user, paymentKey, recordId) {
+    return (`${this.getPaymentPayRecordPath(service, user, paymentKey, recordId)}/` +
+        `${PredefinedDbPaths.PAYMENTS_RESULT}`);
+  }
+
+  getPaymentClaimRecordResultPath(service, user, paymentKey, recordId) {
+    return (`${this.getPaymentClaimRecordPath(service, user, paymentKey, recordId)}/` +
+        `${PredefinedDbPaths.PAYMENTS_RESULT}`);
+  }
+
+  getEscrowHoldRecordPath(source, target, escrowKey, recordId) {
+    return (`${PredefinedDbPaths.ESCROW}/${source}/${target}/${escrowKey}/` +
+        `${PredefinedDbPaths.ESCROW_HOLD}/${recordId}`);
+  }
+
+  getEscrowHoldRecordResultPath(source, target, escrowKey, recordId) {
+    return (`${this.getEscrowHoldRecordPath(source, target, escrowKey, recordId)}/` +
+        `${PredefinedDbPaths.ESCROW_RESULT}`);
+  }
+
+  getEscrowReleaseRecordResultPath(source, target, escrowKey, recordId) {
+    return (`${PredefinedDbPaths.ESCROW}/${source}/${target}/${escrowKey}/` +
+        `${PredefinedDbPaths.ESCROW_RELEASE}/${recordId}/${PredefinedDbPaths.ESCROW_RESULT}`);
   }
 
   getLatestShardReportPath(branchPath) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -507,7 +507,7 @@ class Functions {
     if (value.escrow_key !== undefined) {
       const escrowHoldPath = this.getEscrowHoldRecordPath(
           userServiceAccountName, value.target, value.escrow_key, timestamp);
-      result = this.setValueOrLog(escrowHoldPath, value.amount, auth, timestamp, transaction);
+      result = this.setValueOrLog(escrowHoldPath, { amount: value.amount }, auth, timestamp, transaction);
     } else {
       result = this.setServiceAccountTransferOrLog(
           userServiceAccountName, value.target, value.amount, auth, timestamp, transaction);

--- a/db/index.js
+++ b/db/index.js
@@ -35,7 +35,7 @@ const RuleUtil = require('./rule-util');
 class DB {
   constructor(stateRoot, stateVersion, bc, tp, isNodeDb, blockNumberSnapshot) {
     this.shardingPath = null;
-    this.isRootBlockchain = null;  // Is this the database of the root blockchain?
+    this.isRootBlockchain = null; // Is this the database of the root blockchain?
     this.stateRoot = stateRoot;
     this.stateVersion = stateVersion;
     this.setShardingPath(GenesisSharding[ShardingProperties.SHARDING_PATH]);

--- a/db/index.js
+++ b/db/index.js
@@ -35,7 +35,7 @@ const RuleUtil = require('./rule-util');
 class DB {
   constructor(stateRoot, stateVersion, bc, tp, isNodeDb, blockNumberSnapshot) {
     this.shardingPath = null;
-    this.isRootBlockchain = null; // Is this the database of the root blockchain?
+    this.isRootBlockchain = null;  // Is this the database of the root blockchain?
     this.stateRoot = stateRoot;
     this.stateVersion = stateVersion;
     this.setShardingPath(GenesisSharding[ShardingProperties.SHARDING_PATH]);

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -75,6 +75,14 @@ class RuleUtil {
     }
   }
 
+  toEscrowAccountName(source, target, escrowKey) {
+    return `${source}:${target}:${escrowKey}`;
+  }
+
+  toServiceAccountName(serviceType, serviceName, key) {
+    return `${serviceType}|${serviceName}|${key}`;
+  }
+
   parseServAcntName(accountName) {
     if (this.isString(accountName)) {
       const parsed = accountName.split('|');
@@ -88,6 +96,13 @@ class RuleUtil {
     } else {
       return [null, null, null];
     }
+  }
+
+  getServAcntAdminPath(accountName) {
+    const { PredefinedDbPaths } = require('../common/constants');
+    const parsed = this.parseServAcntName(accountName);
+    return `/${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/` +
+        `${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
   }
 
   getBalancePath(addrOrServAcnt) {

--- a/genesis-configs/base/genesis_functions.json
+++ b/genesis-configs/base/genesis_functions.json
@@ -41,6 +41,42 @@
       }
     }
   },
+  "escrow": {
+    "$source_account": {
+      "$target_account": {
+        "$escrow_key": {
+          "hold": {
+            "$record_id": {
+              ".function": {
+                "_hold": {
+                  "function_type": "NATIVE",
+                  "function_id": "_hold"
+                }
+              }
+            }
+          },
+          "open": {
+            ".function": {
+              "_openEscrow": {
+                "function_type": "NATIVE",
+                "function_id": "_openEscrow"
+              }
+            }
+          },
+          "release": {
+            "$record_id": {
+              ".function": {
+                "_release": {
+                  "function_type": "NATIVE",
+                  "function_id": "_release"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "payments": {
     "$service": {
       "$user_addr": {

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -91,7 +91,7 @@
             }
           },
           "open": {
-            ".write": "util.isCksumAddr(auth.addr) && data === null && util.isDict(newData) && util.isDict(newData.admin) && (util.isCksumAddr($source_account) || util.isServAcntName($source_account)) && (util.isCksumAddr($target_account) || util.isServAcntName($target_account))"
+            ".write": "util.isCksumAddr(auth.addr) && data === null && util.isDict(newData) && util.isDict(newData.admin) && Object.entries(newData.admin).every(([k, v]) => util.isCksumAddr(k) && v === true) && (util.isCksumAddr($source_account) || util.isServAcntName($source_account)) && (util.isCksumAddr($target_account) || util.isServAcntName($target_account))"
           },
           "release": {
             "$record_id": {

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -78,6 +78,33 @@
       }
     }
   },
+  "escrow": {
+    "$source_account": {
+      "$target_account": {
+        "$escrow_key": {
+          "hold": {
+            "$record_id": {
+              ".write": "((util.isServAcntName($source_account) && getValue(util.getServAcntAdminPath($source_account) + '/' + auth.addr) === true) || (util.isCksumAddr($source_account) && $source_account === auth.addr)) && getValue(util.getServAcntAdminPath(util.toServiceAccountName('escrow', 'escrow', util.toEscrowAccountName($source_account, $target_account, $escrow_key)))) !== null && data === null && util.isDict(newData)",
+              "result": {
+                ".write": "auth.fid === '_hold'"
+              }
+            }
+          },
+          "open": {
+            ".write": "util.isCksumAddr(auth.addr) && data === null && util.isDict(newData) && util.isDict(newData.admin) && (util.isCksumAddr($source_account) || util.isServAcntName($source_account)) && (util.isCksumAddr($target_account) || util.isServAcntName($target_account))"
+          },
+          "release": {
+            "$record_id": {
+              ".write": "getValue(util.getServAcntAdminPath(util.toServiceAccountName('escrow', 'escrow', util.toEscrowAccountName($source_account, $target_account, $escrow_key))) + '/' + auth.addr) === true && data === null && util.isDict(newData) && util.isNumber(newData.ratio) && 0 <= newData.ratio && newData.ratio <= 1",
+              "result": {
+                ".write": "auth.fid === '_release'"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "payments": {
     "$service": {
       "config": {
@@ -113,13 +140,14 @@
     "$service_type": {
       "$service_name": {
         "$key": {
+          ".write": "auth.fid === '_openEscrow'",
           "admin": {
             "$admin_addr": {
               ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
             }
           },
           "balance": {
-            ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
+            ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release'"
           }
         }
       }
@@ -138,7 +166,7 @@
       "$to": {
         "$key": {
           "value": {
-            ".write": "(auth.addr === $from || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue(util.getBalancePath($from)) >= newData"
+            ".write": "(auth.addr === $from || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue(util.getBalancePath($from)) >= newData"
           },
           "result": {
             ".write": "auth.fid === '_transfer'"

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -3145,13 +3145,13 @@ describe('Blockchain Node', () => {
           const source = `payments|test_service|${serviceUser}|0`;
           const target = serviceAdmin;
           const holdRef = `/escrow/${source}/${target}/1/hold/${key}`;
-          let paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 + 
+          const paymentBalance = parseOrLog(syncRequest('GET', server1 + 
               `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           let body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: holdRef,
             value: {
-              amount: paymentBalanceBefore
+              amount: paymentBalance
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(0);
@@ -3159,7 +3159,7 @@ describe('Blockchain Node', () => {
           // release
           key = Date.now();
           const releaseRef = `/escrow/${source}/${target}/1/release/${key}`;
-          paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 + 
+          const paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 + 
               `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 + 

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -3107,7 +3107,7 @@ describe('Blockchain Node', () => {
           expect(escrowServiceAccountBalance).to.equals(paymentBalanceBefore);
         });
 
-        it("admin account can write release (ratio = 0, refund to payments via _pay)", () => {
+        it("admin account can write release (ratio = 0, refund to payments via _transfer)", () => {
           const key = Date.now();
           const source = `payments|test_service|${serviceUser}|0`;
           const target = serviceAdmin;
@@ -3126,9 +3126,9 @@ describe('Blockchain Node', () => {
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(0);
           waitUntilTxFinalized(serverList, body.result.tx_hash);
-          const holdResult = parseOrLog(syncRequest('GET', server1 +
+          const releaseResult = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=${releaseRef}/result/code`).body.toString('utf-8')).result;
-          expect(holdResult).to.equals(FunctionResultCode.SUCCESS);
+          expect(releaseResult).to.equals(FunctionResultCode.SUCCESS);
           const escrowServiceAccountBalanceAfter = parseOrLog(syncRequest('GET',
               server1 + `/get_value?ref=/service_accounts/escrow/escrow/${source}:${target}:1/balance`)
               .body.toString('utf-8')).result;
@@ -3175,9 +3175,9 @@ describe('Blockchain Node', () => {
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(0);
           waitUntilTxFinalized(serverList, body.result.tx_hash);
-          const holdResult = parseOrLog(syncRequest('GET', server1 +
+          const releaseResult = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=${releaseRef}/result/code`).body.toString('utf-8')).result;
-          expect(holdResult).to.equals(FunctionResultCode.SUCCESS);
+          expect(releaseResult).to.equals(FunctionResultCode.SUCCESS);
           const escrowServiceAccountBalanceAfter = parseOrLog(syncRequest('GET',
               server1 + `/get_value?ref=/service_accounts/escrow/escrow/${source}:${target}:1/balance`)
               .body.toString('utf-8')).result;

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -3107,7 +3107,7 @@ describe('Blockchain Node', () => {
           expect(escrowServiceAccountBalance).to.equals(paymentBalanceBefore);
         });
 
-        it("admin account can write release (ratio = 0, refund to payments)", () => {
+        it("admin account can write release (ratio = 0, refund to payments via _pay)", () => {
           const key = Date.now();
           const source = `payments|test_service|${serviceUser}|0`;
           const target = serviceAdmin;

--- a/tools/escrow/config_gcp.js
+++ b/tools/escrow/config_gcp.js
@@ -1,0 +1,8 @@
+module.exports = {
+  endpointUrl: "http://dev-node.ainetwork.ai:8080",
+  sourceAddr: "0x07A43138CC760C85A5B1F115aa60eADEaa0bf417",
+  sourcePrivateKey: "0e9876c7e7966fb0237892eb2e890b4738d0e50adfcfe089ef31f5a1579d65cd",
+  targetAddr: "0x08Aed7AF9354435c38d52143EE50ac839D20696b",
+  serviceOwnerAddr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  serviceOwnerPrivateKey: "ee0b1315d446e5318eb6eb4e9d071cd12ef42d2956d546f9acbdc3b75c469640"
+};

--- a/tools/escrow/config_local.js
+++ b/tools/escrow/config_local.js
@@ -1,0 +1,8 @@
+module.exports = {
+  endpointUrl: "http://localhost:8081",
+  sourceAddr: "0x07A43138CC760C85A5B1F115aa60eADEaa0bf417",
+  sourcePrivateKey: "0e9876c7e7966fb0237892eb2e890b4738d0e50adfcfe089ef31f5a1579d65cd",
+  targetAddr: "0x08Aed7AF9354435c38d52143EE50ac839D20696b",
+  serviceOwnerAddr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  serviceOwnerPrivateKey: "ee0b1315d446e5318eb6eb4e9d071cd12ef42d2956d546f9acbdc3b75c469640"
+};

--- a/tools/escrow/sendHoldTx.js
+++ b/tools/escrow/sendHoldTx.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const { signAndSendTx, confirmTransaction } = require('../util');
+let config = {};
+
+function buildHoldTxBody(source, target, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/escrow/${source}/${target}/0/hold/${timestamp}`,
+      value: {
+        amount: 10000,
+      }
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+
+  const txBody = buildHoldTxBody(config.sourceAddr, config.targetAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.sourcePrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendHoldTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/tools/escrow/sendOpenEscrowTx.js
+++ b/tools/escrow/sendOpenEscrowTx.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const { signAndSendTx, confirmTransaction } = require('../util');
+
+let config = {};
+
+function buildOpenEscrowTxBody(source, target, address, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/escrow/${source}/${target}/0/open`,
+      value: {
+        admin: {
+          [address]: true
+        }
+      }
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+
+  const txBody = buildOpenEscrowTxBody(config.sourceAddr, config.targetAddr, config.serviceOwnerAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.serviceOwnerPrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendOpenEscrowTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/tools/escrow/sendReleaseTx.js
+++ b/tools/escrow/sendReleaseTx.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const { signAndSendTx, confirmTransaction } = require('../util');
+let config = {};
+
+function buildReleaseTxBody(source, target, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/escrow/${source}/${target}/0/release/${timestamp}`,
+      value: {
+        ratio: 0.5
+      }
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+
+  const txBody = buildReleaseTxBody(config.sourceAddr, config.targetAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.serviceOwnerPrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendReleaseTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/tools/payments/sendClaimTx.js
+++ b/tools/payments/sendClaimTx.js
@@ -2,14 +2,34 @@ const path = require('path');
 const { signAndSendTx, confirmTransaction } = require('../util');
 let config = {};
 
-function buildClaimTxBody(ownerAddr, userAddr, timestamp) {
+function buildClaimTxBody(ownerAddr, userAddr, timestamp, escrowKey) {
+  const value = {
+    amount: 10000,
+    target: ownerAddr
+  };
+  if (escrowKey !== undefined) {
+    value.escrow_key = escrowKey;
+  }
   return {
     operation: {
       type: 'SET_VALUE',
       ref: `/payments/test_service/${userAddr}/0/claim/${timestamp}`,
+      value: value
+    },
+    timestamp,
+    nonce: -1
+  };
+}
+
+function buildOpenEscrowTxBody(source, target, address, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/escrow/${source}/${target}/0/open`,
       value: {
-        amount: 10000,
-        target: ownerAddr
+        admin: {
+          [address]: true
+        }
       }
     },
     timestamp,
@@ -17,11 +37,24 @@ function buildClaimTxBody(ownerAddr, userAddr, timestamp) {
   }
 }
 
-async function sendTransaction() {
+async function sendTransaction(escrow) {
   console.log('\n*** sendTransaction():');
-  const timestamp = Date.now();
+  let timestamp = Date.now();
 
-  const txBody = buildClaimTxBody(config.serviceOwnerAddr, config.userAddr, timestamp);
+  if (escrow) {
+    const openEscrowTxBody = buildOpenEscrowTxBody(`payments|test_service|${config.userAddr}|0`,
+        config.serviceOwnerAddr, config.serviceOwnerAddr, timestamp);
+    console.log(`openEscrow tx body: ${JSON.stringify(openEscrowTxBody, null, 2)}`);
+    const openEscrowTxInfo = await signAndSendTx(config.endpointUrl, openEscrowTxBody, config.serviceOwnerPrivateKey);
+    if (!openEscrowTxInfo.success) {
+      console.log(`Open escrow failed: ${JSON.stringify(openEscrowTxInfo, null, 2)}`);
+      process.exit(0);
+    }
+    await confirmTransaction(config.endpointUrl, timestamp, openEscrowTxInfo.txHash);
+    timestamp = Date.now();
+  }
+
+  const txBody = buildClaimTxBody(config.serviceOwnerAddr, config.userAddr, timestamp, escrow ? '0' : undefined);
   console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
 
   const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.serviceOwnerPrivateKey);
@@ -32,15 +65,21 @@ async function sendTransaction() {
 }
 
 async function processArguments() {
-  if (process.argv.length !== 3) {
+  if (process.argv.length !== 3 && process.argv.length !== 4) {
+    usage();
+  }
+  if (process.argv.length === 4 && process.argv[3] !== '--escrow') {
+    console.log('Invalid option:', process.argv[3]);
     usage();
   }
   config = require(path.resolve(__dirname, process.argv[2]));
-  await sendTransaction();
+  await sendTransaction(process.argv[3]);
 }
 
 function usage() {
-  console.log('\nExample commandlines:\n  node sendClaimTx.js config_local.js\n')
+  console.log('\nExample commandlines:\n  node sendClaimTx.js config_local.js --escrow\n')
+  console.log('Options:')
+  console.log('  --escrow: Hold payments in escrow')
   process.exit(0)
 }
 

--- a/tools/payments/sendClaimTx.js
+++ b/tools/payments/sendClaimTx.js
@@ -73,7 +73,7 @@ async function processArguments() {
     usage();
   }
   config = require(path.resolve(__dirname, process.argv[2]));
-  await sendTransaction(process.argv[3]);
+  await sendTransaction(!!process.argv[3]);
 }
 
 function usage() {

--- a/tools/util.js
+++ b/tools/util.js
@@ -20,7 +20,9 @@ function signAndSendTx(endpointUrl, txBody, privateKey) {
       id: 0
     }
   ).then((resp) => {
-    const success = !ChainUtil.transactionFailed(_.get(resp, 'data.result'), null);
+    const success = Array.isArray(_.get(resp, 'data.result.result')) ?
+        !ChainUtil.transactionFailed(_.get(resp, 'data.result.result')) :
+        !ChainUtil.transactionFailed(_.get(resp, 'data.result.result.result', null));
     console.log(`result: ${JSON.stringify(success, null, 2)}`);
     return {txHash, signedTx, success};
   }).catch((err) => {

--- a/tools/util.js
+++ b/tools/util.js
@@ -20,9 +20,7 @@ function signAndSendTx(endpointUrl, txBody, privateKey) {
       id: 0
     }
   ).then((resp) => {
-    const success = Array.isArray(_.get(resp, 'data.result.result')) ?
-        !ChainUtil.transactionFailed(_.get(resp, 'data.result.result')) :
-        !ChainUtil.transactionFailed(_.get(resp, 'data.result.result.result', null));
+    const success = !ChainUtil.transactionFailed(_.get(resp, 'data.result.result.result', null));
     console.log(`result: ${JSON.stringify(success, null, 2)}`);
     return {txHash, signedTx, success};
   }).catch((err) => {


### PR DESCRIPTION
- Add escrow service type
  - _openEscrow
    -  ref: `/escrow/<source account>/<target account>/<key>/open`
    - value: `{ admin: { <address>: true } }`
  - _hold
    - ref: `/escrow/<source account>/<target account>/<key>/hold/<recordId>`
    - value: `{ amount: <number> }`
    - moves AIN from source account to escrow service account
  - _release
    - ref: `/escrow/<source account>/<target account>/<key>/release/<recordId>`
    - value: `{ ratio: <number> }`
    - moves AIN from escrow service account to source account and/or target account, according to the ratio (ratio = 1 means all goes to target, ratio = 0 means refund everything to source)
- Extend payments service
  - _pay now accepts 'source' field. If specified, it will try to transfer from 'source' to the payments service account
  - _claim can trigger _hold if 'escrow_key' field is in the value