### PR TITLE
Always return code of transaction execution

### DIFF
--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -18,11 +18,7 @@ const {
   ProofProperties,
   StateVersions,
 } = require('../common/constants');
-const {
-  getTransferValuePath,
-  getCreateAppRecordPath,
-  getStakingStakeRecordValuePath,
-} = require('../common/path-util');
+const PathUtil = require('../common/path-util');
 
 class Block {
   constructor(lastHash, lastVotes, transactions, number, epoch, timestamp,
@@ -212,7 +208,7 @@ class Block {
         // Transfer operation
         const op = {
           type: 'SET_VALUE',
-          ref: getTransferValuePath(ownerAddress, accountAddress, i),
+          ref: PathUtil.getTransferValuePath(ownerAddress, accountAddress, i),
           value: GenesisAccounts[AccountProperties.SHARES],
         };
         transferOps.push(op);
@@ -237,7 +233,7 @@ class Block {
       timestamp,
       operation: {
         type: 'SET_VALUE',
-        ref: getCreateAppRecordPath(PredefinedDbPaths.CONSENSUS, timestamp),
+        ref: PathUtil.getCreateAppRecordPath(PredefinedDbPaths.CONSENSUS, timestamp),
         value: {
           [PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN]: {
             [ownerAddress]: true
@@ -267,7 +263,7 @@ class Block {
         timestamp,
         operation: {
           type: 'SET_VALUE',
-          ref: getStakingStakeRecordValuePath(PredefinedDbPaths.CONSENSUS, address, 0, timestamp),
+          ref: PathUtil.getStakingStakeRecordValuePath(PredefinedDbPaths.CONSENSUS, address, 0, timestamp),
           value: amount
         }
       };

--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -299,7 +299,7 @@ class Block {
         GenesisAccounts[AccountProperties.TIMESTAMP]);
     for (const tx of genesisTransactions) {
       const res = tempGenesisDb.executeTransaction(Transaction.toExecutable(tx));
-      if (ChainUtil.transactionFailed(res)) {
+      if (ChainUtil.isFailedTx(res)) {
         logger.error(`Genesis transaction failed:\n${JSON.stringify(tx, null, 2)}` +
             `\nRESULT: ${JSON.stringify(res)}`)
         return null;

--- a/client/index.js
+++ b/client/index.js
@@ -192,7 +192,7 @@ app.post('/set_value', (req, res, next) => {
       req.body, WriteDbOperations.SET_VALUE));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -201,7 +201,7 @@ app.post('/inc_value', (req, res, next) => {
       req.body, WriteDbOperations.INC_VALUE));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -210,7 +210,7 @@ app.post('/dec_value', (req, res, next) => {
       req.body, WriteDbOperations.DEC_VALUE));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -219,7 +219,7 @@ app.post('/set_function', (req, res, next) => {
       req.body, WriteDbOperations.SET_FUNCTION));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -228,7 +228,7 @@ app.post('/set_rule', (req, res, next) => {
       req.body, WriteDbOperations.SET_RULE));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -237,7 +237,7 @@ app.post('/set_owner', (req, res, next) => {
       req.body, WriteDbOperations.SET_OWNER));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 
@@ -247,7 +247,7 @@ app.post('/set', (req, res, next) => {
   const result = createAndExecuteTransaction(createMultiSetTxBody(req.body));
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: result.result === true ? 0 : 1, result})
+    .send({code: result.result.code === 0 ? 0 : 1, result})
     .end();
 });
 

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -249,20 +249,26 @@ class ChainUtil {
     return newObj;
   }
 
-  static transactionFailed(response) {
-    if (Array.isArray(response)) {
-      for (const result of response) {
-        if (ChainUtil.checkForTransactionErrorCode(result)) {
+  /**
+   * Returns true if the given result is from failed transaction or transaction list.
+   */
+  static isFailedTx(result) {
+    if (!result) {
+      return true;
+    }
+    if (Array.isArray(result)) {
+      for (const elem of result) {
+        if (ChainUtil.isFailedTxResultCode(elem.code)) {
           return true;
         }
       }
       return false;
     }
-    return ChainUtil.checkForTransactionErrorCode(response);
+    return ChainUtil.isFailedTxResultCode(result.code);
   }
 
-  static checkForTransactionErrorCode(result) {
-    return result === null || (result.code !== undefined && result.code !== 0);
+  static isFailedTxResultCode(code) {
+    return code !== 0;
   }
 
   static returnTxResult(code, message = null) {

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -265,7 +265,7 @@ class ChainUtil {
     return result === null || (result.code !== undefined && result.code !== 0);
   }
 
-  static returnError(code, message) {
+  static returnTxResult(code, message = null) {
     return { code, error_message: message };
   }
 
@@ -277,7 +277,7 @@ class ChainUtil {
    * @param {*} message error message
    * @param {*} level level to log with
    */
-  static logAndReturnError(logger, code, message, level = 1) {
+  static logAndReturnTxResult(logger, code, message = null, level = 1) {
     if (level === 0) {
       logger.error(message);
     } else if (level === 1) {
@@ -285,7 +285,7 @@ class ChainUtil {
     } else {
       logger.debug(message);
     }
-    return ChainUtil.returnError(code, message);
+    return ChainUtil.returnTxResult(code, message);
   }
 
   static keyStackToMetricName(keyStack) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -28,7 +28,7 @@ const FeatureFlags = {
 // Environment variables.
 const DEBUG = process.env.DEBUG ? process.env.DEBUG.toLowerCase().startsWith('t') : false;
 const CONSOLE_LOG = FeatureFlags.forceConsoleLogging ||
-    (process.env.CONSOLE_LOG ? !!process.env.CONSOLE_LOG : false);
+    process.env.CONSOLE_LOG ? process.env.CONSOLE_LOG.toLowerCase().startsWith('t') : false;
 const COMCOM_HOST_EXTERNAL_IP =
     process.env.COMCOM_HOST_EXTERNAL_IP ? process.env.COMCOM_HOST_EXTERNAL_IP : '';
 const ACCOUNT_INDEX = process.env.ACCOUNT_INDEX || null;

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -1,222 +1,190 @@
 const { PredefinedDbPaths, ShardingProperties } = require('./constants');
 const ChainUtil = require('./chain-util');
 
-function getAccountBalancePath(address) {
-  return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, balance]);
+class PathUtil {
+  static getAccountBalancePath(address) {
+    return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, balance]);
+  }
+
+  static getServiceAccountPath(serviceType, serviceName, accountKey) {
+    return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, serviceType, serviceName, accountKey]);
+  }
+
+  static getServiceAccountBalancePath(serviceType, serviceName, accountKey) {
+    return `${PathUtil.getServiceAccountPath(serviceType, serviceName, accountKey)}/${PredefinedDbPaths.BALANCE}`;
+  }
+
+  static getServiceAccountPathFromAccountName(accountName) {
+    const parsed = ChainUtil.parseServAcntName(accountName);
+    return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, parsed[0], parsed[1], parsed[2]]);
+  }
+
+  static getServiceAccountAdminPathFromAccountName(accountName) {
+    return `${PathUtil.getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
+  }
+
+  static getServiceAccountAdminAddrPathFromAccountName(accountName, adminAddr) {
+    return `${PathUtil.getServiceAccountAdminPathFromAccountName(accountName)}/${adminAddr}`;
+  }
+
+  static getServiceAccountBalancePathFromAccountName(accountName) {
+    return `${PathUtil.getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.BALANCE}`;
+  }
+
+  static getTransferValuePath(from, to, key) {
+    return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_VALUE]);
+  }
+
+  static getTransferResultPath(from, to, key) {
+    return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_RESULT]);
+  }
+
+  static getCreateAppRecordPath(appName, recordId) {
+    return ChainUtil.formatPath([
+        PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CREATE, recordId]);
+  }
+
+  static getCreateAppResultPath(appName, recordId) {
+    return `${PathUtil.getCreateAppRecordPath(appName, recordId)}/${PredefinedDbPaths.MANAGE_APP_RESULT}`;
+  }
+
+  static getManageAppConfigPath(appName) {
+    return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CONFIG]);
+  }
+
+  static getStakingLockupDurationPath(serviceName) {
+    return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, serviceName,
+        PredefinedDbPaths.MANAGE_APP_CONFIG, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE,
+        PredefinedDbPaths.STAKING, PredefinedDbPaths.STAKING_LOCKUP_DURATION]);
+  }
+
+  static getStakingExpirationPath(serviceName, user, stakingKey) {
+    return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+        PredefinedDbPaths.STAKING_EXPIRE_AT]);
+  }
+
+  static getStakingStakeRecordPath(serviceName, user, stakingKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+        PredefinedDbPaths.STAKING_STAKE, recordId]);
+  }
+
+  static getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
+        PredefinedDbPaths.STAKING_UNSTAKE, recordId]);
+  }
+
+  static getStakingStakeRecordValuePath(serviceName, user, stakingKey, recordId) {
+    return `${PathUtil.getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+        `${PredefinedDbPaths.STAKING_VALUE}`;
+  }
+
+  static getStakingStakeResultPath(serviceName, user, stakingKey, recordId) {
+    return `${PathUtil.getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+        `${PredefinedDbPaths.STAKING_RESULT}`;
+  }
+
+  static getStakingUnstakeResultPath(serviceName, user, stakingKey, recordId) {
+    return `${PathUtil.getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
+        `${PredefinedDbPaths.STAKING_RESULT}`;
+  }
+
+  static getStakingBalanceTotalPath(serviceName) {
+    return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, PredefinedDbPaths.STAKING_BALANCE_TOTAL]);
+  }
+
+  static getPaymentServiceAdminPath(serviceName) {
+    return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, PredefinedDbPaths.PAYMENTS_CONFIG,
+        PredefinedDbPaths.PAYMENTS_ADMIN]);
+  }
+
+  static getPaymentPayRecordPath(serviceName, user, paymentKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
+        PredefinedDbPaths.PAYMENTS_PAY, recordId]);
+  }
+
+  static getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
+        PredefinedDbPaths.PAYMENTS_CLAIM, recordId]);
+  }
+
+  static getPaymentPayRecordResultPath(serviceName, user, paymentKey, recordId) {
+    return `${PathUtil.getPaymentPayRecordPath(serviceName, user, paymentKey, recordId)}/` +
+        `${PredefinedDbPaths.PAYMENTS_RESULT}`;
+  }
+
+  static getPaymentClaimRecordResultPath(serviceName, user, paymentKey, recordId) {
+    return `${PathUtil.getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId)}/` +
+        `${PredefinedDbPaths.PAYMENTS_RESULT}`;
+  }
+
+  static getEscrowHoldRecordPath(source, target, escrowKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
+        PredefinedDbPaths.ESCROW_HOLD, recordId]);
+  }
+
+  static getEscrowHoldRecordResultPath(source, target, escrowKey, recordId) {
+    return `${PathUtil.getEscrowHoldRecordPath(source, target, escrowKey, recordId)}/` +
+        `${PredefinedDbPaths.ESCROW_RESULT}`;
+  }
+
+  static getEscrowReleaseRecordResultPath(source, target, escrowKey, recordId) {
+    return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
+        PredefinedDbPaths.ESCROW_RELEASE, recordId, PredefinedDbPaths.ESCROW_RESULT]);
+  }
+
+  static getLatestShardReportPath(branchPath) {
+    return ChainUtil.formatPath([branchPath, ShardingProperties.LATEST]);
+  }
+
+  static getLatestShardReportPathFromValuePath(valuePath) {
+    const branchPath = ChainUtil.formatPath(valuePath.slice(0, -2));
+    return PathUtil.getLatestShardReportPath(branchPath);
+  }
+
+  static getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash) {
+    return ChainUtil.appendPath(
+        shardingPath,
+        `${branchPath}/${PredefinedDbPaths.CHECKIN_PARENT_FINALIZE}/${txHash}/` +
+            `${PredefinedDbPaths.REMOTE_TX_ACTION_RESULT}`);
+  }
+
+  static getCheckinParentFinalizeResultPathFromValuePath(shardingPath, valuePath, txHash) {
+    const branchPath = ChainUtil.formatPath(valuePath.slice(0, -1));
+    return PathUtil.getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash);
+  }
+
+  static getCheckinPayloadPath(branchPath) {
+    return ChainUtil.appendPath(
+        branchPath,
+        `${PredefinedDbPaths.CHECKIN_REQUEST}/${PredefinedDbPaths.CHECKIN_PAYLOAD}`);
+  }
+
+  static getCheckinPayloadPathFromValuePath(valuePath) {
+    const branchPath = ChainUtil.formatPath(valuePath.slice(0, -3));
+    return PathUtil.getCheckinPayloadPath(branchPath);
+  }
+
+  static getConsensusWhitelistPath() {
+    return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST]);
+  }
+
+  static getConsensusWhitelistAddrPath(address) {
+    return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST, address]);
+  }
+
+  static getConsensusStakingAccountPath(address) {
+    return PathUtil.getServiceAccountPath(PredefinedDbPaths.STAKING, PredefinedDbPaths.CONSENSUS, `${address}|0`);
+  }
+
+  static getConsensusProposePath(blockNumber) {
+    return ChainUtil.formatPath([
+        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);
+  }
+
+  static getConsensusVotePath(blockNumber, address) {
+    return ChainUtil.formatPath([
+        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.VOTE, address]);
+  }
 }
 
-function getServiceAccountPath(serviceType, serviceName, accountKey) {
-  return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, serviceType, serviceName, accountKey]);
-}
-
-function getServiceAccountBalancePath(serviceType, serviceName, accountKey) {
-  return `${getServiceAccountPath(serviceType, serviceName, accountKey)}/${PredefinedDbPaths.BALANCE}`;
-}
-
-function getServiceAccountPathFromAccountName(accountName) {
-  const parsed = ChainUtil.parseServAcntName(accountName);
-  return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, parsed[0], parsed[1], parsed[2]]);
-}
-
-function getServiceAccountAdminPathFromAccountName(accountName) {
-  return `${getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.SERVICE_ACCOUNTS_ADMIN}`;
-}
-
-function getServiceAccountAdminAddrPathFromAccountName(accountName, adminAddr) {
-  return `${getServiceAccountAdminPathFromAccountName(accountName)}/${adminAddr}`;
-}
-
-function getServiceAccountBalancePathFromAccountName(accountName) {
-  return `${getServiceAccountPathFromAccountName(accountName)}/${PredefinedDbPaths.BALANCE}`;
-}
-
-function getTransferValuePath(from, to, key) {
-  return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_VALUE]);
-}
-
-function getTransferResultPath(from, to, key) {
-  return ChainUtil.formatPath([PredefinedDbPaths.TRANSFER, from, to, key, PredefinedDbPaths.TRANSFER_RESULT]);
-}
-
-function getCreateAppRecordPath(appName, recordId) {
-  return ChainUtil.formatPath([
-      PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CREATE, recordId]);
-}
-
-function getCreateAppResultPath(appName, recordId) {
-  return `${getCreateAppRecordPath(appName, recordId)}/${PredefinedDbPaths.MANAGE_APP_RESULT}`;
-}
-
-function getManageAppConfigPath(appName) {
-  return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CONFIG]);
-}
-
-function getStakingLockupDurationPath(serviceName) {
-  return ChainUtil.formatPath([PredefinedDbPaths.MANAGE_APP, serviceName,
-      PredefinedDbPaths.MANAGE_APP_CONFIG, PredefinedDbPaths.MANAGE_APP_CONFIG_SERVICE,
-      PredefinedDbPaths.STAKING, PredefinedDbPaths.STAKING_LOCKUP_DURATION]);
-}
-
-function getStakingExpirationPath(serviceName, user, stakingKey) {
-  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
-      PredefinedDbPaths.STAKING_EXPIRE_AT]);
-}
-
-function getStakingStakeRecordPath(serviceName, user, stakingKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
-      PredefinedDbPaths.STAKING_STAKE, recordId]);
-}
-
-function getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, user, stakingKey,
-      PredefinedDbPaths.STAKING_UNSTAKE, recordId]);
-}
-
-function getStakingStakeRecordValuePath(serviceName, user, stakingKey, recordId) {
-  return `${getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
-      `${PredefinedDbPaths.STAKING_VALUE}`;
-}
-
-function getStakingStakeResultPath(serviceName, user, stakingKey, recordId) {
-  return `${getStakingStakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
-      `${PredefinedDbPaths.STAKING_RESULT}`;
-}
-
-function getStakingUnstakeResultPath(serviceName, user, stakingKey, recordId) {
-  return `${getStakingUnstakeRecordPath(serviceName, user, stakingKey, recordId)}/` +
-      `${PredefinedDbPaths.STAKING_RESULT}`;
-}
-
-function getStakingBalanceTotalPath(serviceName) {
-  return ChainUtil.formatPath([PredefinedDbPaths.STAKING, serviceName, PredefinedDbPaths.STAKING_BALANCE_TOTAL]);
-}
-
-function getPaymentServiceAdminPath(serviceName) {
-  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, PredefinedDbPaths.PAYMENTS_CONFIG,
-      PredefinedDbPaths.PAYMENTS_ADMIN]);
-}
-
-function getPaymentPayRecordPath(serviceName, user, paymentKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
-      PredefinedDbPaths.PAYMENTS_PAY, recordId]);
-}
-
-function getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.PAYMENTS, serviceName, user, paymentKey,
-      PredefinedDbPaths.PAYMENTS_CLAIM, recordId]);
-}
-
-function getPaymentPayRecordResultPath(serviceName, user, paymentKey, recordId) {
-  return `${getPaymentPayRecordPath(serviceName, user, paymentKey, recordId)}/` +
-      `${PredefinedDbPaths.PAYMENTS_RESULT}`;
-}
-
-function getPaymentClaimRecordResultPath(serviceName, user, paymentKey, recordId) {
-  return `${getPaymentClaimRecordPath(serviceName, user, paymentKey, recordId)}/` +
-      `${PredefinedDbPaths.PAYMENTS_RESULT}`;
-}
-
-function getEscrowHoldRecordPath(source, target, escrowKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
-      PredefinedDbPaths.ESCROW_HOLD, recordId]);
-}
-
-function getEscrowHoldRecordResultPath(source, target, escrowKey, recordId) {
-  return `${getEscrowHoldRecordPath(source, target, escrowKey, recordId)}/` +
-      `${PredefinedDbPaths.ESCROW_RESULT}`;
-}
-
-function getEscrowReleaseRecordResultPath(source, target, escrowKey, recordId) {
-  return ChainUtil.formatPath([PredefinedDbPaths.ESCROW, source, target, escrowKey,
-      PredefinedDbPaths.ESCROW_RELEASE, recordId, PredefinedDbPaths.ESCROW_RESULT]);
-}
-
-function getLatestShardReportPath(branchPath) {
-  return ChainUtil.formatPath([branchPath, ShardingProperties.LATEST]);
-}
-
-function getLatestShardReportPathFromValuePath(valuePath) {
-  const branchPath = ChainUtil.formatPath(valuePath.slice(0, -2));
-  return getLatestShardReportPath(branchPath);
-}
-
-function getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash) {
-  return ChainUtil.appendPath(
-      shardingPath,
-      `${branchPath}/${PredefinedDbPaths.CHECKIN_PARENT_FINALIZE}/${txHash}/` +
-          `${PredefinedDbPaths.REMOTE_TX_ACTION_RESULT}`);
-}
-
-function getCheckinParentFinalizeResultPathFromValuePath(shardingPath, valuePath, txHash) {
-  const branchPath = ChainUtil.formatPath(valuePath.slice(0, -1));
-  return getCheckinParentFinalizeResultPath(shardingPath, branchPath, txHash);
-}
-
-function getCheckinPayloadPath(branchPath) {
-  return ChainUtil.appendPath(
-      branchPath,
-      `${PredefinedDbPaths.CHECKIN_REQUEST}/${PredefinedDbPaths.CHECKIN_PAYLOAD}`);
-}
-
-function getConsensusWhitelistPath() {
-  return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST]);
-}
-
-function getConsensusWhitelistAddrPath(address) {
-  return ChainUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST, address]);
-}
-
-function getConsensusStakingAccountPath(address) {
-  return getServiceAccountPath(PredefinedDbPaths.STAKING, PredefinedDbPaths.CONSENSUS, `${address}|0`);
-}
-
-function getConsensusProposePath(blockNumber) {
-  return ChainUtil.formatPath([
-      PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);
-}
-
-function getConsensusVotePath(blockNumber, address) {
-  return ChainUtil.formatPath([
-      PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.VOTE, address]);
-}
-
-module.exports = {
-  getAccountBalancePath,
-  getServiceAccountPath,
-  getServiceAccountBalancePath,
-  getServiceAccountPathFromAccountName,
-  getServiceAccountAdminPathFromAccountName,
-  getServiceAccountAdminAddrPathFromAccountName,
-  getServiceAccountBalancePathFromAccountName,
-  getTransferValuePath,
-  getTransferResultPath,
-  getCreateAppRecordPath,
-  getCreateAppResultPath,
-  getManageAppConfigPath,
-  getStakingLockupDurationPath,
-  getStakingExpirationPath,
-  getStakingStakeRecordPath,
-  getStakingUnstakeRecordPath,
-  getStakingStakeRecordValuePath,
-  getStakingStakeResultPath,
-  getStakingUnstakeResultPath,
-  getStakingBalanceTotalPath,
-  getPaymentServiceAdminPath,
-  getPaymentPayRecordPath,
-  getPaymentClaimRecordPath,
-  getPaymentPayRecordResultPath,
-  getPaymentClaimRecordResultPath,
-  getEscrowHoldRecordPath,
-  getEscrowHoldRecordResultPath,
-  getEscrowReleaseRecordResultPath,
-  getLatestShardReportPath,
-  getLatestShardReportPathFromValuePath,
-  getCheckinParentFinalizeResultPath,
-  getCheckinParentFinalizeResultPathFromValuePath,
-  getCheckinPayloadPath,
-  getConsensusWhitelistPath,
-  getConsensusWhitelistAddrPath,
-  getConsensusStakingAccountPath,
-  getConsensusProposePath,
-  getConsensusVotePath,
-}
+module.exports = PathUtil;

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -246,7 +246,7 @@ class Consensus {
   executeLastVoteOrAbort(db, tx) {
     const LOG_HEADER = 'executeLastVoteOrAbort';
     const txRes = db.executeTransaction(Transaction.toExecutable(tx));
-    if (!ChainUtil.transactionFailed(txRes)) {
+    if (!ChainUtil.isFailedTx(txRes)) {
       logger.debug(`[${LOG_HEADER}] tx: success`);
       return true;
     } else {
@@ -263,7 +263,7 @@ class Consensus {
     }
     logger.debug(`[${LOG_HEADER}] Checking tx ${JSON.stringify(tx, null, 2)}`);
     const txRes = db.executeTransaction(Transaction.toExecutable(tx));
-    if (!ChainUtil.transactionFailed(txRes)) {
+    if (!ChainUtil.isFailedTx(txRes)) {
       logger.debug(`[${LOG_HEADER}] tx: success`);
       validTransactions.push(tx);
     } else {
@@ -508,7 +508,7 @@ class Consensus {
       for (const voteTx of proposalBlock.last_votes) {
         if (voteTx.hash === prevBlockProposal.hash) continue;
         if (!Consensus.isValidConsensusTx(voteTx) ||
-            ChainUtil.transactionFailed(
+            ChainUtil.isFailedTx(
                 tempDb.executeTransaction(Transaction.toExecutable(voteTx)))) {
           logger.error(`[${LOG_HEADER}] voting tx execution for prev block failed`);
           hasInvalidLastVote = true;
@@ -588,7 +588,7 @@ class Consensus {
     const tempVersion = this.node.stateManager.createUniqueVersionName(
       `${StateVersions.CONSENSUS_PROPOSE}:${prevBlock.number}:${number}`);
     const tempDb = this.node.createTempDb(newVersion, tempVersion, prevBlock.number - 1);
-    if (ChainUtil.transactionFailed(tempDb.executeTransaction(executableTx))) {
+    if (ChainUtil.isFailedTx(tempDb.executeTransaction(executableTx))) {
       logger.error(`[${LOG_HEADER}] Failed to execute the proposal tx`);
       this.node.destroyDb(tempDb);
       this.node.destroyDb(newDb);
@@ -651,7 +651,7 @@ class Consensus {
     }
     const voteTxRes = tempDb.executeTransaction(executableTx);
     this.node.destroyDb(tempDb);
-    if (ChainUtil.transactionFailed(voteTxRes)) {
+    if (ChainUtil.isFailedTx(voteTxRes)) {
       logger.error(`[${LOG_HEADER}] Failed to execute the voting tx: ${JSON.stringify(voteTxRes)}`);
       return false;
     }

--- a/db/functions.js
+++ b/db/functions.js
@@ -349,7 +349,7 @@ class Functions {
 
   setValueOrLog(valuePath, value, auth, timestamp, transaction) {
     const result = this.db.setValue(valuePath, value, auth, timestamp, transaction);
-    if (result !== true) {
+    if (result.code !== 0) {
       logger.error(
           `  ==> Failed to setValue on '${valuePath}' with error: ${JSON.stringify(result)}`);
     }
@@ -358,7 +358,7 @@ class Functions {
 
   incValueOrLog(valuePath, delta, auth, timestamp, transaction) {
     const result = this.db.incValue(valuePath, delta, auth, timestamp, transaction);
-    if (result !== true) {
+    if (result.code !== 0) {
       logger.error(
           `  ==> Failed to incValue on '${valuePath}' with error: ${JSON.stringify(result)}`);
     }
@@ -367,7 +367,7 @@ class Functions {
 
   decValueOrLog(valuePath, delta, auth, timestamp, transaction) {
     const result = this.db.decValue(valuePath, delta, auth, timestamp, transaction);
-    if (result !== true) {
+    if (result.code !== 0) {
       logger.error(
           `  ==> Failed to decValue on '${valuePath}' with error: ${JSON.stringify(result)}`);
     }
@@ -402,7 +402,7 @@ class Functions {
             .getServiceAccountAdminAddrPathFromAccountName(to, transaction.address);
         const adminSetupResult = this.setValueOrLog(
             serviceAccountAdminAddrPath, true, auth, timestamp, transaction);
-        if (adminSetupResult !== true) {
+        if (adminSetupResult.code !== 0) {
           return adminSetupResult;
         }
       }
@@ -444,9 +444,9 @@ class Functions {
     const resultPath = PathUtil.getTransferResultPath(from, to, key);
     const transferResult =
         this.transferInternal(fromBalancePath, toBalancePath, value, context);
-    if (transferResult === true) {
+    if (transferResult.code === 0) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
-    } else if (transferResult === false) {
+    } else if (transferResult.code === 1001) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INSUFFICIENT_BALANCE);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -480,7 +480,7 @@ class Functions {
     const manageAppConfigPath = PathUtil.getManageAppConfigPath(appName);
     const setConfigRes = this.setValueOrLog(
         manageAppConfigPath, sanitizedVal, auth, timestamp, transaction);
-    if (setConfigRes === true) {
+    if (setConfigRes.code === 0) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.FAILURE);
@@ -514,13 +514,13 @@ class Functions {
           PredefinedDbPaths.STAKING, serviceName, `${user}|${stakingKey}`);
     const transferResult = this.setServiceAccountTransferOrLog(
         user, stakingServiceAccountName, value, auth, timestamp, transaction);
-    if (transferResult === true) {
+    if (transferResult.code === 0) {
       this.setValueOrLog(
           expirationPath, Number(timestamp) + Number(lockup), auth, timestamp, transaction);
       const balanceTotalPath = PathUtil.getStakingBalanceTotalPath(serviceName);
       this.incValueOrLog(balanceTotalPath, value, auth, timestamp, transaction);
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
-    } else if (transferResult === false) {
+    } else if (transferResult.code === 1001) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INSUFFICIENT_BALANCE);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -547,11 +547,11 @@ class Functions {
         PredefinedDbPaths.STAKING, serviceName, `${user}|${stakingKey}`);
     const transferResult = this.setServiceAccountTransferOrLog(
         stakingServiceAccountName, user, value, auth, timestamp, transaction);
-    if (transferResult === true) {
+    if (transferResult.code === 0) {
       const balanceTotalPath = PathUtil.getStakingBalanceTotalPath(serviceName);
       this.decValueOrLog(balanceTotalPath, value, auth, timestamp, transaction);
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
-    } else if (transferResult === false) {
+    } else if (transferResult.code === 1001) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INSUFFICIENT_BALANCE);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -578,7 +578,7 @@ class Functions {
         PredefinedDbPaths.PAYMENTS, serviceName, `${user}|${paymentKey}`);
     const transferResult = this.setServiceAccountTransferOrLog(
         transaction.address, userServiceAccountName, value.amount, auth, timestamp, transaction);
-    if (transferResult === true) {
+    if (transferResult.code === 0) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -615,7 +615,7 @@ class Functions {
       result = this.setServiceAccountTransferOrLog(
           userServiceAccountName, value.target, value.amount, auth, timestamp, transaction);
     }
-    if (result === true) {
+    if (result.code === 0) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -646,7 +646,7 @@ class Functions {
     const serviceAccountPath = PathUtil.getServiceAccountPathFromAccountName(serviceAccountName);
     const serviceAccountSetupResult =
         this.setValueOrLog(serviceAccountPath, value, auth, timestamp, transaction);
-    if (serviceAccountSetupResult !== true) {
+    if (serviceAccountSetupResult.code !== 0) {
       logger.error(`  ==> Failed to open escrow`);
       this.setExecutionResult(context, FunctionResultCode.FAILURE);
     } else {
@@ -670,7 +670,7 @@ class Functions {
         PredefinedDbPaths.ESCROW, PredefinedDbPaths.ESCROW, accountKey);
     const transferResult = this.setServiceAccountTransferOrLog(
         sourceAccount, escrowServiceAccountName, amount, auth, timestamp, transaction);
-    if (transferResult === true) {
+    if (transferResult.code === 0) {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.SUCCESS);
     } else {
       this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
@@ -700,7 +700,7 @@ class Functions {
     if (targetAmount > 0) {
       const result = this.setServiceAccountTransferOrLog(
           escrowServiceAccountName, targetAccount, targetAmount, auth, timestamp, transaction);
-      if (result !== true) {
+      if (result.code !== 0) {
         this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
         return;
       }
@@ -708,7 +708,7 @@ class Functions {
     if (sourceAmount > 0) {
       const result = this.setServiceAccountTransferOrLog(
           escrowServiceAccountName, sourceAccount, sourceAmount, auth, timestamp, transaction);
-      if (result !== true) {
+      if (result.code !== 0) {
         this.saveAndSetExecutionResult(context, resultPath, FunctionResultCode.INTERNAL_ERROR);
         // TODO(lia): revert the release to target_account if there was any
         return;
@@ -908,17 +908,17 @@ class Functions {
 
     const fromBalance = this.db.getValue(fromPath);
     if (fromBalance < value) {
-      return false;
+      return ChainUtil.returnTxResult(1001, `Insufficient balance: ${fromBalance}`);
     }
     const decResult = this.decValueOrLog(fromPath, value, auth, timestamp, transaction);
-    if (decResult !== true) {
+    if (decResult.code !== 0) {
       return decResult;
     }
     const incResult = this.incValueOrLog(toPath, value, auth, timestamp, transaction);
-    if (incResult !== true) {
+    if (incResult.code !== 0) {
       return incResult;
     }
-    return true;
+    return ChainUtil.returnTxResult(0);
   }
 }
 

--- a/db/functions.js
+++ b/db/functions.js
@@ -791,11 +791,6 @@ class Functions {
     }
   }
 
-  getCheckinPayloadPathFromValuePath(valuePath) {
-    const branchPath = ChainUtil.formatPath(valuePath.slice(0, -3));
-    return PathUtil.getCheckinPayloadPath(branchPath);
-  }
-
   _closeCheckin(value, context) {
     if (!this.tp || !this.db.isNodeDb) {
       // It's not the backupDb

--- a/db/index.js
+++ b/db/index.js
@@ -573,12 +573,12 @@ class DB {
   setValue(valuePath, value, auth, timestamp, transaction, isGlobal) {
     const isValidObj = isValidJsObjectForStates(value);
     if (!isValidObj.isValid) {
-      return ChainUtil.returnError(101, `Invalid object for states: ${isValidObj.invalidPath}`);
+      return ChainUtil.returnTxResult(101, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(valuePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return ChainUtil.returnError(102, `Invalid path: ${isValidPath.invalidPath}`);
+      return ChainUtil.returnTxResult(102, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? DB.toLocalPath(parsedPath, this.shardingPath) : parsedPath;
     if (localPath === null) {
@@ -586,7 +586,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForValue(localPath, value, auth, timestamp)) {
-      return ChainUtil.returnError(103, `No .write permission on: ${valuePath}`);
+      return ChainUtil.returnTxResult(103, `No .write permission on: ${valuePath}`);
     }
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.VALUES_ROOT);
     const isWritablePath = isWritablePathWithSharding(fullPath, this.stateRoot);
@@ -595,7 +595,7 @@ class DB {
         // There is nothing to do.
         return true;
       } else {
-        return ChainUtil.returnError(
+        return ChainUtil.returnTxResult(
             104, `Non-writable path with shard config: ${isWritablePath.invalidPath}`);
       }
     }
@@ -613,7 +613,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return ChainUtil.returnError(201, `Not a number type: ${valueBefore} or ${delta}`);
+      return ChainUtil.returnTxResult(201, `Not a number type: ${valueBefore} or ${delta}`);
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) + delta;
     return this.setValue(valuePath, valueAfter, auth, timestamp, transaction, isGlobal);
@@ -623,7 +623,7 @@ class DB {
     const valueBefore = this.getValue(valuePath, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
-      return ChainUtil.returnError(301, `Not a number type: ${valueBefore} or ${delta}`);
+      return ChainUtil.returnTxResult(301, `Not a number type: ${valueBefore} or ${delta}`);
     }
     const valueAfter = (valueBefore === undefined ? 0 : valueBefore) - delta;
     return this.setValue(valuePath, valueAfter, auth, timestamp, transaction, isGlobal);
@@ -632,17 +632,18 @@ class DB {
   setFunction(functionPath, functionChange, auth, isGlobal) {
     const isValidObj = isValidJsObjectForStates(functionChange);
     if (!isValidObj.isValid) {
-      return ChainUtil.returnError(401, `Invalid object for states: ${isValidObj.invalidPath}`);
+      return ChainUtil.returnTxResult(401, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(functionPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return ChainUtil.returnError(402, `Invalid path: ${isValidPath.invalidPath}`);
+      return ChainUtil.returnTxResult(402, `Invalid path: ${isValidPath.invalidPath}`);
     }
     if (!auth || auth.addr !== this.ownerAddress) {
       const ownerOnlyFid = this.func.hasOwnerOnlyFunction(functionChange);
       if (ownerOnlyFid !== null) {
-        return ChainUtil.returnError(403, `Trying to write owner-only function: ${ownerOnlyFid}`);
+        return ChainUtil.returnTxResult(
+            403, `Trying to write owner-only function: ${ownerOnlyFid}`);
       }
     }
     const localPath = isGlobal === true ?
@@ -652,7 +653,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForFunction(localPath, auth)) {
-      return ChainUtil.returnError(404, `No write_function permission on: ${functionPath}`);
+      return ChainUtil.returnTxResult(404, `No write_function permission on: ${functionPath}`);
     }
     const curFunction = this.getFunction(functionPath, isGlobal);
     const newFunction = Functions.applyFunctionChange(curFunction, functionChange);
@@ -667,12 +668,12 @@ class DB {
   setRule(rulePath, rule, auth, isGlobal) {
     const isValidObj = isValidJsObjectForStates(rule);
     if (!isValidObj.isValid) {
-      return ChainUtil.returnError(501, `Invalid object for states: ${isValidObj.invalidPath}`);
+      return ChainUtil.returnTxResult(501, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(rulePath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return ChainUtil.returnError(502, `Invalid path: ${isValidPath.invalidPath}`);
+      return ChainUtil.returnTxResult(502, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? DB.toLocalPath(parsedPath, this.shardingPath) : parsedPath;
     if (localPath === null) {
@@ -680,7 +681,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForRule(localPath, auth)) {
-      return ChainUtil.returnError(503, `No write_rule permission on: ${rulePath}`);
+      return ChainUtil.returnTxResult(503, `No write_rule permission on: ${rulePath}`);
     }
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
     const ruleCopy = ChainUtil.isDict(rule) ? JSON.parse(JSON.stringify(rule)) : rule;
@@ -693,12 +694,12 @@ class DB {
   setOwner(ownerPath, owner, auth, isGlobal) {
     const isValidObj = isValidJsObjectForStates(owner);
     if (!isValidObj.isValid) {
-      return ChainUtil.returnError(601, `Invalid object for states: ${isValidObj.invalidPath}`);
+      return ChainUtil.returnTxResult(601, `Invalid object for states: ${isValidObj.invalidPath}`);
     }
     const parsedPath = ChainUtil.parsePath(ownerPath);
     const isValidPath = isValidPathForStates(parsedPath);
     if (!isValidPath.isValid) {
-      return ChainUtil.returnError(602, `Invalid path: ${isValidPath.invalidPath}`);
+      return ChainUtil.returnTxResult(602, `Invalid path: ${isValidPath.invalidPath}`);
     }
     const localPath = isGlobal === true ? DB.toLocalPath(parsedPath, this.shardingPath) : parsedPath;
     if (localPath === null) {
@@ -706,7 +707,7 @@ class DB {
       return true;
     }
     if (!this.getPermissionForOwner(localPath, auth)) {
-      return ChainUtil.returnError(
+      return ChainUtil.returnTxResult(
           603, `No write_owner or branch_owner permission on: ${ownerPath}`);
     }
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
@@ -752,7 +753,7 @@ class DB {
         }
       } else {
         // Invalid Operation
-        return ChainUtil.returnError(701, `Invalid opeartion type: ${op.type}`);
+        return ChainUtil.returnTxResult(701, `Invalid opeartion type: ${op.type}`);
       }
     }
     return ret;
@@ -804,10 +805,10 @@ class DB {
     if (tx && auth && auth.addr && !auth.fid) {
       const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (tx.tx_body.nonce >= 0 && tx.tx_body.nonce !== nonce) {
-        return ChainUtil.returnError(900, `Invalid nonce: ${tx.tx_body.nonce}`);
+        return ChainUtil.returnTxResult(900, `Invalid nonce: ${tx.tx_body.nonce}`);
       }
       if (tx.tx_body.nonce === -2 && tx.tx_body.timestamp <= accountTimestamp) {
-        return ChainUtil.returnError(901, `Invalid timestamp: ${tx.tx_body.timestamp}`);
+        return ChainUtil.returnTxResult(901, `Invalid timestamp: ${tx.tx_body.timestamp}`);
       }
     }
     let ret;

--- a/db/index.js
+++ b/db/index.js
@@ -876,7 +876,7 @@ class DB {
     for (const tx of txList) {
       const executableTx = Transaction.toExecutable(tx);
       const res = this.executeTransaction(executableTx);
-      if (ChainUtil.transactionFailed(res)) {
+      if (ChainUtil.isFailedTx(res)) {
         // FIXME: remove the failed transaction from tx pool?
         logger.error(`[${LOG_HEADER}] tx failed: ${JSON.stringify(executableTx, null, 2)}` +
             `\nresult: ${JSON.stringify(res)}`);

--- a/db/index.js
+++ b/db/index.js
@@ -864,8 +864,8 @@ class DB {
         txBody.operation, { addr: tx.address }, txBody.timestamp, tx);
     const stateInfo = this.getStateInfo('/');
     const treeHeight = stateInfo[StateInfoProperties.TREE_HEIGHT];
-    if (executionResult === true && treeHeight > TREE_HEIGHT_LIMIT) {
-      return ChainUtil.returnError(910, `Out of tree height limit ` +
+    if (executionResult.code === 0 && treeHeight > TREE_HEIGHT_LIMIT) {
+      return ChainUtil.returnTxResult(23, `Out of tree height limit ` +
           `(${treeHeight} > ${TREE_HEIGHT_LIMIT})`);
     }
     return executionResult;

--- a/integration/afan_dapp.test.js
+++ b/integration/afan_dapp.test.js
@@ -80,7 +80,7 @@ function setUp() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, res.tx_hash)) {
     console.log(`Failed to check finalization of setUp() tx.`)
   }
@@ -109,7 +109,7 @@ function cleanUp() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, res.tx_hash)) {
     console.log(`Failed to check finalization of cleanUp() tx.`)
   }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -124,7 +124,7 @@ function setUp() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
     console.log(`Failed to check finalization of setUp() tx.`)
   }
@@ -158,7 +158,7 @@ function cleanUp() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
     console.log(`Failed to check finalization of cleanUp() tx.`)
   }
@@ -276,7 +276,7 @@ function setUpForNativeFunctions() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
     console.log(`Failed to check finalization of setUpForNativeFunctions() tx.`)
   }
@@ -330,7 +330,7 @@ function cleanUpForNativeFunctions() {
       nonce: -1,
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
     console.log(`Failed to check finalization of cleanUpForNativeFunctions() tx.`)
   }
@@ -882,7 +882,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -904,7 +904,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -926,7 +926,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -950,7 +950,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -999,7 +999,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
           .body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1048,7 +1048,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
           .body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1109,7 +1109,7 @@ describe('Blockchain Node', () => {
             'POST', server1 + '/set_function', {json: request})
             .body.toString('utf-8'));
         expect(_.get(body, 'code')).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1177,7 +1177,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1258,7 +1258,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1362,7 +1362,7 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
-        assert.equal(_.get(body, 'result.result'), true);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
 
         // Confirm that the original value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1576,31 +1576,52 @@ describe('Blockchain Node', () => {
         }
         assert.deepEqual(body.result, [
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           }
         ]);
@@ -1758,15 +1779,24 @@ describe('Blockchain Node', () => {
         }
         assert.deepEqual(body.result, [
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
@@ -1777,19 +1807,31 @@ describe('Blockchain Node', () => {
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           },
           {
-            "result": true,
+            "result": {
+              "code": 0,
+              "error_message": null
+            },
             "tx_hash": "erased"
           }
         ]);
@@ -1831,7 +1873,10 @@ describe('Blockchain Node', () => {
           assert.deepEqual(res.result, {
             protoVer: CURRENT_PROTOCOL_VERSION,
             result: {
-              result: true,
+              result: {
+                code: 0,
+                error_message: null
+              },
               tx_hash: ChainUtil.hashSignature(signature),
             }
           });
@@ -1870,7 +1915,10 @@ describe('Blockchain Node', () => {
             assert.deepEqual(res.result, {
               protoVer: CURRENT_PROTOCOL_VERSION,
               result: {
-                result: true,
+                result: {
+                  code: 0,
+                  error_message: null
+                },
                 tx_hash: ChainUtil.hashSignature(signature),
               }
             });
@@ -2099,7 +2147,10 @@ describe('Blockchain Node', () => {
           const expected = [];
           for (const tx of txList) {
             expected.push({
-              result: true,
+              result: {
+                code: 0,
+                error_message: null
+              },
               tx_hash: ChainUtil.hashSignature(tx.signature),
             })
           }
@@ -2307,7 +2358,7 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8')).result;
-          assert.equal(_.get(res, 'result'), true);
+          assert.deepEqual(_.get(res, 'result.code'), 0);
           if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
             console.log(`Failed to check finalization of owner only cleanup tx.`)
           }
@@ -2327,8 +2378,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2373,8 +2424,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2392,8 +2443,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2401,7 +2452,7 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${saveLastTxAllowedPath + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
           // Should be the tx hash value.
-          assert.equal(_.get(lastTx, 'tx_hash', null), body.result.tx_hash);
+          assert.deepEqual(_.get(lastTx, 'tx_hash', null), body.result.tx_hash);
         });
       });
 
@@ -2413,8 +2464,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2432,8 +2483,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2441,7 +2492,7 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${saveLastTxAllowedPathWithFids + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
           // Should be the tx hash value.
-          assert.equal(_.get(lastTx, 'tx_hash', null), body.result.tx_hash);
+          assert.deepEqual(_.get(lastTx, 'tx_hash', null), body.result.tx_hash);
         });
       });
     });
@@ -2456,8 +2507,8 @@ describe('Blockchain Node', () => {
           ref: transferPath + '/1/value',
           value: transferAmount
         }}).body.toString('utf-8'));
-        assert.equal(_.get(body, 'result.result'), true);
-        assert.equal(body.code, 0);
+        assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        assert.deepEqual(body.code, 0);
         if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
           console.log(`Failed to check finalization of tx.`)
         }
@@ -2589,8 +2640,8 @@ describe('Blockchain Node', () => {
             ref: stakePath + '/1/value',
             value: stakeAmount
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.log(`Failed to check finalization of tx.`)
           }
@@ -2760,8 +2811,8 @@ describe('Blockchain Node', () => {
             ref: `${unstakePath}/2/value`,
             value: stakeAmount
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.log(`Failed to check finalization of tx.`)
           }
@@ -2791,8 +2842,8 @@ describe('Blockchain Node', () => {
             ref: stakePath + '/3/value',
             value: newStakingAmount
           }}).body.toString('utf-8'));
-          assert.equal(_.get(body, 'result.result'), true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.log(`Failed to check finalization of tx.`)
           }

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -156,7 +156,7 @@ function setUp() {
       ],
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(shardServerList, res.tx_hash)) {
     console.log(`Failed to check finalization of setUp() tx.`)
   }
@@ -189,7 +189,7 @@ function cleanUp() {
       ],
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(shardServerList, res.tx_hash)) {
     console.log(`Failed to check finalization of cleanUp() tx.`)
   }
@@ -250,7 +250,7 @@ function setUpForSharding(shardingConfig) {
       ],
     }
   }).body.toString('utf-8')).result;
-  assert.equal(_.get(res, 'result'), true);
+  assert.deepEqual(_.get(res, 'result.code'), 0);
   if (!waitUntilTxFinalized(parentServerList, res.tx_hash)) {
     console.log(`Failed to check finalization of setUpForSharding() tx.`)
   }
@@ -518,7 +518,7 @@ describe('Sharding', () => {
           const body = parseOrLog(
               syncRequest('GET', server1 + '/get_value?ref=/test/test_value/some/path')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, 100);
         })
 
@@ -526,7 +526,7 @@ describe('Sharding', () => {
           const body = parseOrLog(syncRequest(
               'GET', server1 + '/get_value?ref=/test/test_value/some/path&is_global=false')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, 100);
         })
 
@@ -534,7 +534,7 @@ describe('Sharding', () => {
           const body = parseOrLog(syncRequest(
               'GET', server1 + '/get_value?ref=/apps/afan/test/test_value/some/path&is_global=true')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, 100);
         })
       })
@@ -544,7 +544,7 @@ describe('Sharding', () => {
           const body = parseOrLog(
               syncRequest('GET', server1 + '/get_function?ref=/test/test_function/some/path')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, {
             '.function': {
               'fid': 'some function config'
@@ -556,7 +556,7 @@ describe('Sharding', () => {
           const body = parseOrLog(syncRequest(
               'GET', server1 + '/get_function?ref=/apps/afan/test/test_function/some/path&is_global=true')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, {
             '.function': {
               'fid': 'some function config'
@@ -570,7 +570,7 @@ describe('Sharding', () => {
           const body = parseOrLog(
               syncRequest('GET', server1 + '/get_rule?ref=/test/test_rule/some/path')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, { '.write': 'auth.addr === \'abcd\'' });
         })
 
@@ -578,7 +578,7 @@ describe('Sharding', () => {
           const body = parseOrLog(syncRequest(
               'GET', server1 + '/get_rule?ref=/apps/afan/test/test_rule/some/path&is_global=true')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, { '.write': 'auth.addr === \'abcd\'' });
         })
       })
@@ -588,7 +588,7 @@ describe('Sharding', () => {
           const body = parseOrLog(
               syncRequest('GET', server1 + '/get_owner?ref=/test/test_owner/some/path')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, {
             ".owner": {
               "owners": {
@@ -607,7 +607,7 @@ describe('Sharding', () => {
           const body = parseOrLog(syncRequest(
               'GET', server1 + '/get_owner?ref=/apps/afan/test/test_owner/some/path&is_global=true')
             .body.toString('utf-8'));
-          assert.equal(body.code, 0);
+          assert.deepEqual(body.code, 0);
           assert.deepEqual(body.result, {
             ".owner": {
               "owners": {
@@ -1203,16 +1203,16 @@ describe('Sharding', () => {
           const request = {ref: 'test/test_value/some/path', value: "some value", nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set_value with is_global = false (explicit)', () => {
           const request = {ref: 'test/test_value/some/path', value: "some value", is_global: false, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set_value with is_global = true', () => {
@@ -1221,8 +1221,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1231,8 +1231,8 @@ describe('Sharding', () => {
           const request = {ref: 'test/test_value/some/path', value: 10, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/inc_value with is_global = true', () => {
@@ -1241,8 +1241,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1251,8 +1251,8 @@ describe('Sharding', () => {
           const request = {ref: 'test/test_value/some/path', value: 10, nonce: -1};
           const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/dec_value with is_global = true', () => {
@@ -1261,8 +1261,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
               .body.toString('utf-8'));
-          assert.deepEqual(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1279,8 +1279,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_function', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set_function with is_global = true', () => {
@@ -1296,8 +1296,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_function', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1312,8 +1312,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set_rule with is_global = true', () => {
@@ -1327,8 +1327,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1343,8 +1343,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set_owner with is_global = true', () => {
@@ -1358,8 +1358,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1408,8 +1408,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
 
         it('/set with is_global = true', () => {
@@ -1462,8 +1462,8 @@ describe('Sharding', () => {
           };
           const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
               .body.toString('utf-8'));
-          assert.equal(body.result.result, true);
-          assert.equal(body.code, 0);
+          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
         })
       })
 
@@ -1490,7 +1490,10 @@ describe('Sharding', () => {
               assert.deepEqual(res.result, {
                 protoVer: CURRENT_PROTOCOL_VERSION,
                 result: {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 }
               });
@@ -1520,7 +1523,10 @@ describe('Sharding', () => {
               assert.deepEqual(res.result, {
                 protoVer: CURRENT_PROTOCOL_VERSION,
                 result: {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 }
               });
@@ -1550,7 +1556,10 @@ describe('Sharding', () => {
               assert.deepEqual(res.result, {
                 protoVer: CURRENT_PROTOCOL_VERSION,
                 result: {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 }
               });
@@ -1589,7 +1598,10 @@ describe('Sharding', () => {
               protoVer: CURRENT_PROTOCOL_VERSION,
               result: [
                 {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 },
               ]
@@ -1631,7 +1643,10 @@ describe('Sharding', () => {
               protoVer: CURRENT_PROTOCOL_VERSION,
               result: [
                 {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 },
               ]
@@ -1673,7 +1688,10 @@ describe('Sharding', () => {
               protoVer: CURRENT_PROTOCOL_VERSION,
               result: [
                 {
-                  result: true,
+                  result: {
+                    code: 0,
+                    error_message: null
+                  },
                   tx_hash: ChainUtil.hashSignature(signature),
                 },
               ]

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -12,11 +12,7 @@ const {
   NETWORK_ID,
 } = require('../common/constants');
 const Transaction = require('../tx-pool/transaction');
-const {
-  getAccountBalancePath,
-  getConsensusWhitelistAddrPath,
-  getServiceAccountBalancePath,
-} = require('../common/path-util');
+const PathUtil = require('../common/path-util');
 
 /**
  * Defines the list of funtions which are accessibly to clients through the
@@ -345,7 +341,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
 
     ain_getBalance: function(args, done) {
       const address = args.address;
-      const balance = p2pServer.node.db.getValue(getAccountBalancePath(address)) || 0;
+      const balance = p2pServer.node.db.getValue(PathUtil.getAccountBalancePath(address)) || 0;
       done(null, addProtocolVersion({result: balance}));
     },
 
@@ -357,8 +353,8 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
 
     ain_isValidator: function(args, done) {
       const addr = args.address;
-      const whitelisted = p2pServer.node.db.getValue(getConsensusWhitelistAddrPath(addr));
-      const stake = p2pServer.node.db.getValue(getServiceAccountBalancePath(addr));
+      const whitelisted = p2pServer.node.db.getValue(PathUtil.getConsensusWhitelistAddrPath(addr));
+      const stake = p2pServer.node.db.getValue(PathUtil.getServiceAccountBalancePath(addr));
       done(null, addProtocolVersion({result: stake && whitelisted ? stake : 0}));
     },
 

--- a/node/index.js
+++ b/node/index.js
@@ -305,7 +305,7 @@ class BlockchainNode {
   executeOrRollbackTransaction(tx) {
     const LOG_HEADER = 'executeOrRollbackTransaction';
     if (!this.db.backupDb()) {
-      return ChainUtil.logAndReturnError(
+      return ChainUtil.logAndReturnTxResult(
           logger, 3,
           `[${LOG_HEADER}] Failed to backup db for tx: ${JSON.stringify(tx, null, 2)}`);
     }
@@ -329,12 +329,12 @@ class BlockchainNode {
       logger.info(`[${LOG_HEADER}] EXECUTING TRANSACTION: ${JSON.stringify(tx, null, 2)}`);
     }
     if (this.tp.isNotEligibleTransaction(tx)) {
-      return ChainUtil.logAndReturnError(
+      return ChainUtil.logAndReturnTxResult(
           logger, 1,
           `[${LOG_HEADER}] Already received transaction: ${JSON.stringify(tx, null, 2)}`);
     }
     if (this.state !== BlockchainNodeStates.SERVING) {
-      return ChainUtil.logAndReturnError(
+      return ChainUtil.logAndReturnTxResult(
           logger, 2, `[${LOG_HEADER}] Blockchain node is NOT in SERVING mode: ${this.state}`, 0);
     }
     const executableTx = Transaction.toExecutable(tx);

--- a/node/index.js
+++ b/node/index.js
@@ -310,7 +310,7 @@ class BlockchainNode {
           `[${LOG_HEADER}] Failed to backup db for tx: ${JSON.stringify(tx, null, 2)}`);
     }
     const result = this.db.executeTransaction(tx);
-    if (ChainUtil.transactionFailed(result)) {
+    if (ChainUtil.isFailedTx(result)) {
       if (!this.db.restoreDb()) {
         logger.error(
           `[${LOG_HEADER}] Failed to restore db for tx: ${JSON.stringify(tx, null, 2)}`);
@@ -339,7 +339,7 @@ class BlockchainNode {
     }
     const executableTx = Transaction.toExecutable(tx);
     const result = this.executeOrRollbackTransaction(executableTx);
-    if (ChainUtil.transactionFailed(result)) {
+    if (ChainUtil.isFailedTx(result)) {
       if (FeatureFlags.enableRichTransactionLogging) {
         logger.error(
             `[${LOG_HEADER}] FAILED TRANSACTION: ${JSON.stringify(executableTx, null, 2)}\n ` +

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -484,7 +484,7 @@ class P2pServer {
           tx_hash: subTx.hash,
           result
         });
-        if (!ChainUtil.transactionFailed(result)) {
+        if (!ChainUtil.isFailedTx(result)) {
           txListSucceeded.push(subTx);
         }
       }
@@ -497,7 +497,7 @@ class P2pServer {
     } else {
       const result = this.node.executeTransactionAndAddToPool(tx);
       logger.debug(`\n TX RESULT: ` + JSON.stringify(result));
-      if (!ChainUtil.transactionFailed(result)) {
+      if (!ChainUtil.isFailedTx(result)) {
         this.client.broadcastTransaction(tx);
       }
 

--- a/p2p/util.js
+++ b/p2p/util.js
@@ -33,7 +33,7 @@ async function sendSignedTx(endpoint, params) {
         id: 0
       }
   ).then((resp) => {
-    const success = !ChainUtil.transactionFailed(_.get(resp, 'data.result'), null);
+    const success = !ChainUtil.isFailedTx(_.get(resp, 'data.result'), null);
     return {success};
   }).catch((err) => {
     logger.error(`Failed to send transaction: ${err}`);

--- a/p2p/util.js
+++ b/p2p/util.js
@@ -33,7 +33,7 @@ async function sendSignedTx(endpoint, params) {
         id: 0
       }
   ).then((resp) => {
-    const success = !ChainUtil.isFailedTx(_.get(resp, 'data.result'), null);
+    const success = !ChainUtil.isFailedTx(_.get(resp, 'data.result.result.result'), null);
     return {success};
   }).catch((err) => {
     logger.error(`Failed to send transaction: ${err}`);

--- a/start_servers.sh
+++ b/start_servers.sh
@@ -1,33 +1,33 @@
 # PARENT CHAIN
 node ./tracker-server/index.js &
 sleep 5
-ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
 sleep 10
-ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
 sleep 10
-ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
 sleep 10
-ACCOUNT_INDEX=3 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=3 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
 sleep 10
-ACCOUNT_INDEX=4 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=4 GENESIS_CONFIGS_DIR=genesis-configs/base MIN_NUM_VALIDATORS=5 STAKE=100000 node ./client/index.js &
 sleep 10
 
 # CHILD CHAIN 1
-PORT=9010 P2P_PORT=6010 node ./tracker-server/index.js &
+CONSOLE_LOG=true PORT=9010 P2P_PORT=6010 node ./tracker-server/index.js &
 sleep 10
-PORT=9011 P2P_PORT=6011 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9011 P2P_PORT=6011 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
 sleep 10
-PORT=9012 P2P_PORT=6012 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9012 P2P_PORT=6012 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
 sleep 10
-PORT=9013 P2P_PORT=6013 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9013 P2P_PORT=6013 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard STAKE=250 node ./client/index.js &
 sleep 10
 
 # CHILD CHAIN 2
-PORT=9020 P2P_PORT=6020 node ./tracker-server/index.js &
+CONSOLE_LOG=true PORT=9020 P2P_PORT=6020 node ./tracker-server/index.js &
 sleep 10
-PORT=9021 P2P_PORT=6021 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9021 P2P_PORT=6021 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
 sleep 10
-PORT=9022 P2P_PORT=6022 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9022 P2P_PORT=6022 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
 sleep 10
-PORT=9023 P2P_PORT=6023 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
+CONSOLE_LOG=true PORT=9023 P2P_PORT=6023 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/sim-shard TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 node ./client/index.js &
 sleep 10

--- a/start_servers_afan.sh
+++ b/start_servers_afan.sh
@@ -1,21 +1,21 @@
 rm -rf ./chains/ ./logs/
 
 # PARENT CHAIN
-node ./tracker-server/index.js &
+CONSOLE_LOG=true node ./tracker-server/index.js &
 sleep 5
-ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
 sleep 5
-ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
 sleep 5
-ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
+CONSOLE_LOG=true ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/base node ./client/index.js &
 sleep 15
 
 # AFAN CHILD CHAIN
-PORT=9010 P2P_PORT=6000 node ./tracker-server/index.js &
+CONSOLE_LOG=true PORT=9010 P2P_PORT=6000 node ./tracker-server/index.js &
 sleep 5
-PORT=9011 P2P_PORT=6001 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
+CONSOLE_LOG=true PORT=9011 P2P_PORT=6001 ACCOUNT_INDEX=0 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
 sleep 5
-PORT=9012 P2P_PORT=6002 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
+CONSOLE_LOG=true PORT=9012 P2P_PORT=6002 ACCOUNT_INDEX=1 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
 sleep 5
-PORT=9013 P2P_PORT=6003 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
+CONSOLE_LOG=true PORT=9013 P2P_PORT=6003 ACCOUNT_INDEX=2 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard node ./client/index.js &
 sleep 15

--- a/tools/util.js
+++ b/tools/util.js
@@ -19,7 +19,7 @@ function signAndSendTx(endpointUrl, txBody, privateKey) {
       id: 0
     }
   ).then((resp) => {
-    const success = !ChainUtil.transactionFailed(_.get(resp, 'data.result.result.result', null));
+    const success = !ChainUtil.isFailedTx(_.get(resp, 'data.result.result.result', null));
     console.log(`result: ${JSON.stringify(success, null, 2)}`);
     return {txHash, signedTx, success};
   }).catch((err) => {

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -269,4 +269,35 @@ describe("ChainUtil", () => {
       assert.deepEqual(obj.b.ba, value);
     })
   })
+
+  describe("isFailedTx", () => {
+    it("when normal input", () => {
+      expect(ChainUtil.isFailedTx({
+        code: 0,
+        error_message: null
+      })).to.equal(false);
+
+      expect(ChainUtil.isFailedTx({
+        code: 1,
+        error_message: null
+      })).to.equal(true);
+
+      expect(ChainUtil.isFailedTx({
+        code: 100,
+        error_message: 'some message'
+      })).to.equal(true);
+    })
+
+    it("when abnormal input", () => {
+      expect(ChainUtil.isFailedTx(null)).to.equal(true);
+      expect(ChainUtil.isFailedTx(undefined)).to.equal(true);
+      expect(ChainUtil.isFailedTx(true)).to.equal(true);
+      expect(ChainUtil.isFailedTx(false)).to.equal(true);
+      expect(ChainUtil.isFailedTx('true')).to.equal(true);
+      expect(ChainUtil.isFailedTx({})).to.equal(true);
+      expect(ChainUtil.isFailedTx({
+        error_message: 'some message'
+      })).to.equal(true);
+    })
+  })
 })

--- a/unittest/consensus.test.js
+++ b/unittest/consensus.test.js
@@ -67,6 +67,6 @@ describe("Consensus", () => {
         }
       }
     );
-    expect(node1.db.executeTransaction(voteTx)).to.equal(true);
+    expect(node1.db.executeTransaction(voteTx).code).to.equal(0);
   });
 });

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3008,9 +3008,9 @@ describe("State version handling", () => {
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const newChild21 = newChild2.getChild('child_21');
       const newChild212 = newChild21.getChild('child_212');
-      expect(newChild2 === child2).to.equal(true);
-      expect(newChild21 === child21).to.equal(true);
-      expect(newChild212 === child212).to.equal(true);
+      expect(newChild2).to.equal(child2);  // Not cloned
+      expect(newChild21).to.equal(child21);  // Not cloned
+      expect(newChild212).to.equal(child212);  // Not cloned
     });
   });
 
@@ -3031,9 +3031,9 @@ describe("State version handling", () => {
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const newChild21 = newChild2.getChild('child_21');
       const newChild212 = newChild21.getChild('child_212');
-      expect(newChild2 === child2).to.equal(true);
-      expect(newChild21 === child21).to.equal(true);
-      expect(newChild212 === child212).to.equal(true);
+      expect(newChild2).to.equal(child2);  // Not cloned
+      expect(newChild21).to.equal(child21);  // Not cloned
+      expect(newChild212).to.equal(child212);  // Not cloned
     });
 
     it("the nodes of multiple access paths are cloned - multiple roots", () => {
@@ -3051,9 +3051,9 @@ describe("State version handling", () => {
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const newChild21 = newChild2.getChild('child_21');
       const newChild212 = newChild21.getChild('child_212');
-      expect(newChild2 === child2).to.equal(false);  // Cloned.
-      expect(newChild21 === child21).to.equal(false);  // Cloned.
-      expect(newChild212 === child212).to.equal(false);  // Cloned.
+      expect(newChild2).to.not.equal(child2);  // Cloned.
+      expect(newChild21).to.not.equal(child21);  // Cloned.
+      expect(newChild212).to.not.equal(child212);  // Cloned.
     });
 
     it("the nodes of multiple access paths are cloned - multiple parents case 1", () => {
@@ -3070,9 +3070,9 @@ describe("State version handling", () => {
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const newChild21 = newChild2.getChild('child_21');
       const newChild212 = newChild21.getChild('child_212');
-      expect(newChild2 === child2).to.equal(true);  // Not cloned.
-      expect(newChild21 === child21).to.equal(false);  // Cloned.
-      expect(newChild212 === child212).to.equal(false);  // Cloned.
+      expect(newChild2).to.equal(child2);  // Not cloned.
+      expect(newChild21).to.not.equal(child21);  // Cloned.
+      expect(newChild212).to.not.equal(child212);  // Cloned.
     });
 
     it("the nodes of multiple access paths are cloned - multiple parents case 2", () => {
@@ -3089,9 +3089,9 @@ describe("State version handling", () => {
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const newChild21 = newChild2.getChild('child_21');
       const newChild212 = newChild21.getChild('child_212');
-      expect(newChild2 === child2).to.equal(true);  // Not cloned.
-      expect(newChild21 === child21).to.equal(true);  // Not cloned
-      expect(newChild212 === child212).to.equal(false);  // Cloned.
+      expect(newChild2).to.equal(child2);  // Not cloned.
+      expect(newChild21).to.equal(child21);  // Not cloned.
+      expect(newChild212).to.not.equal(child212);  // Cloned.
     });
 
     it("the on other ref paths are not affected", () => {
@@ -3108,9 +3108,9 @@ describe("State version handling", () => {
       const afterOtherChild2 = otherRoot.getChild('values').getChild('test').getChild('child_2');
       const afterOtherChild21 = afterOtherChild2.getChild('child_21');
       const afterOtherChild212 = afterOtherChild21.getChild('child_212');
-      expect(afterOtherChild2 === beforeOtherChild2).to.equal(true);
-      expect(afterOtherChild21 === beforeOtherChild21).to.equal(true);
-      expect(afterOtherChild212 === beforeOtherChild212).to.equal(true);
+      expect(afterOtherChild2).to.equal(beforeOtherChild2);  // Not cloned
+      expect(afterOtherChild21).to.equal(beforeOtherChild21);  // Not cloned
+      expect(afterOtherChild212).to.equal(beforeOtherChild212);  // Not cloned
 
       // The state values of other roots are not affected.
       assert.deepEqual(otherRoot.getChild('values').getChild('test').toJsObject(), dbValues);

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3191,7 +3191,7 @@ describe("Transaction execution", () => {
         timestamp: 1568798344000,
       };
       const maxHeightTx = Transaction.fromTxBody(maxHeightTxBody, node.account.private_key);
-      assert.equal(node.db.executeTransaction(maxHeightTx).code, 0);
+      assert.deepEqual(node.db.executeTransaction(maxHeightTx).code, 0);
 
       const overHeightTxBody = {
         operation: {
@@ -3203,7 +3203,7 @@ describe("Transaction execution", () => {
         timestamp: 1568798344000,
       };
       const overHeightTx = Transaction.fromTxBody(overHeightTxBody, node.account.private_key);
-      assert.equal(node.db.executeTransaction(overHeightTx).code, 23);
+      assert.deepEqual(node.db.executeTransaction(overHeightTx).code, 23);
     })
   });
 });

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3176,7 +3176,7 @@ describe("Transaction execution", () => {
     });
 
     it("returns false for object transaction", () => {
-      assert.equal(node.db.executeTransaction(objectTx), false);
+      assert.equal(node.db.executeTransaction(objectTx).code, 1101);
       assert.equal(objectTx.extra, undefined);
     });
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3184,26 +3184,26 @@ describe("Transaction execution", () => {
       const maxHeightTxBody = {
         operation: {
           type: 'SET_VALUE',
-          ref: '/test/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18',
+          ref: '/test/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20',
           value: 'some value',
         },
         nonce: -1,
         timestamp: 1568798344000,
       };
       const maxHeightTx = Transaction.fromTxBody(maxHeightTxBody, node.account.private_key);
-      assert.equal(node.db.executeTransaction(maxHeightTx), true);
+      assert.equal(node.db.executeTransaction(maxHeightTx).code, 0);
 
       const overHeightTxBody = {
         operation: {
           type: 'SET_VALUE',
-          ref: '/test/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19',
+          ref: '/test/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21',
           value: 'some value',
         },
         nonce: -1,
         timestamp: 1568798344000,
       };
       const overHeightTx = Transaction.fromTxBody(overHeightTxBody, node.account.private_key);
-      assert.equal(node.db.executeTransaction(overHeightTx).code, 910);
+      assert.equal(node.db.executeTransaction(overHeightTx).code, 23);
     })
   });
 });

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -134,7 +134,7 @@ describe("DB operations", () => {
       }
     };
     result = node.db.setValue("test", dbValues);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbFuncs = {
       "some": {
@@ -158,7 +158,7 @@ describe("DB operations", () => {
       }
     };
     result = node.db.setFunction("test/test_function", dbFuncs);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbRules = {
       "some": {
@@ -176,7 +176,7 @@ describe("DB operations", () => {
       }
     };
     result = node.db.setRule("test/test_rule", dbRules);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbOwners = {
       "some": {
@@ -221,7 +221,7 @@ describe("DB operations", () => {
       }
     };
     result = node.db.setOwner("test/test_owner", dbOwners);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   });
 
   afterEach(() => {
@@ -620,75 +620,75 @@ describe("DB operations", () => {
     it("when evaluating existing variable path rule", () => {
       expect(node.db.evalRule(
           "/test/test_rule/some/var_path", 'value', { addr: 'abcd' }, Date.now()))
-        .to.equal(false);
+              .to.equal(false);
       expect(node.db.evalRule(
           "/test/test_rule/some/var_path", 'value', { addr: 'other' }, Date.now()))
-        .to.equal(true);
+              .to.equal(true);
     })
 
     it("when evaluating existing non-variable path rule", () => {
       expect(node.db.evalRule("/test/test_rule/some/path", 'value', { addr: 'abcd' }, Date.now()))
-        .to.equal(true);
+          .to.equal(true);
       expect(node.db.evalRule("/test/test_rule/some/path", 'value', { addr: 'other' }, Date.now()))
-        .to.equal(false);
+          .to.equal(false);
       expect(node.db.evalRule(
           "/test/test_rule/some/path/deeper/path", 'value', { addr: 'ijkl' }, Date.now()))
-        .to.equal(true);
+              .to.equal(true);
       expect(node.db.evalRule(
-            "/test/test_rule/some/path/deeper/path", 'value', { addr: 'other' }, Date.now()))
-        .to.equal(false);
+          "/test/test_rule/some/path/deeper/path", 'value', { addr: 'other' }, Date.now()))
+              .to.equal(false);
     })
 
     it("when evaluating existing closest rule", () => {
       expect(node.db.evalRule(
           "/test/test_rule/some/path/deeper", 'value', { addr: 'abcd' }, Date.now()))
-        .to.equal(true);
+              .to.equal(true);
       expect(node.db.evalRule(
           "/test/test_rule/some/path/deeper", 'value', { addr: 'other' }, Date.now()))
-        .to.equal(false);
+              .to.equal(false);
     })
   })
 
   describe("evalOwner operations", () => {
     it("when evaluating existing owner with matching address", () => {
       expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', { addr: 'abcd' }))
-        .to.equal(true);
+          .to.equal(true);
       expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', { addr: 'abcd' }))
-        .to.equal(false);
+          .to.equal(false);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper/path", 'write_owner', { addr: 'ijkl' }))
-        .to.equal(true);
+              .to.equal(true);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper/path", 'write_rule', { addr: 'ijkl' }))
-        .to.equal(false);
+              .to.equal(false);
     })
 
     it("when evaluating existing owner without matching address", () => {
       expect(node.db.evalOwner("/test/test_owner/some/path", 'write_owner', { addr: 'other' }))
-        .to.equal(false);
+          .to.equal(false);
       expect(node.db.evalOwner("/test/test_owner/some/path", 'write_rule', { addr: 'other' }))
-        .to.equal(true);
+          .to.equal(true);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper/path", 'write_owner', { addr: 'other' }))
-        .to.equal(false);
+              .to.equal(false);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper/path", 'write_rule', { addr: 'other' }))
-        .to.equal(true);
+              .to.equal(true);
     })
 
     it("when evaluating closest owner", () => {
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper", 'write_owner', { addr: 'abcd' }))
-        .to.equal(true);
+              .to.equal(true);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper", 'write_rule', { addr: 'abcd' }))
-        .to.equal(false);
+              .to.equal(false);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper", 'write_owner', { addr: 'other' }))
-        .to.equal(false);
+              .to.equal(false);
       expect(node.db.evalOwner(
           "/test/test_owner/some/path/deeper", 'write_rule', { addr: 'other' }))
-        .to.equal(true);
+              .to.equal(true);
     })
   })
 
@@ -982,13 +982,13 @@ describe("DB operations", () => {
   describe("setValue operations", () => {
     it("when overwriting nested value", () => {
       const newValue = {"new": 12345}
-      expect(node.db.setValue("test/nested/far/down", newValue)).to.equal(true)
+      expect(node.db.setValue("test/nested/far/down", newValue).code).to.equal(0)
       assert.deepEqual(node.db.getValue("test/nested/far/down"), newValue)
     })
 
     it("when creating new path in database", () => {
       const newValue = 12345
-      expect(node.db.setValue("test/new/unchartered/nested/path", newValue)).to.equal(true)
+      expect(node.db.setValue("test/new/unchartered/nested/path", newValue).code).to.equal(0)
       expect(node.db.getValue("test/new/unchartered/nested/path")).to.equal(newValue)
     })
 
@@ -1087,16 +1087,16 @@ describe("DB operations", () => {
     })
 
     it("when writing with writable path with sharding", () => {
-      expect(node.db.setValue("test/shards/disabled_shard", 20)).to.equal(true);
+      expect(node.db.setValue("test/shards/disabled_shard", 20).code).to.equal(0);
       expect(node.db.getValue("test/shards/disabled_shard")).to.equal(20)
-      expect(node.db.setValue("test/shards/disabled_shard/path", 20)).to.equal(true);
+      expect(node.db.setValue("test/shards/disabled_shard/path", 20).code).to.equal(0);
       expect(node.db.getValue("test/shards/disabled_shard/path")).to.equal(20)
     })
   })
 
   describe("incValue operations", () => {
     it("when increasing value successfully", () => {
-      expect(node.db.incValue("test/increment/value", 10)).to.equal(true)
+      expect(node.db.incValue("test/increment/value", 10).code).to.equal(0)
       expect(node.db.getValue("test/increment/value")).to.equal(30)
     })
 
@@ -1123,14 +1123,14 @@ describe("DB operations", () => {
     })
 
     it("when increasing with writable path with sharding", () => {
-      expect(node.db.incValue("test/shards/disabled_shard/path", 5)).to.equal(true);
+      expect(node.db.incValue("test/shards/disabled_shard/path", 5).code).to.equal(0);
       expect(node.db.getValue("test/shards/disabled_shard/path")).to.equal(15)
     })
   })
 
   describe("decValue operations", () => {
     it("when decreasing value successfully", () => {
-      expect(node.db.decValue("test/decrement/value", 10)).to.equal(true)
+      expect(node.db.decValue("test/decrement/value", 10).code).to.equal(0)
       expect(node.db.getValue("test/decrement/value")).to.equal(10)
     })
 
@@ -1157,7 +1157,7 @@ describe("DB operations", () => {
     })
 
     it("when increasing with writable path with sharding", () => {
-      expect(node.db.decValue("test/shards/disabled_shard/path", 5)).to.equal(true);
+      expect(node.db.decValue("test/shards/disabled_shard/path", 5).code).to.equal(0);
       expect(node.db.getValue("test/shards/disabled_shard/path")).to.equal(5)
     })
   })
@@ -1169,7 +1169,8 @@ describe("DB operations", () => {
           "fid": "other function config"
         }
       };
-      expect(node.db.setFunction("/test/test_function/some/path", functionConfig)).to.equal(true)
+      expect(node.db.setFunction("/test/test_function/some/path", functionConfig).code)
+          .to.equal(0);
       assert.deepEqual(node.db.getFunction("/test/test_function/some/path"), {
         ".function": {
           "fid": "other function config"  // modified
@@ -1190,8 +1191,8 @@ describe("DB operations", () => {
           "fid_other": "other function config"
         }
       };
-      expect(node.db.setFunction("/test/test_function/some/$variable/path", functionConfig))
-          .to.equal(true)
+      expect(node.db.setFunction("/test/test_function/some/$variable/path", functionConfig).code)
+          .to.equal(0);
       assert.deepEqual(
           node.db.getFunction("/test/test_function/some/$variable/path"), functionConfig)
     })
@@ -1222,13 +1223,14 @@ describe("DB operations", () => {
   describe("setRule operations", () => {
     it("when overwriting existing rule config with simple path", () => {
       const ruleConfig = {".write": "other rule config"};
-      expect(node.db.setRule("/test/test_rule/some/path", ruleConfig)).to.equal(true)
+      expect(node.db.setRule("/test/test_rule/some/path", ruleConfig).code).to.equal(0);
       assert.deepEqual(node.db.getRule("/test/test_rule/some/path"), ruleConfig)
     })
 
     it("when writing with variable path", () => {
       const ruleConfig = {".write": "other rule config"};
-      expect(node.db.setRule("/test/test_rule/some/$variable/path", ruleConfig)).to.equal(true)
+      expect(node.db.setRule("/test/test_rule/some/$variable/path", ruleConfig).code)
+          .to.equal(0)
       assert.deepEqual(node.db.getRule("/test/test_rule/some/$variable/path"), ruleConfig)
     })
 
@@ -1257,8 +1259,8 @@ describe("DB operations", () => {
   describe("setOwner operations", () => {
     it("when overwriting existing owner config", () => {
       const ownerConfig = {".owner": "other owner config"};
-      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, { addr: 'abcd' }))
-        .to.equal(true)
+      expect(node.db.setOwner("/test/test_owner/some/path", ownerConfig, { addr: 'abcd' }).code)
+          .to.equal(0)
       assert.deepEqual(node.db.getOwner("/test/test_owner/some/path"), ownerConfig)
     })
 
@@ -1327,7 +1329,7 @@ describe("DB operations", () => {
             ".owner": "other owner config"
           }
         }
-      ], { addr: 'abcd' }, null, { extra: { executed_at: 123456789 }})).to.equal(true)
+      ], { addr: 'abcd' }, null, { extra: { executed_at: 123456789 }}).code).to.equal(0);
       assert.deepEqual(node.db.getValue("test/nested/far/down"), { "new": 12345 })
       expect(node.db.getValue("test/increment/value")).to.equal(30)
       expect(node.db.getValue("test/decrement/value")).to.equal(10)
@@ -1413,7 +1415,7 @@ describe("DB operations", () => {
         }
       };
       const valueResult = node.db.setValue("/test/empty_values/node_0", emptyValues);
-      assert.deepEqual(valueResult, true);
+      assert.deepEqual(valueResult.code, 0);
 
       emptyRules = {
         "terminal_1a": null,
@@ -1432,7 +1434,7 @@ describe("DB operations", () => {
         }
       };
       const ruleResult = node.db.setRule("/test/empty_rules/node_0", emptyRules);
-      assert.deepEqual(ruleResult, true);
+      assert.deepEqual(ruleResult.code, 0);
 
       emptyOwners = {
         "terminal_1a": null,
@@ -1460,23 +1462,23 @@ describe("DB operations", () => {
         }
       };
       const ownerResult = node.db.setOwner("/test/empty_owners/node_0", emptyOwners);
-      assert.deepEqual(ownerResult, true);
+      assert.deepEqual(ownerResult.code, 0);
     });
 
     afterEach(() => {
       const valueResult = node.db.setValue("/test/empty_values/node_0", null);
-      assert.deepEqual(valueResult, true);
+      assert.deepEqual(valueResult.code, 0);
 
       const ruleResult = node.db.setRule("/test/empty_rules/node_0", null);
-      assert.deepEqual(ruleResult, true);
+      assert.deepEqual(ruleResult.code, 0);
 
       const ownerResult = node.db.setRule("/test/empty_owners/node_0", null);
-      assert.deepEqual(ownerResult, true);
+      assert.deepEqual(ownerResult.code, 0);
     });
 
     it("when setValue() with non-empty value", () => {
       expect(node.db.setValue(
-          "/test/empty_values/node_0/node_1a/node_2/node_3", "another value")).to.equal(true)
+          "/test/empty_values/node_0/node_1a/node_2/node_3", "another value").code).to.equal(0);
       assert.deepEqual(node.db.getValue("/test/empty_values/node_0"), {
         "terminal_1a": null,
         "terminal_1b": null,
@@ -1495,7 +1497,7 @@ describe("DB operations", () => {
 
     it("when setValue() with 'null' value", () => {
       expect(node.db.setValue(
-          "/test/empty_values/node_0/node_1a/node_2/node_3", null)).to.equal(true)
+          "/test/empty_values/node_0/node_1a/node_2/node_3", null).code).to.equal(0);
       assert.deepEqual(node.db.getValue("/test/empty_values/node_0"), {
         "terminal_1c": "",
         "node_1b": {
@@ -1508,7 +1510,7 @@ describe("DB operations", () => {
       expect(node.db.setRule(
           "/test/empty_rules/node_0/node_1a/node_2/node_3", {
             ".write": "some other rule"
-          })).to.equal(true)
+          }).code).to.equal(0)
       assert.deepEqual(node.db.getRule("/test/empty_rules/node_0"), {
         "terminal_1a": null,
         "terminal_1b": null,
@@ -1529,7 +1531,7 @@ describe("DB operations", () => {
 
     it("when setRule() with 'null' rule", () => {
       expect(node.db.setRule(
-          "/test/empty_rules/node_0/node_1a/node_2/node_3", null)).to.equal(true)
+          "/test/empty_rules/node_0/node_1a/node_2/node_3", null).code).to.equal(0);
       assert.deepEqual(node.db.getRule("/test/empty_rules/node_0"), {
         "terminal_1c": "",
         "node_1b": {
@@ -1551,7 +1553,7 @@ describe("DB operations", () => {
                 }
               }
             }
-          })).to.equal(true)
+          }).code).to.equal(0)
       assert.deepEqual(node.db.getOwner("/test/empty_owners/node_0"), {
         "terminal_1a": null,
         "terminal_1b": null,
@@ -1581,7 +1583,7 @@ describe("DB operations", () => {
 
     it("when setOwner() with 'null' owner", () => {
       expect(node.db.setOwner(
-          "/test/empty_owners/node_0/node_1a/node_2/node_3", null)).to.equal(true)
+          "/test/empty_owners/node_0/node_1a/node_2/node_3", null).code).to.equal(0);
       assert.deepEqual(node.db.getOwner("/test/empty_owners/node_0"), {
         "terminal_1c": "",
         "node_1b": {
@@ -1634,9 +1636,9 @@ describe("DB rule config", () => {
     dbValues["second_users"][node1.account.address]["something_else"] = "i can write";
 
     result = node1.db.setValue("test", dbValues);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
     result = node2.db.setValue("test", dbValues);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   })
 
   afterEach(() => {
@@ -1645,24 +1647,23 @@ describe("DB rule config", () => {
 
   it("only allows certain users to write certain info if balance is greater than 0", () => {
     expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, 0, null, null))
-      .to.equal(true)
+        .to.equal(true)
     expect(node2.db.evalRule(`test/users/${node2.account.address}/balance`, -1, null, null))
-      .to.equal(false)
+        .to.equal(false)
     expect(node1.db.evalRule(`test/users/${node1.account.address}/balance`, 1, null, null))
-      .to.equal(true)
+        .to.equal(true)
   })
 
   it("only allows certain users to write certain info if data exists", () => {
-    expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/info`, "something", null, null))
-      .to.equal(true)
+    expect(node1.db.evalRule(`test/users/${node1.account.address}/info`, "something", null, null))
+        .to.equal(true)
     expect(node2.db.evalRule(
         `test/users/${node2.account.address}/info`, "something else", null, null))
-      .to.equal(false)
+            .to.equal(false)
     expect(node2.db.evalRule(
         `test/users/${node2.account.address}/new_info`, "something",
         { addr: node2.account.address }, null))
-      .to.equal(true)
+            .to.equal(true)
   })
 
   it("apply the closest ancestor's rule config if not exists", () => {
@@ -1670,47 +1671,45 @@ describe("DB rule config", () => {
         `test/users/${node1.account.address}/child/grandson`, "something",
         { addr: node1.account.address },
         null))
-      .to.equal(true)
+            .to.equal(true)
     expect(node2.db.evalRule(
         `test/users/${node2.account.address}/child/grandson`, "something",
         { addr: node1.account.address },
         null))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("only allows certain users to write certain info if data at other locations exists", () => {
     expect(node2.db.evalRule(
         `test/users/${node2.account.address}/balance_info`, "something", null, null))
-      .to.equal(true)
+            .to.equal(true)
     expect(node1.db.evalRule(
         `test/users/${node1.account.address}/balance_info`, "something", null, null))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("validates old data and new data together", () => {
-    expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/next_counter`, 11, null,  null))
-      .to.equal(true)
-    expect(node1.db.evalRule(
-        `test/users/${node1.account.address}/next_counter`, 12, null, null))
-      .to.equal(false)
+    expect(node1.db.evalRule(`test/users/${node1.account.address}/next_counter`, 11, null,  null))
+        .to.equal(true)
+    expect(node1.db.evalRule(`test/users/${node1.account.address}/next_counter`, 12, null, null))
+        .to.equal(false)
   })
 
   it("can handle nested path variables", () => {
     expect(node2.db.evalRule(
         `test/second_users/${node2.account.address}/${node2.account.address}`, "some value", null,
         null))
-      .to.equal(true)
+            .to.equal(true)
     expect(node1.db.evalRule(
         `test/second_users/${node1.account.address}/next_counter`, "some other value", null, null))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("duplicated path variables", () => {
     expect(node1.db.evalRule('test/no_dup_key/aaa/bbb', "some value", null, null))
-      .to.equal(true)
+        .to.equal(true)
     expect(node1.db.evalRule('test/dup_key/aaa/bbb', "some value", null, null))
-      .to.equal(true)
+        .to.equal(true)
   })
 })
 
@@ -1722,7 +1721,7 @@ describe("DB owner config", () => {
 
     node = new BlockchainNode();
     setNodeForTesting(node);
-    node.db.setOwner("test/test_owner/mixed/true/true/true",
+    assert.deepEqual(node.db.setOwner("test/test_owner/mixed/true/true/true",
       {
         ".owner": {
           "owners": {
@@ -1747,8 +1746,8 @@ describe("DB owner config", () => {
           }
         }
       }
-    );
-    node.db.setOwner("test/test_owner/mixed/false/true/true",
+    ).code, 0);
+    assert.deepEqual(node.db.setOwner("test/test_owner/mixed/false/true/true",
       {
         ".owner": {
           "owners": {
@@ -1773,8 +1772,8 @@ describe("DB owner config", () => {
           }
         }
       }
-    );
-    node.db.setOwner("test/test_owner/mixed/true/false/true",
+    ).code, 0);
+    assert.deepEqual(node.db.setOwner("test/test_owner/mixed/true/false/true",
       {
         ".owner": {
           "owners": {
@@ -1799,8 +1798,8 @@ describe("DB owner config", () => {
           }
         }
       }
-    );
-    node.db.setOwner("test/test_owner/mixed/true/true/false",
+    ).code, 0);
+    assert.deepEqual(node.db.setOwner("test/test_owner/mixed/true/true/false",
       {
         ".owner": {
           "owners": {
@@ -1825,7 +1824,7 @@ describe("DB owner config", () => {
           }
         }
       }
-    );
+    ).code, 0);
   })
 
   afterEach(() => {
@@ -1836,156 +1835,156 @@ describe("DB owner config", () => {
   it("branch_owner permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
   })
 
   it("write_owner permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true', 'write_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true', 'write_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true', 'write_owner', { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false', 'write_owner', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
   })
 
   it("write_rule permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false', 'write_rule', { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("write_rule permission on deeper path for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule', { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("write_function permission for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true', 'write_function', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true', 'write_function', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true', 'write_function', { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false', 'write_function', { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("write_Function permission on deeper path for known user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
         { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
         { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
         { addr: 'known_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
         { addr: 'known_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   // Unknown user
   it("branch_owner permission for unknown user with mixed config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true/branch', 'branch_owner', { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true/branch', 'branch_owner', { addr: 'unknown_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true/branch', 'branch_owner', { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/branch', 'branch_owner', { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("write_owner permission for unknown user with mixed config", () => {
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_owner',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_owner',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_owner',
         { addr: 'unknown_user' }))
-      .to.equal(true)
+            .to.equal(true)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_owner',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
   })
 
   it("write_rule permission for unknown user with mixed config", () => {
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(true)
+            .to.equal(true)
   })
 
   it("write_rule permission on deeper path for unknown user with mixed config", () => {
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner('/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
         { addr: 'unknown_user' }))
-      .to.equal(true)
+            .to.equal(true)
   })
 
   it("write_function permission for unknown user with mixed config", () => {
@@ -2003,19 +2002,19 @@ describe("DB owner config", () => {
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
         { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
          { addr: 'unknown_user' }))
-      .to.equal(false)
+            .to.equal(false)
     expect(node.db.evalOwner(
         '/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
         { addr: 'unknown_user' }))
-      .to.equal(true)
+            .to.equal(true)
   })
 })
 
@@ -2056,7 +2055,7 @@ describe("DB sharding config", () => {
       }
     };
     result = node.db.setValue("test/test_sharding", dbValues);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbFuncs = {
       "some": {
@@ -2075,7 +2074,7 @@ describe("DB sharding config", () => {
       }
     };
     result = node.db.setFunction("test/test_sharding", dbFuncs);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbRules = {
       "some": {
@@ -2091,7 +2090,7 @@ describe("DB sharding config", () => {
       }
     };
     result = node.db.setRule("test/test_sharding", dbRules);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
 
     dbOwners = {
       "some": {
@@ -2118,7 +2117,7 @@ describe("DB sharding config", () => {
       }
     };
     result = node.db.setOwner("test/test_sharding", dbOwners);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   })
 
   afterEach(() => {
@@ -2154,7 +2153,7 @@ describe("DB sharding config", () => {
     it("getValue with isGlobal = true", () => {
       expect(node.db.getValue("test/test_sharding/some/path/to/value", true)).to.equal(null);
       expect(node.db.getValue("apps/afan/test/test_sharding/some/path/to/value", true))
-        .to.equal(value);
+          .to.equal(value);
     })
 
     it("getValue with isGlobal = true and non-existing path", () => {
@@ -2164,24 +2163,24 @@ describe("DB sharding config", () => {
     it("setValue with isGlobal = false", () => {
       expect(node.db.setValue(
           "test/test_sharding/some/path/to/value", newValue, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/value")).to.equal(newValue);
     })
 
     it("setValue with isGlobal = true", () => {
       expect(node.db.setValue(
           "apps/afan/test/test_sharding/some/path/to/value", newValue, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/value")).to.equal(newValue);
     })
 
     it("setValue with isGlobal = true and non-existing path", () => {
       expect(node.db.setValue(
           "some/non-existing/path", newValue, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
     })
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
@@ -2195,47 +2194,47 @@ describe("DB sharding config", () => {
     it("setValue with isGlobal = true and non-writable path with sharding", () => {
       expect(node.db.setValue(
           "apps/afan/test/test_sharding/shards/enabled_shard/path", 20, 'known_user', null, null,
-          true))
-        .to.equal(true);
-      expect(node.db.getValue(
-          "apps/afan/test/test_sharding/shards/enabled_shard/path", true))
-        .to.equal(10);  // value unchanged
+          true).code)
+              .to.equal(0);
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", true))
+          .to.equal(10);  // value unchanged
     })
 
     it("setValue with isGlobal = false and writable path with sharding", () => {
-      expect(node.db.setValue("test/test_sharding/shards/disabled_shard/path", 20)).to.equal(true);
+      expect(node.db.setValue("test/test_sharding/shards/disabled_shard/path", 20).code)
+          .to.equal(0);
       expect(node.db.getValue("test/test_sharding/shards/disabled_shard/path")).to.equal(20);
     })
 
     it("setValue with isGlobal = true and writable path with sharding", () => {
       expect(node.db.setValue(
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 20, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
-        .to.equal(20);  // value changed
+          .to.equal(20);  // value changed
     })
 
     it("incValue with isGlobal = false", () => {
       expect(node.db.incValue(
           "test/test_sharding/some/path/to/number", incDelta, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 + incDelta);
     })
 
     it("incValue with isGlobal = true", () => {
       expect(node.db.incValue(
           "apps/afan/test/test_sharding/some/path/to/number", incDelta, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 + incDelta);
     })
 
     it("incValue with isGlobal = true and non-existing path", () => {
       expect(node.db.incValue(
-          "some/non-existing/path", incDelta, { addr: 'known_user' }, null, null, true))
-        .to.equal(true);
+          "some/non-existing/path", incDelta, { addr: 'known_user' }, null, null, true).code)
+              .to.equal(0);
     })
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
@@ -2249,48 +2248,47 @@ describe("DB sharding config", () => {
     it("setValue with isGlobal = true and non-writable path with sharding", () => {
       expect(node.db.incValue(
           "apps/afan/test/test_sharding/shards/enabled_shard/path", 5, { addr: 'known_user' },
-          null, null, true))
-        .to.equal(true);
-      expect(node.db.getValue(
-          "apps/afan/test/test_sharding/shards/enabled_shard/path", true))
-        .to.equal(10);  // value unchanged
+          null, null, true).code)
+              .to.equal(0);
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", true))
+          .to.equal(10);  // value unchanged
     })
 
     it("setValue with isGlobal = false and writable path with sharding", () => {
-      expect(node.db.incValue("test/test_sharding/shards/disabled_shard/path", 5)).to.equal(true);
+      expect(node.db.incValue("test/test_sharding/shards/disabled_shard/path", 5).code).to.equal(0);
       expect(node.db.getValue("test/test_sharding/shards/disabled_shard/path"))
-        .to.equal(15);  // value changed
+          .to.equal(15);  // value changed
     })
 
     it("setValue with isGlobal = true and writable path with sharding", () => {
       expect(node.db.incValue(
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 5, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
-        .to.equal(15);  // value changed
+          .to.equal(15);  // value changed
     })
 
     it("decValue with isGlobal = false", () => {
       expect(node.db.decValue(
           "test/test_sharding/some/path/to/number", decDelta, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 - decDelta);
     })
 
     it("decValue with isGlobal = true", () => {
       expect(node.db.decValue(
           "apps/afan/test/test_sharding/some/path/to/number", decDelta, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("test/test_sharding/some/path/to/number")).to.equal(10 - decDelta);
     })
 
     it("decValue with isGlobal = true and non-existing path", () => {
       expect(node.db.decValue(
-          "some/non-existing/path", decDelta, { addr: 'known_user' }, null, null, true))
-        .to.equal(true);
+          "some/non-existing/path", decDelta, { addr: 'known_user' }, null, null, true).code)
+              .to.equal(0);
     })
 
     it("setValue with isGlobal = false and non-writable path with sharding", () => {
@@ -2304,24 +2302,25 @@ describe("DB sharding config", () => {
     it("setValue with isGlobal = true and non-writable path with sharding", () => {
       expect(node.db.decValue(
           "apps/afan/test/test_sharding/shards/enabled_shard/path", 5, { addr: 'known_user' },
-          null, null, true))
-        .to.equal(true);
+          null, null, true).code)
+              .to.equal(0);
       expect(node.db.getValue(
           "apps/afan/test/test_sharding/shards/enabled_shard/path", true))
-        .to.equal(10);  // value unchanged
+              .to.equal(10);  // value unchanged
     })
 
     it("setValue with isGlobal = false and writable path with sharding", () => {
-      expect(node.db.decValue("test/test_sharding/shards/disabled_shard/path", 5)).to.equal(true);
+      expect(node.db.decValue("test/test_sharding/shards/disabled_shard/path", 5).code)
+          .to.equal(0);
       expect(node.db.getValue("test/test_sharding/shards/disabled_shard/path"))
-        .to.equal(5);  // value changed
+          .to.equal(5);  // value changed
     })
 
     it("setValue with isGlobal = true and writable path with sharding", () => {
       expect(node.db.decValue(
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 5, { addr: 'known_user' },
-          null, { extra: { executed_at: 123456789 }}, true))
-        .to.equal(true);
+          null, { extra: { executed_at: 123456789 }}, true).code)
+              .to.equal(0);
       expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
         .to.equal(5);  // value changed
     })
@@ -2372,23 +2371,24 @@ describe("DB sharding config", () => {
 
     it("setFunction with isGlobal = false", () => {
       expect(node.db.setFunction(
-          "test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }))
-        .to.equal(true);
+          "test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }).code)
+              .to.equal(0);
       assert.deepEqual(node.db.getFunction("test/test_sharding/some/path/to"), newFunc);
     })
 
     it("setFunction with isGlobal = true", () => {
       expect(node.db.setFunction(
-          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' }, true))
-        .to.equal(true);
+          "apps/afan/test/test_sharding/some/path/to", funcChange, { addr: 'known_user' },
+          true).code)
+              .to.equal(0);
       assert.deepEqual(
           node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), newFunc);
     })
 
     it("setFunction with isGlobal = true and non-existing path", () => {
       expect(node.db.setFunction(
-          "some/non-existing/path", funcChange, { addr: 'known_user' }, true))
-        .to.equal(true);
+          "some/non-existing/path", funcChange, { addr: 'known_user' }, true).code)
+              .to.equal(0);
     })
 
     it("matchFunction with isGlobal = false", () => {
@@ -2471,22 +2471,22 @@ describe("DB sharding config", () => {
 
     it("setRule with isGlobal = false", () => {
       expect(node.db.setRule(
-          "test/test_sharding/some/path/to", newRule, { addr: 'known_user' }))
-        .to.equal(true);
+          "test/test_sharding/some/path/to", newRule, { addr: 'known_user' }).code)
+              .to.equal(0);
       assert.deepEqual(node.db.getRule("test/test_sharding/some/path/to"), newRule);
     })
 
     it("setRule with isGlobal = true", () => {
       expect(node.db.setRule(
-          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, true))
-        .to.equal(true);
+          "apps/afan/test/test_sharding/some/path/to", newRule, { addr: 'known_user' }, true).code)
+              .to.equal(0);
       assert.deepEqual(
           node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), newRule);
     })
 
     it("setRule with isGlobal = true and non-existing path", () => {
-      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, true))
-        .to.equal(true);
+      expect(node.db.setRule("some/non-existing/path", newRule, { addr: 'known_user' }, true).code)
+          .to.equal(0);
     })
 
     it("matchRule with isGlobal = false", () => {
@@ -2535,20 +2535,20 @@ describe("DB sharding config", () => {
 
     it("evalRule with isGlobal = false", () => {
       expect(node.db.evalRule("/test/test_sharding/some/path/to", newValue, { addr: "known_user" }))
-        .to.equal(true);
+          .to.equal(true);
     })
 
     it("evalRule with isGlobal = true", () => {
       expect(node.db.evalRule(
           "/apps/afan/test/test_sharding/some/path/to", newValue, { addr: "known_user" },
           null, true))
-        .to.equal(true);
+              .to.equal(true);
     })
 
     it("evalRule with isGlobal = true and non-existing path", () => {
       expect(node.db.evalRule(
           "/some/non-existing/path", newValue, { addr: "known_user" }, null, true))
-        .to.equal(null);
+              .to.equal(null);
     })
   })
 
@@ -2601,22 +2601,22 @@ describe("DB sharding config", () => {
 
     it("setOwner with isGlobal = false", () => {
       expect(node.db.setOwner(
-          "test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }))
-        .to.equal(true);
+          "test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }).code)
+              .to.equal(0);
       assert.deepEqual(node.db.getOwner("test/test_sharding/some/path/to"), newOwner);
     })
 
     it("setOwner with isGlobal = true", () => {
       expect(node.db.setOwner(
-          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, true))
-        .to.equal(true);
+          "apps/afan/test/test_sharding/some/path/to", newOwner, { addr: 'known_user' }, true).code)
+              .to.equal(0);
       assert.deepEqual(
           node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), newOwner);
     })
 
     it("setOwner with isGlobal = true and non-existing path", () => {
-      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' }, true))
-        .to.equal(true);
+      expect(node.db.setOwner("some/non-existing/path", newOwner, { addr: 'known_user' },
+          true).code).to.equal(0);
     })
 
     it("matchOwner with isGlobal = false", () => {
@@ -2728,7 +2728,7 @@ describe("Proof hash", () => {
       }
     };
     result = node.db.setValue("test", valuesObject);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   });
 
   afterEach(() => {
@@ -2872,7 +2872,7 @@ describe("State info (getStateInfo)", () => {
       }
     };
     result = node.db.setValue("test", valuesObject);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   });
 
   afterEach(() => {
@@ -2885,7 +2885,7 @@ describe("State info (getStateInfo)", () => {
         label121: 'new_value121',
         label122: 'new_value122'
       });
-      assert.deepEqual(result, true);
+      assert.deepEqual(result.code, 0);
 
       // Existing paths.
       assert.deepEqual(
@@ -2915,7 +2915,7 @@ describe("State info (getStateInfo)", () => {
   describe("Tree reduction", () => {
     it("remove state nodes", () => {
       result = node.db.setValue("test/label1/label12", null);  // Reduce tree
-      assert.deepEqual(result, true);
+      assert.deepEqual(result.code, 0);
 
       assert.deepEqual(
           node.db.getStateInfo('/values/test/label1'), { tree_height: 1, tree_size: 2 });
@@ -2933,7 +2933,7 @@ describe("State info (getStateInfo)", () => {
         label211: 'value211',
         label212: 'value212'
       });
-      assert.deepEqual(result, true);
+      assert.deepEqual(result.code, 0);
 
       assert.deepEqual(
           node.db.getStateInfo('/values/test/label1'), { tree_height: 2, tree_size: 5 });
@@ -2986,7 +2986,7 @@ describe("State version handling", () => {
       }
     };
     result = node.db.setValue("test", dbValues);
-    assert.deepEqual(result, true);
+    assert.deepEqual(result.code, 0);
   });
 
   afterEach(() => {
@@ -3121,15 +3121,15 @@ describe("State version handling", () => {
     it("backuped states are restored", () => {
       assert.deepEqual(node.db.getValue('test'), dbValues);
 
-      assert.equal(node.db.backupDb(), true);
+      assert.deepEqual(node.db.backupDb(), true);
       expect(node.db.backupStateVersion).to.not.equal(null);
       expect(node.db.backupStateRoot).to.not.equal(null);
       assert.deepEqual(node.db.getValue('test'), dbValues);
       assert.deepEqual(
-          node.db.setValue('/test/child_2/child_21', { 'new_child': 'new_value' }), true);
+          node.db.setValue('/test/child_2/child_21', { 'new_child': 'new_value' }).code, 0);
       assert.deepEqual(node.db.getValue('/test/child_2/child_21'), { 'new_child': 'new_value' });
 
-      assert.equal(node.db.restoreDb(), true);
+      assert.deepEqual(node.db.restoreDb(), true);
       expect(node.db.backupStateVersion).to.equal(null);
       expect(node.db.backupStateRoot).to.equal(null);
       assert.deepEqual(node.db.getValue('test'), dbValues);
@@ -3170,14 +3170,14 @@ describe("Transaction execution", () => {
     it("returns true for executable transaction", () => {
       expect(executableTx.extra).to.not.equal(undefined);
       expect(executableTx.extra.executed_at).to.equal(null);
-      assert.equal(node.db.executeTransaction(executableTx), true);
+      assert.deepEqual(node.db.executeTransaction(executableTx).code, 0);
       // extra.executed_at is updated with a non-null value.
       expect(executableTx.extra.executed_at).to.not.equal(null);
     });
 
     it("returns false for object transaction", () => {
-      assert.equal(node.db.executeTransaction(objectTx).code, 1101);
-      assert.equal(objectTx.extra, undefined);
+      assert.deepEqual(node.db.executeTransaction(objectTx).code, 21);
+      assert.deepEqual(objectTx.extra, undefined);
     });
 
     it("blocks over-height transaction", () => {

--- a/unittest/functions.test.js
+++ b/unittest/functions.test.js
@@ -81,13 +81,13 @@ describe("Functions", () => {
           "0x12345": null
         }
       };
-      assert.deepEqual(node.db.setFunction(refPathRest, restFunction), true);
-      assert.deepEqual(node.db.setFunction(refPathRestMulti, restFunctionMulti), true);
+      assert.deepEqual(node.db.setFunction(refPathRest, restFunction).code, 0);
+      assert.deepEqual(node.db.setFunction(refPathRestMulti, restFunctionMulti).code, 0);
       assert.deepEqual(
-          node.db.setFunction(refPathRestWithoutListener, restFunctionWithoutListener), true);
+          node.db.setFunction(refPathRestWithoutListener, restFunctionWithoutListener).code, 0);
       assert.deepEqual(
-          node.db.setFunction(refPathRestNotWhitelisted, restFunctionNotWhitelisted), true);
-      assert.deepEqual(node.db.setFunction(refPathNull, nullFunction), true);
+          node.db.setFunction(refPathRestNotWhitelisted, restFunctionNotWhitelisted).code, 0);
+      assert.deepEqual(node.db.setFunction(refPathNull, nullFunction).code, 0);
       functions = new Functions(node.db, null);
 
       // Setup mock for REST API calls.

--- a/unittest/transaction.test.js
+++ b/unittest/transaction.test.js
@@ -145,9 +145,9 @@ describe('Transaction', () => {
 
     it('setExecutedAt', () => {
       const executable = Transaction.toExecutable(Transaction.toJsObject(tx));
-      assert.equal(executable.extra.executed_at, null);
+      assert.deepEqual(executable.extra.executed_at, null);
       executable.setExecutedAt(123456789);
-      assert.equal(executable.extra.executed_at, 123456789);
+      assert.deepEqual(executable.extra.executed_at, 123456789);
     });
   });
 


### PR DESCRIPTION
Summary:
- Always return code of transaction execution
- Rename transactionFailed() -> isFailedTx()
- Define path util as a class with static methods
- Fix a tx result path bug
- Migrate to deepEqual() from equal() as equal() is deprecated: https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message 
- Use strict equal in reference comparison test cases
- Allow explicit turn-off by CONSOLE_LOG=false 

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/316 