### PR TITLE
Move getAddress func to chain-util

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -10,7 +10,6 @@ const P2pClient = require('../p2p');
 const ChainUtil = require('../common/chain-util');
 const VersionUtil = require('../common/version-util');
 const {
-  FeatureFlags,
   ENABLE_DEV_CLIENT_API,
   CURRENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION_MAP,

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -47,6 +47,25 @@ class ChainUtil {
     return '0x' + hashedData.toString('hex');
   }
 
+  /**
+   * Gets address from hash and signature.
+   */
+  static getAddress(hash, signature) {
+    let address = '';
+    try {
+      const sigBuffer = ainUtil.toBuffer(signature);
+      const len = sigBuffer.length;
+      const lenHash = len - 65;
+      const {r, s, v} = ainUtil.ecSplitSig(sigBuffer.slice(lenHash, len));
+      const publicKey = ainUtil.ecRecoverPub(Buffer.from(hash, 'hex'), r, s, v);
+      address = ainUtil.toChecksumAddress(ainUtil.bufferToHex(
+          ainUtil.pubToAddress(publicKey, publicKey.length === 65)));
+    } catch (err) {
+      logger.error(err);
+    }
+    return address;
+  }
+
   // TODO(lia): remove this function
   static genKeyPair() {
     let keyPair;

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -50,7 +50,7 @@ class ChainUtil {
   /**
    * Gets address from hash and signature.
    */
-  static getAddress(hash, signature) {
+  static getAddressFromSignature(hash, signature) {
     let address = '';
     try {
       const sigBuffer = ainUtil.toBuffer(signature);

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -25,7 +25,7 @@ const {
   getAddressFromSocket,
   removeSocketConnectionIfExists,
   signMessage,
-  getAddressFromSignature,
+  getAddressFromMessage,
   verifySignedMessage,
   checkProtoVer,
   closeSocketSafe
@@ -338,7 +338,7 @@ class P2pClient {
             closeSocketSafe(this.outbound, socket);   // NOTE(minsu): strictly close socket necessary??
             return;
           } else {
-            const addressFromSig = getAddressFromSignature(data);
+            const addressFromSig = getAddressFromMessage(data);
             if (addressFromSig !== address) {
               logger.error(`The addresses(${addressFromSig} and ${address}) are not the same!!`);
               closeSocketSafe(this.outbound, socket);

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -44,7 +44,7 @@ const {
   getAddressFromSocket,
   removeSocketConnectionIfExists,
   signMessage,
-  getAddressFromSignature,
+  getAddressFromMessage,
   verifySignedMessage,
   checkProtoVer,
   closeSocketSafe
@@ -387,7 +387,7 @@ class P2pServer {
               closeSocketSafe(this.inbound, socket);   // NOTE(minsu): strictly close socket necessary??
               return;
             } else {
-              const addressFromSig = getAddressFromSignature(data);
+              const addressFromSig = getAddressFromMessage(data);
               if (addressFromSig !== address) {
                 logger.error(`The addresses(${addressFromSig} and ${address}) are not the same!!`);
                 closeSocketSafe(this.inbound, socket);

--- a/p2p/util.js
+++ b/p2p/util.js
@@ -102,9 +102,9 @@ function signMessage(messageBody, privateKey) {
   return ainUtil.ecSignMessage(JSON.stringify(messageBody), Buffer.from(privateKey, 'hex'));
 }
 
-function getAddressFromSignature(message) {
+function getAddressFromMessage(message) {
   const hashedMessage = ainUtil.hashMessage(JSON.stringify(message.body));
-  return ChainUtil.getAddress(hashedMessage, message.signature);
+  return ChainUtil.getAddressFromSignature(hashedMessage, message.signature);
 }
 
 function verifySignedMessage(message, address) {
@@ -140,7 +140,7 @@ module.exports = {
   getAddressFromSocket,
   removeSocketConnectionIfExists,
   signMessage,
-  getAddressFromSignature,
+  getAddressFromMessage,
   verifySignedMessage,
   closeSocketSafe,
   checkProtoVer

--- a/p2p/util.js
+++ b/p2p/util.js
@@ -11,7 +11,6 @@ const ainUtil = require('@ainblockchain/ain-util');
 const logger = require('../logger')('SERVER_UTIL');
 const { CURRENT_PROTOCOL_VERSION } = require('../common/constants');
 const ChainUtil = require('../common/chain-util');
-const Transaction = require('../tx-pool/transaction');
 
 async function sendTxAndWaitForFinalization(endpoint, tx, privateKey) {
   const res = await signAndSendTx(endpoint, tx, privateKey);
@@ -105,8 +104,7 @@ function signMessage(messageBody, privateKey) {
 
 function getAddressFromSignature(message) {
   const hashedMessage = ainUtil.hashMessage(JSON.stringify(message.body));
-  // TODO(minsu): getAddress should be in the chain-util??
-  return Transaction.getAddress(hashedMessage, message.signature);
+  return ChainUtil.getAddress(hashedMessage, message.signature);
 }
 
 function verifySignedMessage(message, address) {

--- a/tx-pool/transaction.js
+++ b/tx-pool/transaction.js
@@ -37,7 +37,7 @@ class Transaction {
       address = txBody.address;
       skipVerif = true;
     } else {
-      address = Transaction.getAddress(hash.slice(2), signature);
+      address = ChainUtil.getAddress(hash.slice(2), signature);
     }
     const createdAt = Date.now();
     return new Transaction(txBody, signature, hash, address, skipVerif, createdAt);
@@ -82,25 +82,6 @@ class Transaction {
 
   toString() {
     return JSON.stringify(this, null, 2);
-  }
-
-  /**
-   * Gets address from hash and signature.
-   */
-  static getAddress(hash, signature) {
-    let address = '';
-    try {
-      const sigBuffer = ainUtil.toBuffer(signature);
-      const len = sigBuffer.length;
-      const lenHash = len - 65;
-      const {r, s, v} = ainUtil.ecSplitSig(sigBuffer.slice(lenHash, len));
-      const publicKey = ainUtil.ecRecoverPub(Buffer.from(hash, 'hex'), r, s, v);
-      address = ainUtil.toChecksumAddress(ainUtil.bufferToHex(
-          ainUtil.pubToAddress(publicKey, publicKey.length === 65)));
-    } catch (err) {
-      logger.error(err);
-    }
-    return address;
   }
 
   /**

--- a/tx-pool/transaction.js
+++ b/tx-pool/transaction.js
@@ -37,7 +37,7 @@ class Transaction {
       address = txBody.address;
       skipVerif = true;
     } else {
-      address = ChainUtil.getAddress(hash.slice(2), signature);
+      address = ChainUtil.getAddressFromSignature(hash.slice(2), signature);
     }
     const createdAt = Date.now();
     return new Transaction(txBody, signature, hash, address, skipVerif, createdAt);


### PR DESCRIPTION
as the getAddress func is called in both transaction.js and p2p/index.js, the function is moved to chain-util.