### PR TITLE
Feature/staking service

### DIFF
--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -17,7 +17,13 @@ const {
   AccountProperties,
   ProofProperties,
   StateVersions,
+  AI_NETWORK,
 } = require('../common/constants');
+const {
+  getTransferValuePath,
+  getCreateAppRecordPath,
+  getStakingStakeRecordValuePath,
+} = require('../db/path-util');
 
 class Block {
   constructor(lastHash, lastVotes, transactions, number, epoch, timestamp,
@@ -207,8 +213,7 @@ class Block {
         // Transfer operation
         const op = {
           type: 'SET_VALUE',
-          ref: `/${PredefinedDbPaths.TRANSFER}/${ownerAddress}/` +
-              `${accountAddress}/${i}/${PredefinedDbPaths.TRANSFER_VALUE}`,
+          ref: getTransferValuePath(ownerAddress, accountAddress, i),
           value: GenesisAccounts[AccountProperties.SHARES],
         };
         transferOps.push(op);
@@ -233,11 +238,10 @@ class Block {
       timestamp,
       operation: {
         type: 'SET_VALUE',
-        ref: `${PredefinedDbPaths.MANAGE_APP}/${PredefinedDbPaths.CONSENSUS}/` +
-            `${PredefinedDbPaths.MANAGE_APP_CREATE}/${timestamp}`,
+        ref: getCreateAppRecordPath(PredefinedDbPaths.CONSENSUS, timestamp),
         value: {
           [PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN]: {
-            AI_NETWORK: true
+            [AI_NETWORK]: true
           },
           [PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE]: {
             [PredefinedDbPaths.STAKING]: {
@@ -264,15 +268,7 @@ class Block {
         timestamp,
         operation: {
           type: 'SET_VALUE',
-          ref: ChainUtil.formatPath([
-            PredefinedDbPaths.STAKING,
-            PredefinedDbPaths.CONSENSUS,
-            address,
-            0,
-            PredefinedDbPaths.STAKING_STAKE,
-            timestamp,
-            PredefinedDbPaths.STAKING_VALUE
-          ]),
+          ref: getStakingStakeRecordValuePath(PredefinedDbPaths.CONSENSUS, address, 0, timestamp),
           value: amount
         }
       };

--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -23,7 +23,7 @@ const {
   getTransferValuePath,
   getCreateAppRecordPath,
   getStakingStakeRecordValuePath,
-} = require('../db/path-util');
+} = require('../common/path-util');
 
 class Block {
   constructor(lastHash, lastVotes, transactions, number, epoch, timestamp,

--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -203,7 +203,7 @@ class Block {
     return Transaction.fromTxBody(firstTxBody, privateKey);
   }
 
-  static buildAccountsSetupTx(ownerAddress, timestamp, privateKey) {
+  static buildAccountsSetupTx(timestamp, privateKey, ownerAddress) {
     const transferOps = [];
     const otherAccounts = GenesisAccounts[AccountProperties.OTHERS];
     if (otherAccounts && Array.isArray(otherAccounts) && otherAccounts.length > 0 &&
@@ -232,7 +232,7 @@ class Block {
     return Transaction.fromTxBody(secondTxBody, privateKey);
   }
 
-  static buildConsensusAppTx(timestamp, privateKey) {
+  static buildConsensusAppTx(timestamp, privateKey, ownerAddress) {
     const thirdTxBody = {
       nonce: -1,
       timestamp,
@@ -241,7 +241,7 @@ class Block {
         ref: getCreateAppRecordPath(PredefinedDbPaths.CONSENSUS, timestamp),
         value: {
           [PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN]: {
-            [AI_NETWORK]: true // NOTE: there is no admin for consensus
+            [ownerAddress]: true
           },
           [PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE]: {
             [PredefinedDbPaths.STAKING]: {
@@ -284,8 +284,8 @@ class Block {
         GenesisAccounts, [AccountProperties.OWNER, AccountProperties.PRIVATE_KEY]);
 
     const firstTx = this.buildDbSetupTx(genesisTime, ownerPrivateKey);
-    const secondTx = this.buildAccountsSetupTx(ownerAddress, genesisTime, ownerPrivateKey);
-    const thirdTx = this.buildConsensusAppTx(genesisTime, ownerPrivateKey);
+    const secondTx = this.buildAccountsSetupTx(genesisTime, ownerPrivateKey, ownerAddress);
+    const thirdTx = this.buildConsensusAppTx(genesisTime, ownerPrivateKey, ownerAddress);
     // TODO(lia): Change the logic to staking & signing by the current node
     const stakingTxs = this.buildGenesisStakingTxs(genesisTime);
 

--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -17,7 +17,6 @@ const {
   AccountProperties,
   ProofProperties,
   StateVersions,
-  AI_NETWORK,
 } = require('../common/constants');
 const {
   getTransferValuePath,

--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -241,7 +241,7 @@ class Block {
         ref: getCreateAppRecordPath(PredefinedDbPaths.CONSENSUS, timestamp),
         value: {
           [PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN]: {
-            [AI_NETWORK]: true
+            [AI_NETWORK]: true // NOTE: there is no admin for consensus
           },
           [PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE]: {
             [PredefinedDbPaths.STAKING]: {

--- a/common/constants.js
+++ b/common/constants.js
@@ -54,6 +54,7 @@ const CHAINS_H2N_DIR_NAME = 'h2n'; // Note: Block hash to block number
 const HASH_DELIMITER = '#';
 const TX_NONCE_ERROR_CODE = 900;
 const TX_TIMESTAMP_ERROR_CODE = 901;
+const AI_NETWORK = 'AI_Network';
 
 // Enums
 /**
@@ -602,6 +603,7 @@ module.exports = {
   HASH_DELIMITER,
   TX_NONCE_ERROR_CODE,
   TX_TIMESTAMP_ERROR_CODE,
+  AI_NETWORK,
   MessageTypes,
   BlockchainNodeStates,
   PredefinedDbPaths,

--- a/common/constants.js
+++ b/common/constants.js
@@ -54,7 +54,6 @@ const CHAINS_H2N_DIR_NAME = 'h2n'; // Note: Block hash to block number
 const HASH_DELIMITER = '#';
 const TX_NONCE_ERROR_CODE = 900;
 const TX_TIMESTAMP_ERROR_CODE = 901;
-const AI_NETWORK = 'AI_Network';
 
 // Enums
 /**
@@ -603,7 +602,6 @@ module.exports = {
   HASH_DELIMITER,
   TX_NONCE_ERROR_CODE,
   TX_TIMESTAMP_ERROR_CODE,
-  AI_NETWORK,
   MessageTypes,
   BlockchainNodeStates,
   PredefinedDbPaths,

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const moment = require('moment');
 const semver = require('semver');
 const ChainUtil = require('./chain-util');
 
@@ -87,7 +86,6 @@ const BlockchainNodeStates = {
  * Predefined database paths.
  * @enum {string}
  */
-// TODO(lia): Pick one convention: full-paths (e.g. /deposit/consensus) or keys (e.g. token)
 // TODO(seo): Move '.something' paths to here from '[Owner|Function|Rule|Value]Properties'.
 const PredefinedDbPaths = {
   // Roots
@@ -123,22 +121,25 @@ const PredefinedDbPaths = {
   TRANSFER: 'transfer',
   TRANSFER_VALUE: 'value',
   TRANSFER_RESULT: 'result',
-  // Deposit & Withdraw
-  DEPOSIT: 'deposit',
-  DEPOSIT_ACCOUNTS: 'deposit_accounts',
-  DEPOSIT_CONFIG: 'config',
-  DEPOSIT_CREATED_AT: 'created_at',
-  DEPOSIT_EXPIRE_AT: 'expire_at',
-  DEPOSIT_LOCKUP_DURATION: 'lockup_duration',
-  DEPOSIT_RESULT: 'result',
-  DEPOSIT_VALUE: 'value',
-  WITHDRAW: 'withdraw',
-  WITHDRAW_CREATED_AT: 'created_at',
-  WITHDRAW_RESULT: 'result',
-  WITHDRAW_VALUE: 'value',
-  DEPOSIT_ACCOUNTS_CONSENSUS: 'deposit_accounts/consensus',
-  DEPOSIT_CONSENSUS: 'deposit/consensus',
-  WITHDRAW_CONSENSUS: 'withdraw/consensus',
+  // Apps & Manage app
+  APPS: 'apps',
+  MANAGE_APP: 'manage_app',
+  MANAGE_APP_CONFIG: 'config',
+  MANAGE_APP_CONFIG_ADMIN: 'admin',
+  MANAGE_APP_CONFIG_BILLING: 'billing',
+  MANAGE_APP_CONFIG_BILLING_USERS: 'users',
+  MANAGE_APP_CONFIG_SERVICE: 'service',
+  MANAGE_APP_CREATE: 'create',
+  MANAGE_APP_RESULT: 'result',
+  // Staking
+  STAKING: 'staking',
+  STAKING_BALANCE_TOTAL: 'balance_total',
+  STAKING_EXPIRE_AT: 'expire_at',
+  STAKING_LOCKUP_DURATION: 'lockup_duration',
+  STAKING_RESULT: 'result',
+  STAKING_STAKE: 'stake',
+  STAKING_UNSTAKE: 'unstake',
+  STAKING_VALUE: 'value',
   // Payments
   PAYMENTS: 'payments',
   PAYMENTS_ADMIN: 'admin',
@@ -257,16 +258,17 @@ const ProofProperties = {
 const NativeFunctionIds = {
   CLAIM: '_claim',
   CLOSE_CHECKIN: '_closeCheckin',
-  DEPOSIT: '_deposit',
+  CREATE_APP: '_createApp',
   HOLD: '_hold',
   OPEN_CHECKIN: '_openCheckin',
   OPEN_ESCROW: '_openEscrow',
   PAY: '_pay',
   RELEASE: '_release',
   SAVE_LAST_TX: '_saveLastTx',
+  STAKE: '_stake',
   TRANSFER: '_transfer',
+  UNSTAKE: '_unstake',
   UPDATE_LATEST_SHARD_REPORT: '_updateLatestShardReport',
-  WITHDRAW: '_withdraw',
 };
 
 /**
@@ -368,13 +370,6 @@ const TransactionStatus = {
   POOL_STATUS: 'POOL',
   TIMEOUT_STATUS: 'TIMEOUT',
   FAIL_STATUS: 'FAIL'
-};
-
-/**
- * Default values.
- */
-const DefaultValues = {
-  DEPOSIT_LOCKUP_DURATION_MS: moment.duration(180, 'days').as('milliseconds')
 };
 
 /**
@@ -625,7 +620,6 @@ module.exports = {
   ReadDbOperations,
   WriteDbOperations,
   TransactionStatus,
-  DefaultValues,
   StateVersions,
   FeatureFlags,
   GenesisToken,

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -1,5 +1,5 @@
-const { PredefinedDbPaths, ShardingProperties } = require('../common/constants');
-const ChainUtil = require('../common/chain-util');
+const { PredefinedDbPaths, ShardingProperties } = require('./constants');
+const ChainUtil = require('./chain-util');
 
 function getAccountBalancePath(address) {
   return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, balance]);

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -39,7 +39,7 @@ const {
   getConsensusProposePath,
   getConsensusVotePath,
   getStakingStakeRecordValuePath,
-} = require('../db/path-util');
+} = require('../common/path-util');
 
 const parentChainEndpoint = GenesisSharding[ShardingProperties.PARENT_CHAIN_POC] + '/json-rpc';
 const shardingPath = GenesisSharding[ShardingProperties.SHARDING_PATH];

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -75,7 +75,7 @@ class Consensus {
     const myAddr = this.node.account.address;
     try {
       const targetStake = process.env.STAKE ? Number(process.env.STAKE) : 0;
-      const currentStake = this.getValidConsensusDeposit(myAddr);
+      const currentStake = this.getValidConsensusStake(myAddr);
       logger.info(`[${LOG_HEADER}] Current stake: ${currentStake} / Target stake: ${targetStake}`);
       if (!targetStake && !currentStake) {
         logger.info(`[${LOG_HEADER}] Node doesn't have any stakes. ` +
@@ -163,7 +163,7 @@ class Consensus {
     if (!lastNotarizedBlock) {
       logger.error(`[${LOG_HEADER}] Empty lastNotarizedBlock (${this.state.epoch})`);
     }
-    // Need the block#1 to be finalized to have the deposits reflected in the state
+    // Need the block#1 to be finalized to have the stakes reflected in the state
     const validators = this.node.bc.lastBlockNumber() < 1 ? lastNotarizedBlock.validators
         : this.getValidators(lastNotarizedBlock.hash, lastNotarizedBlock.number);
 
@@ -331,16 +331,15 @@ class Consensus {
     this.node.tp.removeInvalidTxsFromPool(invalidTransactions);
 
     const myAddr = this.node.account.address;
-    // Need the block#1 to be finalized to have the deposits reflected in the state
+    // Need the block#1 to be finalized to have the stakes reflected in the state
     let validators = {};
     if (this.node.bc.lastBlockNumber() < 1) {
       const whitelist = GENESIS_WHITELIST;
       for (const address in whitelist) {
         if (Object.prototype.hasOwnProperty.call(whitelist, address)) {
-          const deposit = tempDb.getValue(`/${PredefinedDbPaths.DEPOSIT_ACCOUNTS_CONSENSUS}/${address}`);
-          if (whitelist[address] === true && deposit &&
-              deposit.value >= MIN_STAKE_PER_VALIDATOR) {
-            validators[address] = deposit.value;
+          const stakingAccount = tempDb.getValue(this.getConsensusStakingAccount(address));
+          if (whitelist[address] === true && stakingAccount && stakingAccount.balance >= MIN_STAKE_PER_VALIDATOR) {
+            validators[address] = stakingAccount.balance;
           }
         }
       }
@@ -884,6 +883,15 @@ class Consensus {
     return validators;
   }
 
+  getConsensusStakingAccount(address) {
+    return ChainUtil.formatPath([
+      PredefinedDbPaths.SERVICE_ACCOUNTS,
+      PredefinedDbPaths.STAKING,
+      PredefinedDbPaths.CONSENSUS,
+      `${address}|0`
+    ]);
+  }
+
   getWhitelist() {
     const LOG_HEADER = 'getWhitelist';
     const whitelist = this.node.getValueWithStateVersion(
@@ -907,11 +915,11 @@ class Consensus {
         `/${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.WHITELIST}`, false, stateVersion) || {};
     const validators = {};
     Object.keys(whitelist).forEach((address) => {
-      const deposit = this.node.getValueWithStateVersion(
-        `/${PredefinedDbPaths.DEPOSIT_ACCOUNTS_CONSENSUS}/${address}`, false, stateVersion) || {};
-      if (whitelist[address] === true && deposit &&
-          deposit.value >= MIN_STAKE_PER_VALIDATOR) {
-        validators[address] = deposit.value;
+      const stakingAccount = this.node.getValueWithStateVersion(
+          this.getConsensusStakingAccount(address), false, stateVersion);
+      if (whitelist[address] === true && stakingAccount &&
+          stakingAccount.balance >= MIN_STAKE_PER_VALIDATOR) {
+        validators[address] = stakingAccount.balance;
       }
     });
     logger.debug(`[${LOG_HEADER}] validators: ${JSON.stringify(validators, null, 2)}, ` +
@@ -919,12 +927,11 @@ class Consensus {
     return validators;
   }
 
-  getValidConsensusDeposit(address) {
-    const deposit = this.node.getValueWithStateVersion(
-        `/${PredefinedDbPaths.DEPOSIT_ACCOUNTS_CONSENSUS}/${address}`, false,
-        this.node.stateManager.getFinalVersion()) || {};
-    if (deposit && deposit.value > 0) {
-      return deposit.value;
+  getValidConsensusStake(address) {
+    const stakingAccount = this.node.getValueWithStateVersion(
+        this.getConsensusStakingAccount(address), false, this.node.stateManager.getFinalVersion());
+    if (stakingAccount && stakingAccount.balance > 0) {
+      return stakingAccount.balance;
     }
     return 0;
   }
@@ -948,15 +955,18 @@ class Consensus {
     const operation = {
       type: WriteDbOperations.SET_VALUE,
       ref: ChainUtil.formatPath([
-        PredefinedDbPaths.DEPOSIT_CONSENSUS,
+        PredefinedDbPaths.STAKING,
+        PredefinedDbPaths.CONSENSUS,
         this.node.account.address,
+        0,
+        PredefinedDbPaths.STAKING_STAKE,
         PushId.generate(),
-        PredefinedDbPaths.DEPOSIT_VALUE
+        PredefinedDbPaths.STAKING_VALUE
       ]),
       value: amount
     };
-    const depositTx = this.node.createTransaction({ operation, nonce: -1 });
-    return depositTx;
+    const stakeTx = this.node.createTransaction({ operation, nonce: -1 });
+    return stakeTx;
   }
 
   async reportStateProofHashes() {
@@ -1161,10 +1171,10 @@ class Consensus {
     }
   }
 
-  static filterDepositTxs(txs) {
+  static filterStakeTxs(txs) {
     return txs.filter((tx) => {
       const ref = _.get(tx, 'tx_body.operation.ref');
-      return ref && ref.startsWith(`/${PredefinedDbPaths.DEPOSIT_CONSENSUS}`) &&
+      return ref && ref.startsWith(`/${PredefinedDbPaths.STAKING}/${PredefinedDbPaths.CONSENSUS}`) &&
         _.get(tx, 'tx_body.operation.type') === WriteDbOperations.SET_VALUE;
     });
   }

--- a/db/functions.js
+++ b/db/functions.js
@@ -17,7 +17,7 @@ const {
   FeatureFlags,
 } = require('../common/constants');
 const ChainUtil = require('../common/chain-util');
-const PathUtil = require('./path-util');
+const PathUtil = require('../common/path-util');
 const {
   sendSignedTx,
   signAndSendTx

--- a/db/functions.js
+++ b/db/functions.js
@@ -547,27 +547,6 @@ class Functions {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.IN_LOCKUP_PERIOD);
       return;
     }
-    if (serviceName === PredefinedDbPaths.CONSENSUS) {
-      // Reject withdrawing consensus stakes if it reduces the number of validators to less than
-      // MIN_NUM_VALIDATORS.
-      const whitelist = this.db.getValue(
-          ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST]));
-      let numValidators = 0;
-      Object.keys(whitelist).forEach((address) => {
-        const accountName = ChainUtil.toServiceAccountName(
-            PredefinedDbPaths.STAKING, serviceName, `${address}|0`);
-        const stakingAccount = this.db.getValue(
-            ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, PredefinedDbPaths.STAKING,
-                PredefinedDbPaths.CONSENSUS, accountName]));
-        if (stakingAccount && stakingAccount.balance > MIN_STAKE_PER_VALIDATOR) {
-          numValidators++;
-        }
-      });
-      if (numValidators <= MIN_NUM_VALIDATORS) {
-        this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
-        return;
-      }
-    }
     const stakingServiceAccountName = ChainUtil.toServiceAccountName(
         PredefinedDbPaths.STAKING, serviceName, `${user}|${stakingKey}`);
     const transferResult = this.setServiceAccountTransferOrLog(

--- a/db/functions.js
+++ b/db/functions.js
@@ -460,11 +460,8 @@ class Functions {
     const transaction = context.transaction;
     const auth = context.auth;
     const resultPath = PathUtil.getCreateAppResultPath(appName, recordId);
-    const lockupDurationKey = `${PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE}.` +
-        `${PredefinedDbPaths.STAKING}.${PredefinedDbPaths.STAKING_LOCKUP_DURATION}`;
-    const lockupDurationVal = _.get(value, lockupDurationKey);
     if (!ChainUtil.isDict(_.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN)) ||
-        !ChainUtil.isNumber(lockupDurationVal)) {
+        !ChainUtil.isDict(_.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE))) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
       return;
     }

--- a/db/functions.js
+++ b/db/functions.js
@@ -460,15 +460,14 @@ class Functions {
     const transaction = context.transaction;
     const auth = context.auth;
     const resultPath = PathUtil.getCreateAppResultPath(appName, recordId);
-    if (!ChainUtil.isDict(_.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN)) ||
-        !ChainUtil.isDict(_.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE))) {
-      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
-      return;
-    }
     const sanitizedVal = {};
     const adminConfig = value[PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN];
     const billingConfig = _.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING);
     const serviceConfig = _.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE);
+    if (!ChainUtil.isDict(adminConfig) || !ChainUtil.isDict(serviceConfig)) {
+      this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
+      return;
+    }
     if (adminConfig) {
       sanitizedVal[PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN] = adminConfig;
     }

--- a/db/functions.js
+++ b/db/functions.js
@@ -470,18 +470,13 @@ class Functions {
     }
     const sanitizedVal = {};
     const adminConfig = value[PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN];
-    const billingUsersConfig = _.get(value,
-        `${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING}.${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING_USERS}`);
-    const serviceConfig = {
-      [PredefinedDbPaths.STAKING]: {
-        [PredefinedDbPaths.STAKING_LOCKUP_DURATION]: lockupDurationVal
-      }
-    };
+    const billingConfig = _.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING);
+    const serviceConfig = _.get(value, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE);
     if (adminConfig) {
       sanitizedVal[PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN] = adminConfig;
     }
-    if (billingUsersConfig) {
-      sanitizedVal[PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING] = billingUsersConfig;
+    if (billingConfig) {
+      sanitizedVal[PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING] = billingConfig;
     }
     if (serviceConfig) {
       sanitizedVal[PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE] = serviceConfig;

--- a/db/path-util.js
+++ b/db/path-util.js
@@ -1,0 +1,222 @@
+const { PredefinedDbPaths, ShardingProperties } = require('../common/constants');
+const ChainUtil = require('../common/chain-util');
+
+function getAccountBalancePath(address) {
+  return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, balance]);
+}
+
+function getServiceAccountPath(serviceType, serviceName, accountKey) {
+  return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, serviceType, serviceName, accountKey]);
+}
+
+function getServiceAccountBalancePath(serviceType, serviceName, accountKey) {
+  return `${getServiceAccountPath(serviceType, serviceName, accountKey)}/${PredefinedDbPaths.BALANCE}`;
+}
+
+function getServiceAccountPathFromAccountName(accountName) {
+  const parsed = ChainUtil.parseServAcntName(accountName);
+  return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, parsed[0], parsed[1], parsed[2]]);
+}
+
+function getServiceAccountAdminPathFromAccountName(accountName) {
+  return `${getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
+}
+
+function getServiceAccountAdminAddrPathFromAccountName(accountName, adminAddr) {
+  return `${getServiceAccountAdminPathFromAccountName(accountName)}/${adminAddr}`;
+}
+
+function getServiceAccountBalancePathFromAccountName(accountName) {
+  return `${getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.BALANCE}`;
+}
+
+function getTransferValuePath(from, to, key) {
+  return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_VALUE]);
+}
+
+function getTransferResultPath(from, to, key) {
+  return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_RESULT]);
+}
+
+function getCreateAppRecordPath(appName, recordId) {
+  return ChainUtil.formatPath([
+      PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CREATE, recordId]);
+}
+
+function getCreateAppResultPath(appName, recordId) {
+  return `${getCreateAppRecordPath(appName, recordId)}/${PredefinedDbPaths.MANAGE_APP_RESULT}`;
+}
+
+function getManageAppConfigPath(appName) {
+  return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CONFIG]);
+}
+
+function getStakingLockupDurationPath(serviceName) {
+  return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, serviceName,
+      PredefinedDbPaths.MANAGE_APP_CONFIG, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE,
+      PredefinedDbPaths.STAKING, PredefinedDbPaths.STAKING_LOCKUP_DURATION]);
+}
+
+function getStakingExpirationPath(serviceName, user, stakingKey) {
+  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+      PredefinedDbPaths.STAKING_EXPIRE_AT]);
+}
+
+function getStakingStakeRecordPath(serviceName, user, stakingKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+      PredefinedDbPaths.STAKING_STAKE, recordId]);
+}
+
+function getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+      PredefinedDbPaths.STAKING_UNSTAKE, recordId]);
+}
+
+function getStakingStakeRecordValuePath(serviceName, user, stakingKey, recordId) {
+  return `${getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+      `${PredefinedDbPaths.STAKING_VALUE}`;
+}
+
+function getStakingStakeResultPath(serviceName, user, stakingKey, recordId) {
+  return `${getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+      `${PredefinedDbPaths.STAKING_RESULT}`;
+}
+
+function getStakingUnstakeResultPath(serviceName, user, stakingKey, recordId) {
+  return `${getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+      `${PredefinedDbPaths.STAKING_RESULT}`;
+}
+
+function getStakingBalanceTotalPath(serviceName) {
+  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, PredefinedDbPaths.STAKING_BALANCE_TOTAL]);
+}
+
+function getPaymentServiceAdminPath(serviceName) {
+  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, PredefinedDbPaths.PAYMENTS_CONFIG,
+      PredefinedDbPaths.PAYMENTS_ADMIN]);
+}
+
+function getPaymentPayRecordPath(serviceName, user, paymentKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
+      PredefinedDbPaths.PAYMENTS_PAY, recordId]);
+}
+
+function getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
+      PredefinedDbPaths.PAYMENTS_CLAIM, recordId]);
+}
+
+function getPaymentPayRecordResultPath(serviceName, user, paymentKey, recordId) {
+  return `${getPaymentPayRecordPath(serviceName, user, paymentKey, recordId)}/` +
+      `${PredefinedDbPaths.PAYMENTS_RESULT}`;
+}
+
+function getPaymentClaimRecordResultPath(serviceName, user, paymentKey, recordId) {
+  return `${getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId)}/` +
+      `${PredefinedDbPaths.PAYMENTS_RESULT}`;
+}
+
+function getEscrowHoldRecordPath(source, target, escrowKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
+      PredefinedDbPaths.ESCROW_HOLD, recordId]);
+}
+
+function getEscrowHoldRecordResultPath(source, target, escrowKey, recordId) {
+  return `${getEscrowHoldRecordPath(source, target, escrowKey, recordId)}/` +
+      `${PredefinedDbPaths.ESCROW_RESULT}`;
+}
+
+function getEscrowReleaseRecordResultPath(source, target, escrowKey, recordId) {
+  return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
+      PredefinedDbPaths.ESCROW_RELEASE, recordId, PredefinedDbPaths.ESCROW_RESULT]);
+}
+
+function getLatestShardReportPath(branchPath) {
+  return ChainUtil.formatPath([branchPath, ShardingProperties.LATEST]);
+}
+
+function getLatestShardReportPathFromValuePath(valuePath) {
+  const branchPath = ChainUtil.formatPath(valuePath.slice(0, -2));
+  return getLatestShardReportPath(branchPath);
+}
+
+function getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash) {
+  return ChainUtil.appendPath(
+      shardingPath,
+      `${branchPath}/${PredefinedDbPaths.CHECKIN_PARENT_FINALIZE}/${txHash}/` +
+          `${PredefinedDbPaths.REMOTE_TX_ACTION_RESULT}`);
+}
+
+function getCheckinParentFinalizeResultPathFromValuePath(shardingPath, valuePath, txHash) {
+  const branchPath = ChainUtil.formatPath(valuePath.slice(0, -1));
+  return getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash);
+}
+
+function getCheckinPayloadPath(branchPath) {
+  return ChainUtil.appendPath(
+      branchPath,
+      `${PredefinedDbPaths.CHECKIN_REQUEST}/${PredefinedDbPaths.CHECKIN_PAYLOAD}`);
+}
+
+function getConsensusWhitelistPath() {
+  return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST]);
+}
+
+function getConsensusWhitelistAddrPath(address) {
+  return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST, address]);
+}
+
+function getConsensusStakingAccountPath(address) {
+  return getServiceAccountPath(PredefinedDbPaths.STAKING, PredefinedDbPaths.CONSENSUS, `${address}|0`);
+}
+
+function getConsensusProposePath(blockNumber) {
+  return ChainUtil.formatPath([
+      PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);
+}
+
+function getConsensusVotePath(blockNumber, address) {
+  return ChainUtil.formatPath([
+      PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.VOTE, address]);
+}
+
+module.exports = {
+  getAccountBalancePath,
+  getServiceAccountPath,
+  getServiceAccountBalancePath,
+  getServiceAccountPathFromAccountName,
+  getServiceAccountAdminPathFromAccountName,
+  getServiceAccountAdminAddrPathFromAccountName,
+  getServiceAccountBalancePathFromAccountName,
+  getTransferValuePath,
+  getTransferResultPath,
+  getCreateAppRecordPath,
+  getCreateAppResultPath,
+  getManageAppConfigPath,
+  getStakingLockupDurationPath,
+  getStakingExpirationPath,
+  getStakingStakeRecordPath,
+  getStakingUnstakeRecordPath,
+  getStakingStakeRecordValuePath,
+  getStakingStakeResultPath,
+  getStakingUnstakeResultPath,
+  getStakingBalanceTotalPath,
+  getPaymentServiceAdminPath,
+  getPaymentPayRecordPath,
+  getPaymentClaimRecordPath,
+  getPaymentPayRecordResultPath,
+  getPaymentClaimRecordResultPath,
+  getEscrowHoldRecordPath,
+  getEscrowHoldRecordResultPath,
+  getEscrowReleaseRecordResultPath,
+  getLatestShardReportPath,
+  getLatestShardReportPathFromValuePath,
+  getCheckinParentFinalizeResultPath,
+  getCheckinParentFinalizeResultPathFromValuePath,
+  getCheckinPayloadPath,
+  getConsensusWhitelistPath,
+  getConsensusWhitelistAddrPath,
+  getConsensusStakingAccountPath,
+  getConsensusProposePath,
+  getConsensusVotePath,
+}

--- a/genesis-configs/base/genesis_functions.json
+++ b/genesis-configs/base/genesis_functions.json
@@ -25,22 +25,6 @@
       }
     }
   },
-  "deposit": {
-    "$service": {
-      "$user_addr": {
-        "$deposit_id": {
-          "value": {
-            ".function": {
-              "_deposit": {
-                "function_type": "NATIVE",
-                "function_id": "_deposit"
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "escrow": {
     "$source_account": {
       "$target_account": {
@@ -77,8 +61,22 @@
       }
     }
   },
+  "manage_app": {
+    "$app_name": {
+      "create": {
+        "$record_id": {
+          ".function": {
+            "_createApp": {
+              "function_type": "NATIVE",
+              "function_id": "_createApp"
+            }
+          }
+        }
+      }
+    }
+  },
   "payments": {
-    "$service": {
+    "$service_name": {
       "$user_addr": {
         "$payment_key": {
           "pay": {
@@ -105,6 +103,38 @@
       }
     }
   },
+  "staking": {
+    "$service_name": {
+      "$user_addr": {
+        "$staking_key": {
+          "stake": {
+            "$record_id": {
+              "value": {
+                ".function": {
+                  "_stake": {
+                    "function_type": "NATIVE",
+                    "function_id": "_stake"
+                  }
+                }
+              }
+            }
+          },
+          "unstake": {
+            "$record_id": {
+              "value": {
+                ".function": {
+                  "_unstake": {
+                    "function_type": "NATIVE",
+                    "function_id": "_unstake"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "transfer": {
     "$from": {
       "$to": {
@@ -114,22 +144,6 @@
               "_transfer": {
                 "function_type": "NATIVE",
                 "function_id": "_transfer"
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "withdraw":{
-    "$service": {
-      "$user_addr": {
-        "$withdraw_id": {
-          "value": {
-            ".function": {
-              "_withdraw": {
-                "function_type": "NATIVE",
-                "function_id": "_withdraw"
               }
             }
           }

--- a/genesis-configs/base/genesis_owners.json
+++ b/genesis-configs/base/genesis_owners.json
@@ -11,18 +11,6 @@
       }
     }
   },
-  "deposit_accounts": {
-    ".owner": {
-      "owners": {
-        "*": {
-          "branch_owner": true,
-          "write_function": true,
-          "write_owner": true,
-          "write_rule": true
-        }
-      }
-    }
-  },
   "payments": {
     ".owner": {
       "owners": {

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -3,7 +3,7 @@
   "accounts": {
     "$user_addr": {
       "balance": {
-        ".write": "auth.fid === '_transfer' || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim'"
+        ".write": "auth.fid === '_transfer'"
       }
     }
   },
@@ -127,7 +127,7 @@
             }
           },
           "balance": {
-            ".write": "auth.fid === '_transfer' || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release'"
+            ".write": "auth.fid === '_transfer'"
           }
         }
       }

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -3,7 +3,7 @@
   "accounts": {
     "$user_addr": {
       "balance": {
-        ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
+        ".write": "auth.fid === '_transfer' || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim'"
       }
     }
   },
@@ -28,11 +28,11 @@
       "$number": {
         ".write": "newData === null && !!getValue('/consensus/number/' + (Number($number) + 1000))",
         "propose": {
-          ".write": "newData !== null && util.isDict(newData) && newData.proposer === auth.addr && Number($number) === newData.number && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || getValue('/deposit_accounts/consensus/' + auth.addr + '/value') >= util.getMinStakeAmount())"
+          ".write": "newData !== null && util.isDict(newData) && newData.proposer === auth.addr && Number($number) === newData.number && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') >= util.getMinStakeAmount())"
         },
         "vote": {
           "$user_addr": {
-            ".write": "auth.addr === $user_addr && util.isDict(newData) && util.isString(newData.block_hash) && util.isNumber(newData.stake) && newData.stake > 0 && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || getValue('/deposit_accounts/consensus/' + auth.addr + '/value') >= util.getMinStakeAmount())"
+            ".write": "auth.addr === $user_addr && util.isDict(newData) && util.isString(newData.block_hash) && util.isNumber(newData.stake) && newData.stake > 0 && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') >= util.getMinStakeAmount())"
           }
         }
       }
@@ -40,41 +40,6 @@
     "whitelist": {
       "$user_addr": {
         ".write": "auth.addr === util.getOwnerAddr() && (newData === true || (newData === null && util.length(util.values(getValue('/consensus/whitelist')).filter(x => x === true)) > util.getMinNumValidators()))"
-      }
-    }
-  },
-  "deposit": {
-    "$service": {
-      "$user_addr": {
-        "$deposit_id": {
-          "value": {
-            ".write": "auth.addr === $user_addr && !getValue('/deposit/' + $service + '/' + $user_addr + '/' + $deposit_id) && (util.length($user_addr) !== 42 || util.isCksumAddr($user_addr)) && util.isNumber(newData) && getValue('/accounts/' + $user_addr + '/balance') >= newData"
-          },
-          "created_at": {
-            ".write": "auth.fid === '_deposit'"
-          },
-          "result": {
-            ".write": "auth.fid === '_deposit'"
-          }
-        }
-      }
-    }
-  },
-  "deposit_accounts": {
-    "$service": {
-      "config": {
-        ".write": "!getValue('/deposit_accounts/' + $service) || (getOwner('/deposit_accounts/' + $service) && getOwner('/deposit_accounts/' + $service).owners && getOwner('/deposit_accounts/' + $service).owners[auth.addr])"
-      },
-      "$user_addr": {
-        ".write": "auth.fid === '_deposit' || auth.fid === '_withdraw'"
-      }
-    },
-    "consensus": {
-      "config": {
-        ".write": false
-      },
-      "$user_addr": {
-        ".write": "auth.fid === '_deposit' || auth.fid === '_withdraw'"
       }
     }
   },
@@ -105,12 +70,27 @@
       }
     }
   },
+  "manage_app": {
+    "$app_name": {
+      "config": {
+        ".write": "auth.fid === '_createApp'"
+      },
+      "create": {
+        "$record_id": {
+          ".write": "data === null && getValue('/manage_app/' + $app_name + '/config') === null && util.isDict(newData)",
+          "result": {
+            ".write": "auth.fid === '_createApp'"
+          }
+        }
+      }
+    }
+  },
   "payments": {
-    "$service": {
+    "$service_name": {
       "config": {
         "admin": {
           "$admin_addr": {
-            ".write": "evalOwner('/payments/' + $service + '/config', 'write_owner', auth) && (newData === true || newData === null)"
+            ".write": "evalOwner('/payments/' + $service_name + '/config', 'write_owner', auth) && (newData === true || newData === null)"
           }
         }
       },
@@ -118,7 +98,7 @@
         "$payment_key": {
           "claim": {
             "$record_id": {
-              ".write": "getValue('/payments/' + $service + '/config/admin/' + auth.addr) === true && data === null && newData !== null && util.isNumber(newData.amount) && newData.amount > 0 && (util.isCksumAddr(newData.target) || util.isServAcntName(newData.target))",
+              ".write": "getValue('/payments/' + $service_name + '/config/admin/' + auth.addr) === true && data === null && newData !== null && util.isNumber(newData.amount) && newData.amount > 0 && (util.isCksumAddr(newData.target) || util.isServAcntName(newData.target))",
               "result": {
                 ".write": "auth.fid === '_claim'"
               }
@@ -126,7 +106,7 @@
           },
           "pay": {
             "$record_id": {
-              ".write": "getValue('/payments/' + $service + '/config/admin/' + auth.addr) === true && data === null && newData !== null && util.isNumber(newData.amount) && newData.amount > 0",
+              ".write": "getValue('/payments/' + $service_name + '/config/admin/' + auth.addr) === true && data === null && newData !== null && util.isNumber(newData.amount) && newData.amount > 0",
               "result": {
                 ".write": "auth.fid === '_pay'"
               }
@@ -143,11 +123,11 @@
           ".write": "auth.fid === '_openEscrow'",
           "admin": {
             "$admin_addr": {
-              ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim'"
+              ".write": "auth.fid === '_transfer' || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim'"
             }
           },
           "balance": {
-            ".write": "auth.fid === '_transfer' || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release'"
+            ".write": "auth.fid === '_transfer' || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release'"
           }
         }
       }
@@ -161,32 +141,49 @@
       }
     }
   },
-  "transfer": {
-    "$from": {
-      "$to": {
-        "$key": {
-          "value": {
-            ".write": "(auth.addr === $from || auth.fid === '_deposit' || auth.fid === '_withdraw' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue(util.getBalancePath($from)) >= newData"
+  "staking": {
+    "$service_name": {
+      "balance_total": {
+        ".write": "auth.fid === '_stake' || auth.fid === '_unstake'"
+      },
+      "$user_addr": {
+        "$staking_key": {
+          "expire_at": {
+            ".write": "auth.fid === '_stake'"
           },
-          "result": {
-            ".write": "auth.fid === '_transfer'"
+          "stake": {
+            "$record_id": {
+              "value": {
+                ".write": "$user_addr === auth.addr && data === null && util.isNumber(newData) && newData >= 0 && getValue('/accounts/' + $user_addr + '/balance') >= newData"
+              },
+              "result": {
+                ".write": "auth.fid === '_stake'"
+              }
+            }
+          },
+          "unstake": {
+            "$record_id": {
+              "value": {
+                ".write": "$user_addr === auth.addr && data === null && util.isNumber(newData) && newData > 0 && newData <= getValue(util.getBalancePath(util.toServiceAccountName('staking', $service_name, $user_addr + '|' + $staking_key)))"
+              },
+              "result": {
+                ".write": "auth.fid === '_unstake'"
+              }
+            }
           }
         }
       }
     }
   },
-  "withdraw":{
-    "$service": {
-      "$user_addr": {
-        "$withdraw_id": {
+  "transfer": {
+    "$from": {
+      "$to": {
+        "$key": {
           "value": {
-            ".write": "auth.addr === $user_addr && !getValue('/withdraw/' + $service + '/' + $user_addr + '/' + $withdraw_id) && util.isNumber(newData) && getValue('/deposit_accounts/' + $service + '/' + $user_addr + '/value') >= newData"
-          },
-          "created_at": {
-            ".write": "auth.fid === '_withdraw'"
+            ".write": "(auth.addr === $from || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && getValue(util.getBalancePath($from)) >= newData"
           },
           "result": {
-            ".write": "auth.fid === '_withdraw'"
+            ".write": "auth.fid === '_transfer'"
           }
         }
       }

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -73,7 +73,7 @@
   "manage_app": {
     "$app_name": {
       "config": {
-        ".write": "auth.fid === '_createApp'"
+        ".write": "auth.fid === '_createApp' || getValue('/manage_app/' + $app_name + '/config/admin/' + auth.addr) === true"
       },
       "create": {
         "$record_id": {

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -16,7 +16,7 @@ const {
   getAccountBalancePath,
   getConsensusWhitelistAddrPath,
   getServiceAccountBalancePath,
-} = require('../db/path-util');
+} = require('../common/path-util');
 
 /**
  * Defines the list of funtions which are accessibly to clients through the

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -7,15 +7,16 @@ const {
   CURRENT_PROTOCOL_VERSION,
   BlockchainNodeStates,
   ReadDbOperations,
-  PredefinedDbPaths,
   TransactionStatus,
   MAX_TX_BYTES,
   NETWORK_ID,
 } = require('../common/constants');
-const {
-  ConsensusConsts,
-} = require('../consensus/constants');
 const Transaction = require('../tx-pool/transaction');
+const {
+  getAccountBalancePath,
+  getConsensusWhitelistAddrPath,
+  getServiceAccountBalancePath,
+} = require('../db/path-util');
 
 /**
  * Defines the list of funtions which are accessibly to clients through the
@@ -344,8 +345,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
 
     ain_getBalance: function(args, done) {
       const address = args.address;
-      const balance =
-          p2pServer.node.db.getValue(`/${PredefinedDbPaths.ACCOUNTS}/${address}/balance`) || 0;
+      const balance = p2pServer.node.db.getValue(getAccountBalancePath(address)) || 0;
       done(null, addProtocolVersion({result: balance}));
     },
 
@@ -356,16 +356,10 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     },
 
     ain_isValidator: function(args, done) {
-      const whitelisted = p2pServer.node.db.getValue(
-          `${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.WHITELIST}/${args.address}`);
-      const stake = p2pServer.node.db.getValue(
-          `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${PredefinedDbPaths.STAKING}/` +
-          `${PredefinedDbPaths.CONSENSUS}/${args.address}|0/balance`);
-      const expireAt = p2pServer.node.db.getValue(
-          `${PredefinedDbPaths.STAKING}/${PredefinedDbPaths.CONSENSUS}/${args.address}/0/` +
-          `${PredefinedDbPaths.STAKING_EXPIRE_AT}`);
-      const stakeValid = stake && stake > 0 && expireAt > Date.now() + ConsensusConsts.DAY_MS;
-      done(null, addProtocolVersion({result: stakeValid && whitelisted ? stakeValid : 0}));
+      const addr = args.address;
+      const whitelisted = p2pServer.node.db.getValue(getConsensusWhitelistAddrPath(addr));
+      const stake = p2pServer.node.db.getValue(getServiceAccountBalancePath(addr));
+      done(null, addProtocolVersion({result: stake && whitelisted ? stake : 0}));
     },
 
     // Network API

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -357,11 +357,14 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
 
     ain_isValidator: function(args, done) {
       const whitelisted = p2pServer.node.db.getValue(
-          `${PredefinedDbPaths.DEPOSIT_ACCOUNTS_CONSENSUS}/${PredefinedDbPaths.WHITELIST}/${args.address}`);
-      const deposit = p2pServer.node.db.getValue(
-          `${PredefinedDbPaths.DEPOSIT_ACCOUNTS_CONSENSUS}/${args.address}`);
-      const stakeValid = deposit && deposit.value > 0 &&
-          deposit.expire_at > Date.now() + ConsensusConsts.DAY_MS;
+          `${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.WHITELIST}/${args.address}`);
+      const stake = p2pServer.node.db.getValue(
+          `${PredefinedDbPaths.SERVICE_ACCOUNTS}/${PredefinedDbPaths.STAKING}/` +
+          `${PredefinedDbPaths.CONSENSUS}/${args.address}|0/balance`);
+      const expireAt = p2pServer.node.db.getValue(
+          `${PredefinedDbPaths.STAKING}/${PredefinedDbPaths.CONSENSUS}/${args.address}/0/` +
+          `${PredefinedDbPaths.STAKING_EXPIRE_AT}`);
+      const stakeValid = stake && stake > 0 && expireAt > Date.now() + ConsensusConsts.DAY_MS;
       done(null, addProtocolVersion({result: stakeValid && whitelisted ? stakeValid : 0}));
     },
 

--- a/stop_servers.sh
+++ b/stop_servers.sh
@@ -1,6 +1,5 @@
 
 BASEDIR=$(dirname "$0")
 rm -rf $BASEDIR/blockchains
-rm -rf $BASEDIR/logger/logs
-rm -rf $BASEDIR/tracker-server/logs
+rm -rf $BASEDIR/logs
 killall -9 node # SIGKILL

--- a/stop_servers.sh
+++ b/stop_servers.sh
@@ -1,5 +1,5 @@
 
 BASEDIR=$(dirname "$0")
-rm -rf $BASEDIR/blockchains
-rm -rf $BASEDIR/logs
+rm -rf $BASEDIR/chains/
+rm -rf $BASEDIR/logs/
 killall -9 node # SIGKILL

--- a/tools/staking/config_local.js
+++ b/tools/staking/config_local.js
@@ -1,0 +1,7 @@
+module.exports = {
+  endpointUrl: "http://localhost:8081",
+  userAddr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  userPrivateKey: "ee0b1315d446e5318eb6eb4e9d071cd12ef42d2956d546f9acbdc3b75c469640",
+  serviceOwnerAddr: "0x08Aed7AF9354435c38d52143EE50ac839D20696b",
+  serviceOwnerPrivateKey: "9fad756c0bd0d3a42643973f36e61d4d76e01cbb41371fa3046bcced6926e1b2"
+};

--- a/tools/staking/sendCreateAppTx.js
+++ b/tools/staking/sendCreateAppTx.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const moment = require('moment');
+const { signAndSendTx, confirmTransaction } = require('../util');
+
+function buildCreateAppTxBody(address, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/manage_app/test_service/create/${timestamp}`,
+      value: {
+        admin: { [address]: true },
+        service: {
+          staking: { lockup_duration: moment.duration(5, 'minute').as('milliseconds') }
+        }
+      }
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+  const txBody = buildCreateAppTxBody(config.serviceOwnerAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.serviceOwnerPrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendCreateAppTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/tools/staking/sendStakeTx.js
+++ b/tools/staking/sendStakeTx.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const { signAndSendTx, confirmTransaction } = require('../util');
+
+function buildStakeTxBody(address, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/staking/test_service/${address}/0/stake/${timestamp}/value`,
+      value: 100
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+  const txBody = buildStakeTxBody(config.userAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.userPrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendStakeTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/tools/staking/sendUnstakeTx.js
+++ b/tools/staking/sendUnstakeTx.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const { signAndSendTx, confirmTransaction } = require('../util');
+
+function buildUnstakeTxBody(address, timestamp) {
+  return {
+    operation: {
+      type: 'SET_VALUE',
+      ref: `/staking/test_service/${address}/0/unstake/${timestamp}/value`,
+      value: 100
+    },
+    timestamp,
+    nonce: -1
+  }
+}
+
+async function sendTransaction() {
+  console.log('\n*** sendTransaction():');
+  const timestamp = Date.now();
+  const txBody = buildUnstakeTxBody(config.userAddr, timestamp);
+  console.log(`txBody: ${JSON.stringify(txBody, null, 2)}`);
+  const txInfo = await signAndSendTx(config.endpointUrl, txBody, config.userPrivateKey);
+  console.log(`txInfo: ${JSON.stringify(txInfo, null, 2)}`);
+  if (txInfo.success) {
+    await confirmTransaction(config.endpointUrl, timestamp, txInfo.txHash);
+  }
+}
+
+async function processArguments() {
+  if (process.argv.length !== 3) {
+    usage();
+  }
+  config = require(path.resolve(__dirname, process.argv[2]));
+  await sendTransaction();
+}
+
+function usage() {
+  console.log('\nExample commandlines:\n  node sendUnstakeTx.js config_local.js\n')
+  process.exit(0)
+}
+
+processArguments();

--- a/unittest/consensus.test.js
+++ b/unittest/consensus.test.js
@@ -47,20 +47,20 @@ describe("Consensus", () => {
 
   it("Staked nodes can vote", () => {
     const addr = node1.account.address;
-    const depositTx = getTransaction(node1,
+    const stakeTx = getTransaction(node1,
       { operation: 
         { 
           type: 'SET_VALUE', 
-          ref: `/deposit/consensus/${addr}/key1/value`, 
+          ref: `/staking/consensus/${addr}/0/stake/key1/value`, 
           value: 200
         } 
       }
     );
-    addBlock(node1, [depositTx], [], {});
+    addBlock(node1, [stakeTx], [], {});
     const lastBlock = node1.bc.lastBlock();
     const voteTx = getTransaction(node1,
       { operation: 
-        { 
+        {
           type: 'SET_VALUE', 
           ref: `/consensus/number/${lastBlock.number}/vote/${addr}`,
           value: { block_hash: lastBlock.hash, stake: 200 }

--- a/unittest/data/rules_for_testing.json
+++ b/unittest/data/rules_for_testing.json
@@ -15,7 +15,7 @@
         },
         "vote": {
           "$user_addr": {
-            ".write": "auth.addr === $user_addr && util.isDict(newData) && util.isString(newData.block_hash) && util.isNumber(newData.stake) && newData.stake > 0 && getValue('/deposit_accounts/consensus/' + $user_addr + '/value') >= newData.stake"
+            ".write": "auth.addr === $user_addr && util.isDict(newData) && util.isString(newData.block_hash) && util.isNumber(newData.stake) && newData.stake > 0 && getValue('/service_accounts/staking/consensus/' + $user_addr + '|0/value') >= newData.stake"
           }
         }
       }


### PR DESCRIPTION
- Revamp _deposit, _withdraw. Now we have staking services with _stake and _unstake native functions
  - /deposit/${service_name}/${user_addr}/${key} -> /staking/${service_name}/${user_addr}/${staking_key}/stake/${record_id}
  - /withdraw/${service_name}/${user_addr}/${key} -> /staking/${service_name}/${user_addr}/${staking_key}/unstake/${record_id}
- Replace deposit_accounts with service_accounts (#239)
  - /deposit_accounts/${service_name}/${user_addr}/value -> /service_accounts/staking/${service_name}/${user_addr}|${staking_key}/balance
- Total staking balance of an app is tracked at /staking/${service_name}/balance_total
- User's staking lockup expiration time is tracked at /staking/${service_name}/${user_addr}/${staking_key}/expire_at
- Add minimal implementation for manage_app and _createApp (service consistency & reusability features are coming soon!)
- Add tool scripts for staking
