### PR TITLE
Do not return state gas amount.

### DIFF
--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -316,17 +316,15 @@ class ChainUtil {
     return NATIVE_SERVICE_TYPES.includes(_.get(parsedPath, 0));
   }
 
-  static getGasAmountObj(path, bandwidth, state) {
+  static getGasAmountObj(path, value) {
     const parsedPath = ChainUtil.parsePath(path);
     const gasAmount = {};
     if (ChainUtil.isServicePath(parsedPath)) {
-      ChainUtil.setJsObject(gasAmount, ['service', 'bandwidth'], bandwidth);
-      ChainUtil.setJsObject(gasAmount, ['service', 'state'], state);
+      ChainUtil.setJsObject(gasAmount, ['service'], value);
     } else if (ChainUtil.isAppPath(parsedPath)) {
       const appName = _.get(parsedPath, 1);
       if (!appName) return;
-      ChainUtil.setJsObject(gasAmount, ['app', appName, 'bandwidth'], bandwidth);
-      ChainUtil.setJsObject(gasAmount, ['app', appName, 'state'], state);
+      ChainUtil.setJsObject(gasAmount, ['app', appName], value);
     }
     return gasAmount;
   }
@@ -335,7 +333,7 @@ class ChainUtil {
     if (!result) {
       return 0;
     }
-    return _.get(result, 'gas.gas_amount.service.bandwidth', 0);
+    return _.get(result, 'gas.gas_amount.service', 0);
   }
 
   /**

--- a/common/constants.js
+++ b/common/constants.js
@@ -66,7 +66,6 @@ const TX_TIMESTAMP_ERROR_CODE = 901;
 const MILLI_AIN = 10**-3; // 1,000 milliain = 1 ain
 const MICRO_AIN = 10**-6; // 1,000,000 microain = 1 ain
 const NATIVE_SERVICE_TYPES = [
-  'consensus',
   'checkin',
   'consensus',
   'escrow',

--- a/db/functions.js
+++ b/db/functions.js
@@ -196,9 +196,7 @@ class Functions {
               return true;
             }));
             this.addToFunctionGasAmount({
-              service: {
-                bandwidth: GasFeeConstants.EXTERNAL_RPC_CALL_GAS_AMOUNT
-              }
+              service: GasFeeConstants.EXTERNAL_RPC_CALL_GAS_AMOUNT
             });
             if (FeatureFlags.enableRichFunctionLogging) {
               logger.info(
@@ -226,9 +224,7 @@ class Functions {
     fidList.push(fid);
     const callDepth = this.callStackSize();
     const gasAmount = {
-      service: {
-        bandwidth: nativeFunction.execGasAmount
-      }
+      service: nativeFunction.execGasAmount
     };
     this.callStack.push({
       fid,
@@ -962,9 +958,7 @@ class Functions {
     const toBalance = this.db.getValue(toPath);
     if (toBalance === null) {
       this.addToFunctionGasAmount({
-        service: {
-          bandwidth: GasFeeConstants.ACCOUNT_REGISTRATION_GAS_AMOUNT
-        }
+        service: GasFeeConstants.ACCOUNT_REGISTRATION_GAS_AMOUNT
       });
     }
     const decResult = this.decValueOrLog(fromPath, value, auth, timestamp, transaction);

--- a/db/index.js
+++ b/db/index.js
@@ -762,7 +762,6 @@ class DB {
   }
 
   executeSingleSetOperation(op, auth, timestamp, tx) {
-    const stateInfoBefore = this.getStateInfo('/');
     let result;
     switch (op.type) {
       case undefined:
@@ -788,11 +787,8 @@ class DB {
         return ChainUtil.returnTxResult(14, `Invalid operation type: ${op.type}`);
     }
     if (!ChainUtil.isFailedTx(result)) {
-      const stateInfoAfter = this.getStateInfo('/');
-      const treeSizeDelta = stateInfoAfter[StateInfoProperties.TREE_SIZE] -
-          stateInfoBefore[StateInfoProperties.TREE_SIZE];
       const gas = {
-        gas_amount: ChainUtil.getGasAmountObj(op.ref, 1, treeSizeDelta)
+        gas_amount: ChainUtil.getGasAmountObj(op.ref, 1)
       };
       ChainUtil.mergeNumericJsObjects(result, { gas });
     } else {

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -1396,10 +1396,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 2
-                }
+                "service": 1,
               }
             }
           },
@@ -1407,10 +1404,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 1
-                }
+                "service": 1,
               }
             }
           },
@@ -1418,10 +1412,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 1
-                }
+                "service": 1,
               }
             }
           },
@@ -1429,10 +1420,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 3
-                }
+                "service": 1,
               }
             }
           },
@@ -1440,10 +1428,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 3
-                }
+                "service": 1,
               }
             }
           },
@@ -1451,10 +1436,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 3
-                }
+                "service": 1,
               }
             }
           },
@@ -1531,10 +1513,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 2
-                }
+                "service": 1,
               }
             }
           },
@@ -1542,10 +1521,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 1
-                }
+                "service": 1,
               }
             }
           },
@@ -1553,10 +1529,7 @@ describe('Blockchain Node', () => {
             "code": 0,
             "gas": {
               "gas_amount": {
-                "service": {
-                  "bandwidth": 1,
-                  "state": 1
-                }
+                "service": 1,
               }
             }
           },
@@ -1711,10 +1684,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 2
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1725,10 +1695,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 1
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1739,10 +1706,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 1
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1753,10 +1717,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1767,10 +1728,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1781,10 +1739,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1796,10 +1751,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 2
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -1807,10 +1759,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 1
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -1818,10 +1767,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 1
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -1829,10 +1775,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -1840,10 +1783,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -1851,10 +1791,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               }
@@ -2020,10 +1957,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 2
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2034,10 +1968,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 1
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2048,10 +1979,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 1
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2069,10 +1997,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2083,10 +2008,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2097,10 +2019,7 @@ describe('Blockchain Node', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -2112,10 +2031,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 2
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -2123,10 +2039,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 1
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -2134,10 +2047,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 1
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -2145,10 +2055,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -2156,10 +2063,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               },
@@ -2167,10 +2071,7 @@ describe('Blockchain Node', () => {
                 "code": 0,
                 "gas": {
                   "gas_amount": {
-                    "service": {
-                      "bandwidth": 1,
-                      "state": 3
-                    }
+                    "service": 1,
                   }
                 }
               }
@@ -2220,10 +2121,7 @@ describe('Blockchain Node', () => {
                 code: 0,
                 gas: {
                   gas_amount: {
-                    service: {
-                      bandwidth: 1,
-                      state: 0
-                    }
+                    service: 1,
                   }
                 }
               },
@@ -2269,10 +2167,7 @@ describe('Blockchain Node', () => {
                   code: 0,
                   gas: {
                     gas_amount: {
-                      service: {
-                        bandwidth: 1,
-                        state: 0
-                      }
+                      service: 1,
                     }
                   }
                 },
@@ -2957,10 +2852,7 @@ describe('Blockchain Node', () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1003,
-                "state": 9
-              }
+              "service": 1003,
             }
           }
         });
@@ -2976,10 +2868,7 @@ describe('Blockchain Node', () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 3,
-                "state": 6
-              }
+              "service": 3,
             }
           }
         });
@@ -2995,10 +2884,7 @@ describe('Blockchain Node', () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1007,
-                "state": 22
-              }
+              "service": 1007,
             }
           }
         });
@@ -3014,10 +2900,7 @@ describe('Blockchain Node', () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 7,
-                "state": 12
-              }
+              "service": 7,
             }
           }
         });
@@ -3033,10 +2916,7 @@ describe('Blockchain Node', () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 11,
-                "state": 1
-              }
+              "service": 11,
             }
           }
         });

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -1439,10 +1439,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 2
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1450,10 +1447,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1461,10 +1455,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 1
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1472,10 +1463,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1483,10 +1471,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1494,10 +1479,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 3
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1560,10 +1542,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1571,10 +1550,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1582,10 +1558,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1593,10 +1566,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1604,10 +1574,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1615,10 +1582,7 @@ describe('Sharding', () => {
               "code": 0,
               "gas": {
                 "gas_amount": {
-                  "service": {
-                    "bandwidth": 1,
-                    "state": 0
-                  }
+                  "service": 1,
                 }
               }
             },
@@ -1654,10 +1618,7 @@ describe('Sharding', () => {
                     code: 0,
                     gas: {
                       gas_amount: {
-                        service: {
-                          bandwidth: 1,
-                          state: 0
-                        }
+                        service: 1,
                       }
                     }
                   },
@@ -1694,10 +1655,7 @@ describe('Sharding', () => {
                     code: 0,
                     gas: {
                       gas_amount: {
-                        service: {
-                          bandwidth: 1,
-                          state: 0
-                        }
+                        service: 1,
                       }
                     }
                   },
@@ -1735,10 +1693,7 @@ describe('Sharding', () => {
                     gas: {
                       gas_amount: {
                         app: {
-                          afan: {
-                            bandwidth: 1,
-                            state: 0
-                          }
+                          afan: 1,
                         }
                       }
                     }
@@ -1785,10 +1740,7 @@ describe('Sharding', () => {
                     code: 0,
                     gas: {
                       gas_amount: {
-                        service: {
-                          bandwidth: 1,
-                          state: 0
-                        }
+                        service: 1,
                       }
                     }
                   },
@@ -1837,10 +1789,7 @@ describe('Sharding', () => {
                     code: 0,
                     gas: {
                       gas_amount: {
-                        service: {
-                          bandwidth: 1,
-                          state: 0
-                        }
+                        service: 1,
                       }
                     }
                   },
@@ -1890,10 +1839,7 @@ describe('Sharding', () => {
                     gas: {
                       gas_amount: {
                         app: {
-                          afan: {
-                            bandwidth: 1,
-                            state: 0
-                          }
+                          afan: 1,
                         }
                       }
                     }

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -404,11 +404,7 @@ describe("ChainUtil", () => {
         "code": 0,
         "gas": {
           "gas_amount": {
-            "service": {
-              "bandwidth": 50,
-              "state": 50
-            },
-            "app": {}
+            "service": 50,
           }
         }
       };
@@ -421,10 +417,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-              },
-              "app": {}
+              "service": 1,
             }
           }
         },
@@ -432,10 +425,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 10
-              },
-              "app": {}
+              "service": 10,
             }
           }
         },
@@ -443,10 +433,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 100
-              },
-              "app": {}
+              "service": 100,
             }
           }
         },
@@ -473,11 +460,7 @@ describe("ChainUtil", () => {
         "code": 0,
         "gas": {
           "gas_amount": {
-            "service": {
-              "bandwidth": 50,
-              "state": 50
-            },
-            "app": {}
+            "service": 50,
           }
         }
       };
@@ -490,10 +473,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-              },
-              "app": {}
+              "service": 1,
             }
           }
         },
@@ -501,10 +481,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 10
-              },
-              "app": {}
+              "service": 10,
             }
           }
         },
@@ -512,10 +489,7 @@ describe("ChainUtil", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 100
-              },
-              "app": {}
+              "service": 100,
             }
           }
         },

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -1334,10 +1334,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 1
-              }
+              "service": 1,
             }
           }
         },
@@ -1345,10 +1342,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 0
-              }
+              "service": 1,
             }
           }
         },
@@ -1356,10 +1350,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 0
-              }
+              "service": 1,
             }
           }
         },
@@ -1367,10 +1358,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 0
-              }
+              "service": 1,
             }
           }
         },
@@ -1378,10 +1366,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": -3
-              }
+              "service": 1,
             }
           }
         },
@@ -1389,10 +1374,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": -25
-              }
+              "service": 1,
             }
           }
         }
@@ -1442,10 +1424,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 1
-              }
+              "service": 1,
             }
           }
         },
@@ -1481,10 +1460,7 @@ describe("DB operations", () => {
           "code": 0,
           "gas": {
             "gas_amount": {
-              "service": {
-                "bandwidth": 1,
-                "state": 1
-              }
+              "service": 1,
             }
           }
         },

--- a/unittest/functions.test.js
+++ b/unittest/functions.test.js
@@ -6,8 +6,6 @@ const nock = require('nock');
 const _ = require('lodash');
 const {
   CHAINS_DIR,
-  NativeFunctionIds,
-  GasFeeConstants,
 } = require('../common/constants')
 const BlockchainNode = require('../node')
 const {
@@ -398,9 +396,7 @@ describe("Functions", () => {
           });
           const gasAmountActual = functions.getFunctionGasAmount();
           assert.deepEqual(gasAmountActual, {
-            "service": {
-              "bandwidth": 1002,
-            }
+            "service": 1002,
           });
         });
       });
@@ -433,9 +429,7 @@ describe("Functions", () => {
           });
           const gasAmountActual = functions.getFunctionGasAmount();
           assert.deepEqual(gasAmountActual, {
-            "service": {
-              "bandwidth": 2
-            }
+            "service": 2
           });
         });
       });
@@ -467,9 +461,7 @@ describe("Functions", () => {
           });
           const gasAmountActual = functions.getFunctionGasAmount();
           assert.deepEqual(gasAmountActual, {
-            "service": {
-              "bandwidth": 10
-            }
+            "service": 10
           });
         });
       })


### PR DESCRIPTION
Change summary:
- Do not return state gas amount
- Remove dup elements from NATIVE_SERVICE_TYPES

Background:
- We found some inconsistency in the value esp. in tests e.g. different results from:
  `yarn run test_node` and `yarn run test_node -g 'REST function with external RPC call'`
  due to common database state path between e.g. `/test/test_function_triggering/rest_function_path` and 
  `/test/test_function_triggering/allowed_path/value`
- So we decide to remove this feature as currently it doesn't have any use case except debugging

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/316