### PR TITLE
Feature/block level nonce tracking

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -24,6 +24,7 @@ if (!fs.existsSync(PROTOCOL_VERSIONS)) {
 const PROTOCOL_VERSION_MAP = JSON.parse(fs.readFileSync(PROTOCOL_VERSIONS));
 const BLOCKCHAINS_DIR = path.resolve(__dirname, '../blockchain/blockchains');
 const HASH_DELIMITER = '#';
+const TX_NONCE_ERROR_CODES = [105, 405, 504, 604, 702];
 
 // Enums
 /**
@@ -85,6 +86,8 @@ const PredefinedDbPaths = {
   SAVE_LAST_TX_LAST_TX: '.last_tx',
   // Accounts & Transfer
   ACCOUNTS: 'accounts',
+  ACCOUNTS_NONCE: 'nonce',
+  ACCOUNTS_TIMESTAMP: 'timestamp',
   SERVICE_ACCOUNTS: 'service_accounts',
   SERVICE_ACCOUNTS_ADMIN: 'admin',
   BALANCE: 'balance',
@@ -593,6 +596,7 @@ module.exports = {
   P2P_PORT,
   LIGHTWEIGHT,
   HASH_DELIMITER,
+  TX_NONCE_ERROR_CODES,
   MessageTypes,
   BlockchainNodeStates,
   PredefinedDbPaths,

--- a/common/constants.js
+++ b/common/constants.js
@@ -24,7 +24,8 @@ if (!fs.existsSync(PROTOCOL_VERSIONS)) {
 const PROTOCOL_VERSION_MAP = JSON.parse(fs.readFileSync(PROTOCOL_VERSIONS));
 const BLOCKCHAINS_DIR = path.resolve(__dirname, '../blockchain/blockchains');
 const HASH_DELIMITER = '#';
-const TX_NONCE_ERROR_CODES = [105, 405, 504, 604, 702];
+const TX_NONCE_ERROR_CODE = 900;
+const TX_TIMESTAMP_ERROR_CODE = 901;
 
 // Enums
 /**
@@ -596,7 +597,8 @@ module.exports = {
   P2P_PORT,
   LIGHTWEIGHT,
   HASH_DELIMITER,
-  TX_NONCE_ERROR_CODES,
+  TX_NONCE_ERROR_CODE,
+  TX_TIMESTAMP_ERROR_CODE,
   MessageTypes,
   BlockchainNodeStates,
   PredefinedDbPaths,

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -316,7 +316,7 @@ class Consensus {
           return null;
         }
       } else {
-        logger.error(`[${LOG_HEADER}] tx: failure\n ${JSON.stringify(txRes)}`);
+        logger.debug(`[${LOG_HEADER}] tx: failure\n ${JSON.stringify(txRes)}`);
         invalidTransactions.push(tx);
         tempDb.setStateVersion(backupRoot, backupVersion);
         this.node.stateManager.deleteVersion(tempVersion);

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -303,8 +303,7 @@ class Consensus {
       } else {
         logger.error(`[${LOG_HEADER}] tx: failure\n ${JSON.stringify(txRes)}`);
         invalidTransactions.push(tx);
-        this.node.stateManager.renameVersion(backupVersion, tempVersion);
-        this.node.stateManager.deleteVersion(backupVersion);
+        tempDb.setStateVersion(backupRoot, backupVersion);
         backupRoot = this.node.stateManager.cloneVersion(tempVersion, backupVersion);
         if (!backupRoot) {
           logger.error(`[${LOG_HEADER}] Failed to clone state version: ${tempVersion}`);

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -239,16 +239,7 @@ class Consensus {
 
   executeLastVoteOrAbort(db, tx) {
     const LOG_HEADER = 'executeLastVoteOrAbort';
-    const dbVersion = db.stateVersion;
-    const backupVersion = this.node.stateManager.createUniqueVersionName(
-      `${StateVersions.BACKUP}:${dbVersion}`);
-    const backupRoot = this.node.stateManager.cloneVersion(dbVersion, backupVersion);
-    if (!backupRoot) {
-      logger.error(`[${LOG_HEADER}] Failed to clone state version: ${dbVersion}`);
-      return false;
-    }
     const txRes = db.executeTransaction(tx);
-    this.node.stateManager.deleteVersion(backupVersion);
     if (!ChainUtil.transactionFailed(txRes)) {
       logger.debug(`[${LOG_HEADER}] tx: success`);
       return true;

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -262,7 +262,6 @@ class Consensus {
     const tempVersion = this.node.stateManager.createUniqueVersionName(
         `${StateVersions.CONSENSUS_CREATE}:${lastBlock.number}:${blockNumber}`);
     const tempDb = this.node.createTempDb(baseVersion, tempVersion, lastBlock.number - 1);
-    logger.debug(`[${LOG_HEADER}] Created a temp state for tx checks`);
     const lastBlockInfo = this.blockPool.hashToBlockInfo[lastBlock.hash];
     logger.debug(`[${LOG_HEADER}] lastBlockInfo: ${JSON.stringify(lastBlockInfo, null, 2)}`);
     // FIXME(minsu or lia): When I am behind and a newly coming node is ahead of me, then I cannot
@@ -272,27 +271,49 @@ class Consensus {
     if (lastBlockInfo && lastBlockInfo.proposal) {
       lastVotes.unshift(lastBlockInfo.proposal);
     }
-    lastVotes.forEach((voteTx) => {
-      if (!ChainUtil.transactionFailed(tempDb.executeTransaction(voteTx))) {
+
+    const backupVersion = this.node.stateManager.createUniqueVersionName(
+      `${StateVersions.BACKUP}:${tempVersion}`);
+    let backupRoot = this.node.stateManager.cloneVersion(tempVersion, backupVersion);
+    if (!backupRoot) {
+      logger.error(`[${LOG_HEADER}] Failed to clone state version: ${tempVersion}`);
+    }
+    for (const voteTx of lastVotes) {
+      const txRes = tempDb.executeTransaction(voteTx);
+      if (!ChainUtil.transactionFailed(txRes)) {
         logger.debug(`[${LOG_HEADER}] last vote: success`);
       } else {
-        logger.error(`[${LOG_HEADER}] last vote: failed`);
+        logger.error(`[${LOG_HEADER}] last vote: failure\n ${JSON.stringify(txRes)}`);
+        this.node.stateManager.deleteVersion(backupVersion);
+        this.node.stateManager.deleteVersion(tempVersion);
+        return null;
       }
-    })
+    }
 
-    const transactions = this.node.tp.getValidTransactions(longestNotarizedChain);
+    // TODO(lia): restrict the size / number of txs
+    const transactions = this.node.tp.getValidTransactions(longestNotarizedChain, tempVersion);
     const validTransactions = [];
     const invalidTransactions = [];
-    transactions.forEach((tx) => {
+    for (const tx of transactions) {
       logger.debug(`[${LOG_HEADER}] Checking tx ${JSON.stringify(tx, null, 2)}`);
-      if (!ChainUtil.transactionFailed(tempDb.executeTransaction(tx))) {
+      const txRes = tempDb.executeTransaction(tx);
+      if (!ChainUtil.transactionFailed(txRes)) {
         logger.debug(`[${LOG_HEADER}] tx: success`);
         validTransactions.push(tx);
       } else {
-        logger.debug(`[${LOG_HEADER}] tx: failure`);
+        logger.error(`[${LOG_HEADER}] tx: failure\n ${JSON.stringify(txRes)}`);
         invalidTransactions.push(tx);
+        this.node.stateManager.renameVersion(backupVersion, tempVersion);
+        this.node.stateManager.deleteVersion(backupVersion);
+        backupRoot = this.node.stateManager.cloneVersion(tempVersion, backupVersion);
+        if (!backupRoot) {
+          logger.error(`[${LOG_HEADER}] Failed to clone state version: ${tempVersion}`);
+          this.node.stateManager.deleteVersion(tempVersion);
+          return null;
+        }
       }
-    })
+    }
+    this.node.stateManager.deleteVersion(backupVersion);
 
     // Once successfully executed txs (when submitted to tx pool) can become invalid
     // after some blocks are created. Remove those transactions from tx pool.
@@ -510,9 +531,9 @@ class Consensus {
       return false;
     }
     // TODO(lia): Check last_votes if they indeed voted for the previous block
-    // TODO(lia): Check the timestamps and nonces of the last_votes and transactions
     let baseVersion;
     let prevDb;
+    let isSnapDb = false;
     if (prevBlock.number === this.node.bc.lastBlockNumber()) {
       baseVersion = this.node.stateManager.getFinalVersion();
     } else if (this.blockPool.hashToDb.has(last_hash)) {
@@ -523,12 +544,15 @@ class Consensus {
         logger.error(`[${LOG_HEADER}] Previous db state doesn't exist`);
         return false;
       }
+      isSnapDb = true;
       baseVersion = prevDb.stateVersion;
-      this.node.destroyDb(prevDb);
     }
     const newVersion = this.node.stateManager.createUniqueVersionName(
         `${StateVersions.POOL}:${prevBlock.number}:${number}`);
     const newDb = this.node.createTempDb(baseVersion, newVersion, prevBlock.number);
+    if (isSnapDb) {
+      this.node.destroyDb(prevDb);
+    }
     if (!newDb.executeTransactionList(proposalBlock.last_votes)) {
       logger.error(`[${LOG_HEADER}] Failed to execute last votes`);
       this.node.destroyDb(newDb);
@@ -705,11 +729,11 @@ class Consensus {
       if (blockToFinalize.number <= this.node.bc.lastBlockNumber()) {
         continue;
       }
-      const versionToFinalize = this.blockPool.hashToDb.get(blockToFinalize.hash).stateVersion;
-      this.node.cloneAndFinalizeVersion(versionToFinalize, blockToFinalize.number);
       if (this.node.addNewBlock(blockToFinalize)) {
         logger.info(`[${LOG_HEADER}] Finalized a block of number ${blockToFinalize.number} and ` +
             `hash ${blockToFinalize.hash}`);
+        const versionToFinalize = this.blockPool.hashToDb.get(blockToFinalize.hash).stateVersion;
+        this.node.cloneAndFinalizeVersion(versionToFinalize, blockToFinalize.number);
       } else {
         logger.error(`[${LOG_HEADER}] Failed to finalize a block: ` +
             `${JSON.stringify(blockToFinalize, null, 2)}`);

--- a/db/index.js
+++ b/db/index.js
@@ -389,7 +389,7 @@ class DB {
   }
 
   updateAccountNonceAndTimestamp(address, nonce, timestamp) {
-    if (nonce === undefined || timestamp === undefined) return;
+    if (!ChainUtil.isNumber(nonce) || !ChainUtil.isNumber(timestamp)) return;
     const parsedNoncePath = ChainUtil.parsePath(
         `/${PredefinedDbPaths.ACCOUNTS}/${address}/${PredefinedDbPaths.ACCOUNTS_NONCE}`);
     const parsedTimestampPath = ChainUtil.parsePath(

--- a/db/index.js
+++ b/db/index.js
@@ -440,7 +440,7 @@ class DB {
     }
     const valueCopy = ChainUtil.isDict(value) ? JSON.parse(JSON.stringify(value)) : value;
     this.writeDatabase(fullPath, valueCopy);
-    // NOTE(lia): Allow recursive function triggering but no circular calls.
+    // NOTE(lia): Allow chained function triggering but no circular calls.
     if (auth && (auth.addr || auth.fid)) {
       this.func.triggerFunctions(localPath, valueCopy, auth, timestamp, Date.now(), transaction);
     }

--- a/db/index.js
+++ b/db/index.js
@@ -374,7 +374,7 @@ class DB {
     return resultList;
   }
 
-  getAccountsNonceAndTimestamp(address) {
+  getAccountNonceAndTimestamp(address) {
     let nonce = this.getValue(
         `/${PredefinedDbPaths.ACCOUNTS}/${address}/${PredefinedDbPaths.ACCOUNTS_NONCE}`, false);
     let timestamp = this.getValue(
@@ -425,7 +425,7 @@ class DB {
       return true;
     }
     if (!fromSetOp && transaction && auth && auth.addr && !auth.fid) {
-      const { nonce, timestamp: accountTimestamp } = this.getAccountsNonceAndTimestamp(auth.addr);
+      const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (transaction.tx_body.nonce >= 0 && transaction.tx_body.nonce !== nonce) {
         return ChainUtil.returnError(105, `Invalid nonce: ${transaction.tx_body.nonce}`);
       }
@@ -505,7 +505,7 @@ class DB {
       return true;
     }
     if (!fromSetOp && transaction && auth && auth.addr && !auth.fid) {
-      const { nonce, timestamp: accountTimestamp } = this.getAccountsNonceAndTimestamp(auth.addr);
+      const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (transaction.tx_body.nonce >= 0 && transaction.tx_body.nonce !== nonce) {
         return ChainUtil.returnError(405, `Invalid nonce: ${transaction.tx_body.nonce}`);
       }
@@ -545,7 +545,7 @@ class DB {
       return true;
     }
     if (!fromSetOp && transaction && auth && auth.addr && !auth.fid) {
-      const { nonce, timestamp: accountTimestamp } = this.getAccountsNonceAndTimestamp(auth.addr);
+      const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (transaction.tx_body.nonce >= 0 && transaction.tx_body.nonce !== nonce) {
         return ChainUtil.returnError(504, `Invalid nonce: ${transaction.tx_body.nonce}`);
       }
@@ -583,7 +583,7 @@ class DB {
       return true;
     }
     if (!fromSetOp && transaction && auth && auth.addr && !auth.fid) {
-      const { nonce, timestamp: accountTimestamp } = this.getAccountsNonceAndTimestamp(auth.addr);
+      const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (transaction.tx_body.nonce >= 0 && transaction.tx_body.nonce !== nonce) {
         return ChainUtil.returnError(604, `Invalid nonce: ${transaction.tx_body.nonce}`);
       }
@@ -608,7 +608,7 @@ class DB {
   set(opList, auth, timestamp, transaction) {
     let ret = true;
     if (transaction && auth && auth.addr && !auth.fid) {
-      const { nonce, timestamp: accountTimestamp } = this.getAccountsNonceAndTimestamp(auth.addr);
+      const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (transaction.tx_body.nonce >= 0 && transaction.tx_body.nonce !== nonce) {
         return ChainUtil.returnError(702, `Invalid nonce: ${transaction.tx_body.nonce}`);
       }

--- a/db/index.js
+++ b/db/index.js
@@ -774,7 +774,7 @@ class DB {
       evalRuleRes = !!this.evalRuleString(
         matched.closestRule.config, matched.pathVars, data, newData, auth, timestamp);
       if (!evalRuleRes) {
-        logger.error(`[${LOG_HEADER}] evalRuleRes ${evalRuleRes}, ` +
+        logger.debug(`[${LOG_HEADER}] evalRuleRes ${evalRuleRes}, ` +
           `matched: ${JSON.stringify(matched, null, 2)}, data: ${JSON.stringify(data)}, ` +
           `newData: ${JSON.stringify(newData)}, auth: ${JSON.stringify(auth)}, ` +
           `timestamp: ${timestamp}\n`);

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -880,9 +880,6 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, "some value with nonce unordered");
       })
 
-      // TODO(seo): Uncomment below once https://github.com/ainblockchain/ain-blockchain/issues/228
-      //            is fixed.
-      /*
       it('set_value with nonce strictly ordered', () => {
         const nonce = parseOrLog(
             syncRequest('GET', server1 + '/get_nonce').body.toString('utf-8')).result;
@@ -906,7 +903,6 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8')).result;
         assert.deepEqual(resultAfter, "some value with nonce strictly ordered");
       })
-      */
 
       it('set_value with failing operation', () => {
         // Check the original value.

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -49,28 +49,28 @@ const ENV_VARIABLES = [
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
     PORT: 9091, P2P_PORT: 6001,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0, EPOCH_MS: 1000, DEBUG: false,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
     PORT: 9092, P2P_PORT: 6002,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1, EPOCH_MS: 1000, DEBUG: false,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
     PORT: 9093, P2P_PORT: 6003,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2, EPOCH_MS: 1000, DEBUG: false,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
     PORT: 9094, P2P_PORT: 6004,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3, EPOCH_MS: 1000, DEBUG: false,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
@@ -154,7 +154,6 @@ function setUp() {
           }
         }
       ],
-      nonce: -1,
     }
   }).body.toString('utf-8')).result;
   assert.equal(_.get(res, 'result'), true);
@@ -188,7 +187,6 @@ function cleanUp() {
           value: null
         },
       ],
-      nonce: -1,
     }
   }).body.toString('utf-8')).result;
   assert.equal(_.get(res, 'result'), true);
@@ -250,7 +248,6 @@ function setUpForSharding(shardingConfig) {
           value: shardingConfig
         }
       ],
-      nonce: -1,
     }
   }).body.toString('utf-8')).result;
   assert.equal(_.get(res, 'result'), true);
@@ -488,7 +485,7 @@ describe('Sharding', () => {
         waitForNewBlocks(server2, sharding.reporting_period);
         console.log(`Restarting server[0]...`);
         server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2]);
-        waitForNewBlocks(server2, sharding.reporting_period);
+        waitForNewBlocks(server2, sharding.reporting_period * 2);
         waitUntilNodeSyncs(server1);
         waitForNewBlocks(server1, sharding.reporting_period);
         const reportsAfter = parseOrLog(syncRequest(

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -350,19 +350,9 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     },
 
     ain_getNonce: function(args, done) {
-      const address = args.address;
-      if (args.from === 'pending') {
-        if (ChainUtil.areSameAddrs(p2pServer.node.account.address, address)) {
-          done(null, addProtocolVersion({result: p2pServer.node.nonce}));
-        } else {
-          const nonce = node.tp.pendingNonceTracker[address];
-          done(null, addProtocolVersion({result: nonce === undefined ? -1 : nonce}));
-        }
-      } else {
-        // get the "committed nonce" by default
-        const nonce = node.tp.committedNonceTracker[address];
-        done(null, addProtocolVersion({result: nonce === undefined ? -1 : nonce}));
-      }
+      done(null, addProtocolVersion({
+          result: p2pServer.node.getNonceForAddr(args.address, args.from === 'pending')
+        }));
     },
 
     ain_isValidator: function(args, done) {

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -2,6 +2,7 @@
 
 const semver = require('semver');
 const sizeof = require('object-sizeof');
+const _ = require('lodash');
 const {
   CURRENT_PROTOCOL_VERSION,
   BlockchainNodeStates,
@@ -15,7 +16,6 @@ const {
   ConsensusConsts,
 } = require('../consensus/constants');
 const Transaction = require('../tx-pool/transaction');
-const ChainUtil = require('../common/chain-util');
 
 /**
  * Defines the list of funtions which are accessibly to clients through the
@@ -208,11 +208,14 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
         if (transactionInfo.status === TransactionStatus.BLOCK_STATUS) {
           const block = node.bc.getBlockByNumber(transactionInfo.number);
           const index = transactionInfo.index;
-          transactionInfo.transaction = block.transactions[index];
+          if (index >= 0) {
+            transactionInfo.transaction = block.transactions[index];
+          } else {
+            transactionInfo.transaction = _.find(block.last_votes, (tx) => tx.hash === args.hash);
+          }
         } else if (transactionInfo.status === TransactionStatus.POOL_STATUS) {
           const address = transactionInfo.address;
-          const index = transactionInfo.index;
-          transactionInfo.transaction = node.tp.transactions[address][index];
+          transactionInfo.transaction = _.find(node.tp.transactions[address], (tx) => tx.hash === args.hash);
         }
       }
       done(null, addProtocolVersion({result: transactionInfo}));

--- a/node/index.js
+++ b/node/index.js
@@ -5,7 +5,8 @@ const logger = require('../logger')('NODE');
 const {
   PORT,
   ACCOUNT_INDEX,
-  TX_NONCE_ERROR_CODES,
+  TX_NONCE_ERROR_CODE,
+  TX_TIMESTAMP_ERROR_CODE,
   BlockchainNodeStates,
   PredefinedDbPaths,
   ShardingProperties,
@@ -350,7 +351,8 @@ class BlockchainNode {
     if (ChainUtil.transactionFailed(result)) {
       logger.info(`[${LOG_HEADER}] FAILED TRANSACTION: ${JSON.stringify(tx, null, 2)}\n ` +
           `WITH RESULT:${JSON.stringify(result)}`);
-      if (TX_NONCE_ERROR_CODES.includes(_.get(result, 'code'))) {
+      const errorCode = _.get(result, 'code');
+      if (errorCode === TX_NONCE_ERROR_CODE || errorCode === TX_TIMESTAMP_ERROR_CODE) {
         this.tp.addTransaction(tx);
       }
     } else {

--- a/node/index.js
+++ b/node/index.js
@@ -261,13 +261,13 @@ class BlockchainNode {
     *                                        not
     * @return {Transaction} Instance of the transaction class
     */
-  createTransaction(txBody, baseDb) {
+  createTransaction(txBody) {
     const LOG_HEADER = 'createTransaction';
 
     if (Transaction.isBatchTxBody(txBody)) {
       const txList = [];
       for (const subTxBody of txBody.tx_body_list) {
-        const createdTx = this.createSingleTransaction(subTxBody, baseDb);
+        const createdTx = this.createSingleTransaction(subTxBody);
         if (createdTx === null) {
           logger.info(`[${LOG_HEADER}] Failed to create a transaction with subTx: ` +
               `${JSON.stringify(subTxBody, null, 2)}`);
@@ -277,7 +277,7 @@ class BlockchainNode {
       }
       return { tx_list: txList };
     }
-    const createdTx = this.createSingleTransaction(txBody, baseDb);
+    const createdTx = this.createSingleTransaction(txBody);
     if (createdTx === null) {
       logger.info(`[${LOG_HEADER}] Failed to create a transaction with txBody: ` +
           `${JSON.stringify(txBody, null, 2)}`);
@@ -286,10 +286,9 @@ class BlockchainNode {
     return createdTx;
   }
 
-  createSingleTransaction(txBody, baseDb) {
+  createSingleTransaction(txBody) {
     if (txBody.nonce === undefined) {
-      const db = baseDb ? baseDb : this.db;
-      const { nonce } = db.getAccountNonceAndTimestamp(this.account.address);
+      const { nonce } = this.db.getAccountNonceAndTimestamp(this.account.address);
       txBody.nonce = nonce;
     }
     if (txBody.timestamp === undefined) {

--- a/node/index.js
+++ b/node/index.js
@@ -22,7 +22,7 @@ const TransactionPool = require('../tx-pool');
 const StateManager = require('../db/state-manager');
 const DB = require('../db');
 const Transaction = require('../tx-pool/transaction');
-const { isCksumAddr } = require('../common/chain-util');
+const { isValAddr, toCksumAddr } = require('../common/chain-util');
 
 class BlockchainNode {
   constructor() {
@@ -221,16 +221,17 @@ class BlockchainNode {
   }
 
   getNonceForAddr(address, pending) {
-    if (!isCksumAddr(address)) return -1;
+    if (!isValAddr(address)) return -1;
+    const cksumAddr = toCksumAddr(address);
     if (pending) {
-      const { nonce } = this.db.getAccountNonceAndTimestamp(address);
+      const { nonce } = this.db.getAccountNonceAndTimestamp(cksumAddr);
       return nonce;
     }
-    if (address === this.account.address) {
+    if (cksumAddr === this.account.address) {
       return this.nonce;
     }
     const nonce = this.getValueWithStateVersion(
-        `${PredefinedDbPaths.ACCOUNTS}/${address}/${PredefinedDbPaths.ACCOUNTS_NONCE}`,
+        `${PredefinedDbPaths.ACCOUNTS}/${cksumAddr}/${PredefinedDbPaths.ACCOUNTS_NONCE}`,
         false, this.stateManager.finalVersion);
     return nonce === null ? 0 : nonce;
   }

--- a/node/index.js
+++ b/node/index.js
@@ -132,6 +132,8 @@ class BlockchainNode {
         logger.error(`[${LOG_HEADER}] Failed to delete version: ${oldVersion}`);
       }
     }
+    const newNonce = this.db.getAccountNonceAndTimestamp(this.account.address).nonce;
+    this.nonce = newNonce;
     return true;
   }
 
@@ -163,8 +165,6 @@ class BlockchainNode {
     }
     const nodeVersion = `${StateVersions.NODE}:${blockNumber}`;
     this.syncDb(nodeVersion);
-    const newNonce = this.db.getAccountNonceAndTimestamp(this.account.address).nonce;
-    this.nonce = newNonce;
   }
 
   dumpFinalVersion(withDetails) {

--- a/node/index.js
+++ b/node/index.js
@@ -114,8 +114,8 @@ class BlockchainNode {
     return this.stateManager.deleteVersion(db.stateVersion);
   }
 
-  syncDb(newVersion) {
-    const LOG_HEADER = 'syncDb';
+  syncDbAndNonce(newVersion) {
+    const LOG_HEADER = 'syncDbAndNonce';
 
     const oldVersion = this.db.stateVersion;
     if (newVersion === oldVersion) {
@@ -165,7 +165,7 @@ class BlockchainNode {
       }
     }
     const nodeVersion = `${StateVersions.NODE}:${blockNumber}`;
-    this.syncDb(nodeVersion);
+    this.syncDbAndNonce(nodeVersion);
   }
 
   dumpFinalVersion(withDetails) {

--- a/node/index.js
+++ b/node/index.js
@@ -163,7 +163,7 @@ class BlockchainNode {
     }
     const nodeVersion = `${StateVersions.NODE}:${blockNumber}`;
     this.syncDb(nodeVersion);
-    const newNonce = this.db.getAccountsNonceAndTimestamp(this.account.address).nonce;
+    const newNonce = this.db.getAccountNonceAndTimestamp(this.account.address).nonce;
     this.nonce = newNonce;
   }
 
@@ -222,7 +222,7 @@ class BlockchainNode {
   getNonceForAddr(address, pending) {
     if (!isCksumAddr(address)) return -1;
     if (pending) {
-      const { nonce } = this.db.getAccountsNonceAndTimestamp(address);
+      const { nonce } = this.db.getAccountNonceAndTimestamp(address);
       return nonce;
     }
     if (address === this.account.address) {
@@ -289,7 +289,7 @@ class BlockchainNode {
   createSingleTransaction(txBody, baseDb) {
     if (txBody.nonce === undefined) {
       const db = baseDb ? baseDb : this.db;
-      const { nonce } = db.getAccountsNonceAndTimestamp(this.account.address);
+      const { nonce } = db.getAccountNonceAndTimestamp(this.account.address);
       txBody.nonce = nonce;
     }
     if (txBody.timestamp === undefined) {

--- a/node/index.js
+++ b/node/index.js
@@ -323,10 +323,10 @@ class BlockchainNode {
           logger.error(`[${LOG_HEADER}] Failed to finalize version: ${backupVersion}`);
         }
       }
+      this.db.setStateVersion(backupRoot, backupVersion);
       if (!this.stateManager.deleteVersion(this.db.stateVersion)) {
         logger.error(`[${LOG_HEADER}] Failed to delete version: ${this.db.stateVersion}`);
       }
-      this.db.setStateVersion(backupRoot, backupVersion);
     } else {
       if (!this.stateManager.deleteVersion(backupVersion)) {
         logger.error(`[${LOG_HEADER}] Failed to delete version: ${backupVersion}`);

--- a/node/index.js
+++ b/node/index.js
@@ -323,6 +323,9 @@ class BlockchainNode {
           logger.error(`[${LOG_HEADER}] Failed to finalize version: ${backupVersion}`);
         }
       }
+      if (!this.stateManager.deleteVersion(this.db.stateVersion)) {
+        logger.error(`[${LOG_HEADER}] Failed to delete version: ${this.db.stateVersion}`);
+      }
       this.db.setStateVersion(backupRoot, backupVersion);
     } else {
       if (!this.stateManager.deleteVersion(backupVersion)) {

--- a/node/index.js
+++ b/node/index.js
@@ -1,9 +1,11 @@
 /* eslint guard-for-in: "off" */
 const ainUtil = require('@ainblockchain/ain-util');
+const _ = require('lodash');
 const logger = require('../logger')('NODE');
 const {
   PORT,
   ACCOUNT_INDEX,
+  TX_NONCE_ERROR_CODES,
   BlockchainNodeStates,
   PredefinedDbPaths,
   ShardingProperties,
@@ -19,6 +21,7 @@ const TransactionPool = require('../tx-pool');
 const StateManager = require('../db/state-manager');
 const DB = require('../db');
 const Transaction = require('../tx-pool/transaction');
+const { isCksumAddr } = require('../common/chain-util');
 
 class BlockchainNode {
   constructor() {
@@ -42,7 +45,7 @@ class BlockchainNode {
     this.stateManager = new StateManager();
     const initialVersion = `${StateVersions.NODE}:${this.bc.lastBlockNumber()}`;
     this.db = this.createDb(StateVersions.EMPTY, initialVersion, this.bc, this.tp, false, true);
-    this.nonce = null;
+    this.nonce = null;  // nonce from current final version
     this.state = BlockchainNodeStates.STARTING;
   }
 
@@ -75,9 +78,9 @@ class BlockchainNode {
         this.createDb(StateVersions.EMPTY, StateVersions.START, this.bc, this.tp, true);
     startingDb.initDbStates();
     this.executeChainOnDb(startingDb);
-    this.nonce = this.getNonce();
+    this.nonce = this.getNonceFromChain();
     this.cloneAndFinalizeVersion(StateVersions.START, this.bc.lastBlockNumber());
-    this.db.executeTransactionList(this.tp.getValidTransactions());
+    this.db.executeTransactionList(this.tp.getValidTransactions(null, this.stateManager.finalVersion));
     this.state = BlockchainNodeStates.SYNCING;
     return lastBlockWithoutProposal;
   }
@@ -159,7 +162,9 @@ class BlockchainNode {
       }
     }
     const nodeVersion = `${StateVersions.NODE}:${blockNumber}`;
-    this.syncDb(nodeVersion)
+    this.syncDb(nodeVersion);
+    const newNonce = this.db.getAccountsNonceAndTimestamp(this.account.address).nonce;
+    this.nonce = newNonce;
   }
 
   dumpFinalVersion(withDetails) {
@@ -190,8 +195,8 @@ class BlockchainNode {
         versionRoot, PredefinedDbPaths.OWNERS_ROOT, refPath, isGlobal, this.db.shardingPath);
   }
 
-  getNonce() {
-    const LOG_HEADER = 'getNonce';
+  getNonceFromChain() {
+    const LOG_HEADER = 'getNonceFromChain';
 
     // TODO (Chris): Search through all blocks for any previous nonced transaction with current
     //               publicKey
@@ -212,6 +217,21 @@ class BlockchainNode {
 
     logger.info(`[${LOG_HEADER}] Setting nonce to ${nonce}`);
     return nonce;
+  }
+
+  getNonceForAddr(address, pending) {
+    if (!isCksumAddr(address)) return -1;
+    if (pending) {
+      const { nonce } = this.db.getAccountsNonceAndTimestamp(address);
+      return nonce;
+    }
+    if (address === this.account.address) {
+      return this.nonce;
+    }
+    const nonce = this.getValueWithStateVersion(
+        `${PredefinedDbPaths.ACCOUNTS}/${address}/${PredefinedDbPaths.ACCOUNTS_NONCE}`,
+        false, this.stateManager.finalVersion);
+    return nonce === null ? 0 : nonce;
   }
 
   getSharding() {
@@ -241,13 +261,13 @@ class BlockchainNode {
     *                                        not
     * @return {Transaction} Instance of the transaction class
     */
-  createTransaction(txBody) {
+  createTransaction(txBody, baseDb) {
     const LOG_HEADER = 'createTransaction';
 
     if (Transaction.isBatchTxBody(txBody)) {
       const txList = [];
       for (const subTxBody of txBody.tx_body_list) {
-        const createdTx = this.createSingleTransaction(subTxBody);
+        const createdTx = this.createSingleTransaction(subTxBody, baseDb);
         if (createdTx === null) {
           logger.info(`[${LOG_HEADER}] Failed to create a transaction with subTx: ` +
               `${JSON.stringify(subTxBody, null, 2)}`);
@@ -257,7 +277,7 @@ class BlockchainNode {
       }
       return { tx_list: txList };
     }
-    const createdTx = this.createSingleTransaction(txBody);
+    const createdTx = this.createSingleTransaction(txBody, baseDb);
     if (createdTx === null) {
       logger.info(`[${LOG_HEADER}] Failed to create a transaction with txBody: ` +
           `${JSON.stringify(txBody, null, 2)}`);
@@ -266,9 +286,11 @@ class BlockchainNode {
     return createdTx;
   }
 
-  createSingleTransaction(txBody) {
+  createSingleTransaction(txBody, baseDb) {
     if (txBody.nonce === undefined) {
-      txBody.nonce = this.nonce++;
+      const db = baseDb ? baseDb : this.db;
+      const { nonce } = db.getAccountsNonceAndTimestamp(this.account.address);
+      txBody.nonce = nonce;
     }
     if (txBody.timestamp === undefined) {
       txBody.timestamp = Date.now();
@@ -329,6 +351,9 @@ class BlockchainNode {
     if (ChainUtil.transactionFailed(result)) {
       logger.info(`[${LOG_HEADER}] FAILED TRANSACTION: ${JSON.stringify(tx, null, 2)}\n ` +
           `WITH RESULT:${JSON.stringify(result)}`);
+      if (TX_NONCE_ERROR_CODES.includes(_.get(result, 'code'))) {
+        this.tp.addTransaction(tx);
+      }
     } else {
       this.tp.addTransaction(tx);
     }
@@ -339,9 +364,6 @@ class BlockchainNode {
   addNewBlock(block) {
     if (this.bc.addNewBlockToChain(block)) {
       this.tp.cleanUpForNewBlock(block);
-      const newVersion = `${StateVersions.NODE}:${block.number}`;
-      this.syncDb(newVersion);
-      this.tp.updateNonceTrackers(block.transactions);
       this.tp.checkRemoteTransactions();
       return true;
     }
@@ -422,7 +444,6 @@ class BlockchainNode {
       this.cloneAndFinalizeVersion(tempDb.stateVersion, lastBlockNumber);
       for (const block of validBlocks) {
         this.tp.cleanUpForNewBlock(block);
-        this.tp.updateNonceTrackers(block.transactions);
       }
     } else {
       logger.info(`[${LOG_HEADER}] No blocks to apply.`);
@@ -445,7 +466,6 @@ class BlockchainNode {
         logger.error(`[${LOG_HEADER}] Failed to execute transactions`)
       }
       this.tp.cleanUpForNewBlock(block);
-      this.tp.updateNonceTrackers(transactions);
     });
   }
 }

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -204,8 +204,6 @@ class P2pServer {
     return {
       txPoolSize: this.node.tp.getPoolSize(),
       txTrackerSize: Object.keys(this.node.tp.transactionTracker).length,
-      committedNonceTrackerSize: Object.keys(this.node.tp.committedNonceTracker).length,
-      pendingNonceTrackerSize: Object.keys(this.node.tp.pendingNonceTracker).length,
     };
   }
 

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -126,10 +126,10 @@ class TransactionPool {
         // sort transactions
         addrToTxList[address].sort((a, b) => {
           if (a.tx_body.nonce === b.tx_body.nonce) {
-            if (a.tx_body.nonce >= -1) { // both strictly ordered / unordered
+            if (a.tx_body.nonce >= 0) { // both strictly ordered
               return 0;
             }
-            return a.tx_body.timestamp - b.tx_body.timestamp; // both loosely ordered
+            return a.tx_body.timestamp - b.tx_body.timestamp; // both loosely ordered / unordered
           }
           if (a.tx_body.nonce >= 0 && b.tx_body.nonce >= 0) { // both strictly ordered
             return a.tx_body.nonce - b.tx_body.nonce;

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -118,7 +118,7 @@ class TransactionPool {
             return a.hash === b.hash;
           });
       // exclude consensus transactions
-      filteredTransactions = this.excludeConsensusTransactions(filteredTransactions);
+      filteredTransactions = TransactionPool.excludeConsensusTransactions(filteredTransactions);
       if (!filteredTransactions.length) {
         delete addrToTxList[address];
       } else {
@@ -168,15 +168,15 @@ class TransactionPool {
       addrToTxList[addr] = newTxList;
     }
     // Merge lists of transactions while ordering by timestamp. Initial ordering by nonce is preserved.
-    return this.mergeMultipleSortedArrays(Object.values(addrToTxList));
+    return TransactionPool.mergeMultipleSortedArrays(Object.values(addrToTxList));
   }
 
-  mergeMultipleSortedArrays(arrays) {
+  static mergeMultipleSortedArrays(arrays) {
     while (arrays.length > 1) {
       const newArr = [];
       for (let i = 0; i < arrays.length; i += 2) {
         if (i + 1 < arrays.length) {
-          newArr.push(this.mergeTwoSortedArrays(arrays[i], arrays[i + 1]));
+          newArr.push(TransactionPool.mergeTwoSortedArrays(arrays[i], arrays[i + 1]));
         } else {
           newArr.push(arrays[i]);
         }
@@ -186,7 +186,7 @@ class TransactionPool {
     return arrays.length === 1 ? arrays[0] : [];
   }
 
-  mergeTwoSortedArrays(arr1, arr2) {
+  static mergeTwoSortedArrays(arr1, arr2) {
     const newArr = [];
     let i = 0;
     let j = 0;

--- a/unittest/block-pool.test.js
+++ b/unittest/block-pool.test.js
@@ -65,15 +65,17 @@ describe("BlockPool", () => {
     const block = Block.create(
         lastBlock.hash, [], [], lastBlock.number + 1, lastBlock.epoch + 1, '', addr, {[addr]: 100000});
     const proposalTx = getTransaction(node1, {
-        operation: 'SET_VALUE',
-        ref: `/consensus/number/${block.number}/propose`,
-        value: {
-          number: block.number,
-          epoch: block.epoch,
-          validators: {[addr]: 100000},
-          total_at_stake: 100000,
-          proposer: addr,
-          block_hash: block.hash
+        operation: {
+          type: 'SET_VALUE',
+          ref: `/consensus/number/${block.number}/propose`,
+          value: {
+            number: block.number,
+            epoch: block.epoch,
+            validators: {[addr]: 100000},
+            total_at_stake: 100000,
+            proposer: addr,
+            block_hash: block.hash
+          }
         }
       }
     );
@@ -90,15 +92,17 @@ describe("BlockPool", () => {
     const block = Block.create(
         lastBlock.hash, [], [], lastBlock.number + 1, lastBlock.epoch + 1, '', addr, {[addr]: 100000});
     const proposalTx = getTransaction(node1, {
-        operation: 'SET_VALUE',
-        ref: `/consensus/number/${block.number}/propose`,
-        value: {
-          number: block.number,
-          epoch: block.epoch,
-          validators: {[addr]: 100000},
-          total_at_stake: 100000,
-          proposer: addr,
-          block_hash: block.hash
+        operation: {
+          type: 'SET_VALUE',
+          ref: `/consensus/number/${block.number}/propose`,
+          value: {
+            number: block.number,
+            epoch: block.epoch,
+            validators: {[addr]: 100000},
+            total_at_stake: 100000,
+            proposer: addr,
+            block_hash: block.hash
+          }
         }
       }
     );

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -1397,6 +1397,10 @@ describe("DB operations", () => {
 
   describe("batch operations", () => {
     it("when batch applied successfully", () => {
+      let now = Date.now();
+      const address = node.account.address;
+      let nonce = node.db.getValue(`/accounts/${address}/nonce`);
+      if (nonce === null) nonce = 0;
       assert.deepEqual(node.db.batch([
         {
           tx_body: {
@@ -1406,8 +1410,11 @@ describe("DB operations", () => {
               value: {
                 "new": 12345
               }
-            }
-          }
+            },
+            nonce: nonce++,
+            timestamp: now++
+          },
+          address
         },
         {
           tx_body: {
@@ -1415,8 +1422,11 @@ describe("DB operations", () => {
               type: "INC_VALUE",
               ref: "test/increment/value",
               value: 10
-            }
-          }
+            },
+            nonce: nonce++,
+            timestamp: now++
+          },
+          address
         },
         {
           tx_body: {
@@ -1424,8 +1434,11 @@ describe("DB operations", () => {
               type: "DEC_VALUE",
               ref: "test/decrement/value",
               value: 10
-            }
-          }
+            },
+            nonce: nonce++,
+            timestamp: now++
+          },
+          address
         },
         {
           tx_body: {
@@ -1437,8 +1450,11 @@ describe("DB operations", () => {
                   "fid": "other function config"
                 }
               }
-            }
-          }
+            },
+            nonce: nonce++,
+            timestamp: now++
+          },
+          address
         },
         {
           tx_body: {
@@ -1448,8 +1464,11 @@ describe("DB operations", () => {
               value: {
                 ".write": "other rule config"
               }
-            }
-          }
+            },
+            nonce: nonce++,
+            timestamp: now++
+          },
+          address
         },
         {
           tx_body: {
@@ -1459,7 +1478,9 @@ describe("DB operations", () => {
               value: {
                 ".owner": "other owner config"
               }
-            }
+            },
+            nonce: -1,
+            timestamp: now++
           },
           address: 'abcd'
         }
@@ -2622,7 +2643,7 @@ describe("DB sharding config", () => {
 
     it("setFunction with isGlobal = true", () => {
       expect(node.db.setFunction(
-          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }, true))
+          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }, null, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), newFunc);
@@ -2630,7 +2651,7 @@ describe("DB sharding config", () => {
 
     it("setFunction with isGlobal = true and non-existing path", () => {
       expect(node.db.setFunction(
-          "some/non-existing/path", funcChange, { addr: 'known_user' }, true))
+          "some/non-existing/path", funcChange, { addr: 'known_user' }, null, true))
         .to.equal(true);
     })
 
@@ -2721,14 +2742,14 @@ describe("DB sharding config", () => {
 
     it("setRule with isGlobal = true", () => {
       expect(node.db.setRule(
-          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, true))
+          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, null, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), newRule);
     })
 
     it("setRule with isGlobal = true and non-existing path", () => {
-      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, true))
+      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, null, true))
         .to.equal(true);
     })
 
@@ -2851,14 +2872,14 @@ describe("DB sharding config", () => {
 
     it("setOwner with isGlobal = true", () => {
       expect(node.db.setOwner(
-          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, true))
+          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, null, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), newOwner);
     })
 
     it("setOwner with isGlobal = true and non-existing path", () => {
-      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' }, true))
+      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' }, null, true))
         .to.equal(true);
     })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -2643,7 +2643,7 @@ describe("DB sharding config", () => {
 
     it("setFunction with isGlobal = true", () => {
       expect(node.db.setFunction(
-          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }, null, true))
+          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), newFunc);
@@ -2651,7 +2651,7 @@ describe("DB sharding config", () => {
 
     it("setFunction with isGlobal = true and non-existing path", () => {
       expect(node.db.setFunction(
-          "some/non-existing/path", funcChange, { addr: 'known_user' }, null, true))
+          "some/non-existing/path", funcChange, { addr: 'known_user' }, true))
         .to.equal(true);
     })
 
@@ -2742,14 +2742,14 @@ describe("DB sharding config", () => {
 
     it("setRule with isGlobal = true", () => {
       expect(node.db.setRule(
-          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, null, true))
+          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), newRule);
     })
 
     it("setRule with isGlobal = true and non-existing path", () => {
-      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, null, true))
+      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, true))
         .to.equal(true);
     })
 
@@ -2798,20 +2798,20 @@ describe("DB sharding config", () => {
     })
 
     it("evalRule with isGlobal = false", () => {
-      expect(node.db.evalRule("/test/test_sharding/some/path/to", newValue, {addr: "known_user" }))
+      expect(node.db.evalRule("/test/test_sharding/some/path/to", newValue, { addr: "known_user" }))
         .to.equal(true);
     })
 
     it("evalRule with isGlobal = true", () => {
       expect(node.db.evalRule(
-          "/apps/afan/test/test_sharding/some/path/to", newValue, {addr: "known_user" },
+          "/apps/afan/test/test_sharding/some/path/to", newValue, { addr: "known_user" },
           null, true))
         .to.equal(true);
     })
 
     it("evalRule with isGlobal = true and non-existing path", () => {
       expect(node.db.evalRule(
-          "/some/non-existing/path", newValue, {addr: "known_user" }, null, true))
+          "/some/non-existing/path", newValue, { addr: "known_user" }, null, true))
         .to.equal(null);
     })
   })
@@ -2872,14 +2872,14 @@ describe("DB sharding config", () => {
 
     it("setOwner with isGlobal = true", () => {
       expect(node.db.setOwner(
-          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, null, true))
+          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, true))
         .to.equal(true);
       assert.deepEqual(
           node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), newOwner);
     })
 
     it("setOwner with isGlobal = true and non-existing path", () => {
-      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' }, null, true))
+      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' }, true))
         .to.equal(true);
     })
 

--- a/unittest/test-util.js
+++ b/unittest/test-util.js
@@ -62,7 +62,7 @@ function addBlock(node, txs, votes, validators) {
   const finalDb = node.createDb(node.stateManager.getFinalVersion(),
       `${StateVersions.FINAL}:${lastBlock.number + 1}`, node.bc, node.tp, true);
   finalDb.executeTransactionList(txs);
-  node.syncDb(`${StateVersions.NODE}:${lastBlock.number + 1}`);
+  node.syncDbAndNonce(`${StateVersions.NODE}:${lastBlock.number + 1}`);
   node.addNewBlock(Block.create(
       lastBlock.hash, votes, txs, lastBlock.number + 1, lastBlock.epoch + 1, '',
       node.account.address, validators));

--- a/unittest/transaction.test.js
+++ b/unittest/transaction.test.js
@@ -7,6 +7,7 @@ const Transaction = require('../tx-pool/transaction');
 const BlockchainNode = require('../node/');
 const {setNodeForTesting, getTransaction} = require('./test-util');
 const ChainUtil = require('../common/chain-util');
+const { msleep } = require('sleep');
 
 describe('Transaction', () => {
   let node;
@@ -63,7 +64,7 @@ describe('Transaction', () => {
     txBodyForNode = {
       operation: {
         type: 'SET_VALUE',
-        ref: 'path',
+        ref: 'test/comcom',
         value: 'val'
       }
     };
@@ -135,6 +136,8 @@ describe('Transaction', () => {
       for (currentNonce = node.nonce - 1; currentNonce < 50; currentNonce++) {
         delete txBodyForNode.nonce;
         tx2 = getTransaction(node, txBodyForNode);
+        node.db.executeTransaction(tx2);
+        msleep(1);
       }
       expect(tx2).to.not.equal(null);
       expect(tx2.tx_body.nonce).to.equal(currentNonce);

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -5,7 +5,8 @@ const shuffleSeed = require('shuffle-seed');
 const ChainUtil = require('../common/chain-util');
 const {Block} = require('../blockchain/block');
 const BlockchainNode = require('../node');
-const {setNodeForTesting, getTransaction} = require('./test-util')
+const {setNodeForTesting, getTransaction} = require('./test-util');
+const { msleep } = require('sleep');
 
 describe('TransactionPool', () => {
   let node, transaction;
@@ -13,16 +14,16 @@ describe('TransactionPool', () => {
   beforeEach(() => {
     node = new BlockchainNode();
     setNodeForTesting(node);
-
     transaction = getTransaction(node, {
       operation: {
         type: 'SET_VALUE',
         ref: 'REF',
-        value:
-        'VALUE'
-      }
+        value: 'VALUE'
+      },
+      nonce: node.nonce++
     });
     node.tp.addTransaction(transaction);
+    msleep(1);
   });
 
   it('adds a transaction to the pool', () => {
@@ -41,9 +42,11 @@ describe('TransactionPool', () => {
             type: 'SET_VALUE',
             ref: 'REF',
             value: 'VALUE',
-          }
+          },
+          nonce: node.nonce++
         });
         node.tp.addTransaction(t);
+        msleep(1);
       }
       node.tp.transactions[node.account.address] =
           shuffleSeed.shuffle(node.tp.transactions[node.account.address]);
@@ -62,9 +65,11 @@ describe('TransactionPool', () => {
               type: 'SET_VALUE',
               ref: 'REF',
               value: 'VALUE',
-            }
-          }, true);
+            },
+            nonce: nodes[j].nonce++
+          });
           node.tp.addTransaction(t);
+          msleep(1);
         }
         node.tp.transactions[nodes[j].account.address] =
             shuffleSeed.shuffle(node.tp.transactions[nodes[j].account.address]);
@@ -122,7 +127,8 @@ describe('TransactionPool', () => {
             type: 'SET_VALUE',
             ref: 'REF',
             value: 'VALUE',
-          }
+          },
+          nonce: node.nonce++
         }));
         node.tp.addTransaction(newTransactions[node.account.address][i]);
       }

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -7,6 +7,7 @@ const {Block} = require('../blockchain/block');
 const BlockchainNode = require('../node');
 const {setNodeForTesting, getTransaction} = require('./test-util');
 const { msleep } = require('sleep');
+const TransactionPool = require('../tx-pool');
 
 describe('TransactionPool', () => {
   let node, transaction;
@@ -134,6 +135,126 @@ describe('TransactionPool', () => {
       }
       node.tp.cleanUpForNewBlock(block);
       assert.deepEqual(newTransactions, node.tp.transactions);
+    });
+
+    it('mergeTwoSortedArrays', () => {
+      assert.deepEqual(TransactionPool.mergeTwoSortedArrays([], []), []);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays([], [{tx_body: {timestamp: 1}}]),
+          [{tx_body: {timestamp: 1}}]);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays(
+              [{tx_body: {timestamp: 1}}],
+              [{tx_body: {timestamp: 1}}]),
+          [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 1}}]);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays(
+              [{tx_body: {timestamp: 1}}],
+              [{tx_body: {timestamp: 2}}]),
+          [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}]);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays(
+              [{tx_body: {timestamp: 2}}],
+              [{tx_body: {timestamp: 1}}]),
+          [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}]);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays(
+              [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}],
+              [{tx_body: {timestamp: 3}}]),
+          [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}, {tx_body: {timestamp: 3}}]);
+      assert.deepEqual(
+          TransactionPool.mergeTwoSortedArrays(
+              [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 3}}],
+              [{tx_body: {timestamp: 2}}]),
+          [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}, {tx_body: {timestamp: 3}}]);
+    });
+
+    it('mergeMultipleSortedArrays', () => {
+      assert.deepEqual(TransactionPool.mergeMultipleSortedArrays([]), []);
+      assert.deepEqual(TransactionPool.mergeMultipleSortedArrays([[], []]), []);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays([[{tx_body: {timestamp: 1}}], []]),
+          [{tx_body: {timestamp: 1}}]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 1}}],
+                  [{tx_body: {timestamp: 2}}],
+                  [{tx_body: {timestamp: 3}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}}
+          ]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 3}}],
+                  [{tx_body: {timestamp: 2}}],
+                  [{tx_body: {timestamp: 1}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}}
+          ]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 3}}],
+                  [{tx_body: {timestamp: 2}}, {tx_body: {timestamp: 4}}],
+                  [{tx_body: {timestamp: 1}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 4}}
+          ]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 4}}],
+                  [{tx_body: {timestamp: 5}}],
+                  [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}, {tx_body: {timestamp: 3}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 4}},
+              {tx_body: {timestamp: 5}}
+          ]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 3}}],
+                  [{tx_body: {timestamp: 3}}],
+                  [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}, {tx_body: {timestamp: 4}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 4}}
+          ]);
+      assert.deepEqual(
+          TransactionPool.mergeMultipleSortedArrays(
+              [
+                  [{tx_body: {timestamp: 3}}],
+                  [{tx_body: {timestamp: 3}}, {tx_body: {timestamp: 5}}],
+                  [{tx_body: {timestamp: 1}}, {tx_body: {timestamp: 2}}, {tx_body: {timestamp: 4}}]
+              ]),
+          [
+              {tx_body: {timestamp: 1}},
+              {tx_body: {timestamp: 2}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 3}},
+              {tx_body: {timestamp: 4}},
+              {tx_body: {timestamp: 5}}
+          ]);
     });
   });
 });


### PR DESCRIPTION
Summary:
- Migrate nonce tracking to db states for block-level nonce tracking
  - DB path: `/accounts/${address}/nonce`
- Deprecate committedNonceTracker and pendingNonceTracker in tx pool
- Revamp getValidTransactions() in tx pool
- Support loosely ordered noncing (nonce = -2)
  - Ordered by timestamp tracked in the states
  - DB path: `/accounts/${address}/timestamp`
- Update nonce API
- Fix bugs in transaction APIs
- Fix transaction execution bug in consensus checkProposal() by using a backup db & reverting when execution fails
- Remove unnecessary syncDb() in node addNewBlock()

Related issues: 
#227 
#213 
#228 