### PR TITLE
Update isFailedTx() to check function results as well

### DIFF
--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -396,13 +396,12 @@ class ChainUtil {
   }
 
   static returnTxResult(code, message = null, gasAmount = 0, funcResults = null) {
-    const { ExecResultProperties } = require('../common/constants');
     const result = {};
     if (message) {
       result.error_message = message;
     }
     if (!ChainUtil.isEmpty(funcResults)) {
-      result[ExecResultProperties.FUNC_RESULTS] = funcResults;
+      result.func_results = funcResults;
     }
     result.code = code;
     result.gas_amount = gasAmount;
@@ -482,8 +481,8 @@ class ChainUtil {
     });
   };
 
-  static convertEnvVarInputToBool = (input) => {
-    return input ? input.toLowerCase().startsWith('t') : false;
+  static convertEnvVarInputToBool = (input, defaultValue = false) => {
+    return input ? input.toLowerCase().startsWith('t') : defaultValue;
   }
 }
 

--- a/common/constants.js
+++ b/common/constants.js
@@ -34,7 +34,7 @@ const ENABLE_DEV_CLIENT_API = ChainUtil.convertEnvVarInputToBool(process.env.ENA
 const ENABLE_TX_SIG_VERIF_WORKAROUND =
     ChainUtil.convertEnvVarInputToBool(process.env.ENABLE_TX_SIG_VERIF_WORKAROUND);
 const ENABLE_GAS_FEE_WORKAROUND =
-    ChainUtil.convertEnvVarInputToBool(process.env.ENABLE_GAS_FEE_WORKAROUND);
+    ChainUtil.convertEnvVarInputToBool(process.env.ENABLE_GAS_FEE_WORKAROUND, true);
 const COMCOM_HOST_EXTERNAL_IP = process.env.COMCOM_HOST_EXTERNAL_IP ?
     process.env.COMCOM_HOST_EXTERNAL_IP : '';
 const ACCOUNT_INDEX = process.env.ACCOUNT_INDEX || null;
@@ -403,18 +403,6 @@ const FunctionResultCode = {
 };
 
 /**
- * Properties of execution results.
- *
- * @enum {string}
- */
-const ExecResultProperties = {
-  FUNC_RESULTS: '.func_results',
-  OP_RESULTS: '.op_results',
-  PATH: 'path',
-  RESULT: 'result',
-};
-
-/**
  * Constant values for transactionTracker.
  *
  * @enum {string}
@@ -697,7 +685,6 @@ module.exports = {
   ReadDbOperations,
   WriteDbOperations,
   TransactionStatus,
-  ExecResultProperties,
   StateVersions,
   GenesisToken,
   GenesisAccounts,

--- a/db/functions.js
+++ b/db/functions.js
@@ -192,9 +192,10 @@ class Functions {
               failCount++;
               return true;
             }));
-            ChainUtil.mergeNumericJsObjects(funcResults, {
-              gas_amount: GasFeeConstants.REST_FUNCTION_CALL_GAS_AMOUNT
-            });
+            funcResults[functionEntry.function_id] = {
+              code: FunctionResultCode.SUCCESS,
+              gas_amount: GasFeeConstants.REST_FUNCTION_CALL_GAS_AMOUNT,
+            };
             triggerCount++;
           }
         }
@@ -799,7 +800,7 @@ class Functions {
     const blockNumber = Number(context.params.block_number);
     const parsedValuePath = context.valuePath;
     if (!ChainUtil.isArray(context.functionPath)) {
-      return false;
+      return this.returnFuncResult(context, FunctionResultCode.FAILURE);
     }
     if (!ChainUtil.isString(value)) {
       // Removing old report or invalid reporting
@@ -809,7 +810,7 @@ class Functions {
     const currentLatestBlockNumber = this.db.getValue(latestReportPath);
     if (currentLatestBlockNumber !== null && Number(currentLatestBlockNumber) >= blockNumber) {
       // Nothing to update
-      return false;
+      return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
     }
     const result = this.setValueOrLog(latestReportPath, blockNumber, context);
     if (!ChainUtil.isFailedTx(result)) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -16,7 +16,6 @@ const {
   TokenExchangeSchemes,
   FunctionProperties,
   GasFeeConstants,
-  ExecResultProperties,
   REST_FUNCTION_CALL_TIMEOUT_MS,
 } = require('../common/constants');
 const ChainUtil = require('../common/chain-util');
@@ -266,10 +265,7 @@ class Functions {
   }
 
   static addToOpResultList(path, result, context) {
-    context.opResultList.push({
-      [ExecResultProperties.PATH]: path,
-      [ExecResultProperties.RESULT]: result,
-    });
+    context.opResultList.push({ path, result, });
   }
 
   static formatFunctionParams(
@@ -448,7 +444,7 @@ class Functions {
     const opResultList = Functions.getOpResultList(context);
     const funcResultToReturn = {};
     if (!ChainUtil.isEmpty(opResultList)) {
-      funcResultToReturn[ExecResultProperties.OP_RESULTS] = opResultList;
+      funcResultToReturn.op_results = opResultList;
     }
     Object.assign(funcResultToReturn, this.buildFuncResultToReturn(context, code, extraGasAmount));
     return funcResultToReturn;

--- a/integration/afan_dapp.test.js
+++ b/integration/afan_dapp.test.js
@@ -16,19 +16,19 @@ const APP_SERVER = PROJECT_ROOT + 'client/index.js';
 const ENV_VARIABLES = [
   {
     MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
   },
   {
     MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
   },
   {
     MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
   },
   {
     MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
   },
 ];
 
@@ -125,16 +125,15 @@ describe('DApp Test', () => {
 
   before(() => {
     rimraf.sync(CHAINS_DIR);
-
-    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', {}, false);
+    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', { CONSOLE_LOG: false }, true);
     sleep(2000);
-    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[0], false);
+    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[0], true);
     sleep(2000);
-    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[1], false);
+    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[1], true);
     sleep(2000);
-    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[2], false);
+    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[2], true);
     sleep(2000);
-    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[3], false);
+    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[3], true);
     sleep(2000);
   });
 

--- a/integration/blockchain.test.js
+++ b/integration/blockchain.test.js
@@ -27,25 +27,25 @@ const { waitForNewBlocks, waitUntilNodeSyncs, parseOrLog } = require('../unittes
 const ENV_VARIABLES = [
   {
     ACCOUNT_INDEX: 0, MIN_NUM_VALIDATORS: 4, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     ACCOUNT_INDEX: 1, MIN_NUM_VALIDATORS: 4, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     ACCOUNT_INDEX: 2, MIN_NUM_VALIDATORS: 4, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     ACCOUNT_INDEX: 3, MIN_NUM_VALIDATORS: 4, EPOCH_MS: 1000, DEBUG: false,
-    ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
@@ -173,25 +173,6 @@ for (let i = 0; i < ENV_VARIABLES.length; i++) {
   SERVER_PROCS.push(new Process(APP_SERVER, ENV_VARIABLES[i]));
 }
 
-// Wait until there are two blocks of multiple validators.
-function waitUntilNodeStakes() {
-  let count = 0;
-  let blocksAfterStaking = 0;
-  let validators = {};
-  while (count <= MAX_PROMISE_STACK_DEPTH && blocksAfterStaking < 2) {
-    const block = parseOrLog(syncRequest('POST', server1 + '/json-rpc',
-        {json: {jsonrpc: '2.0', method: JSON_RPC_GET_RECENT_BLOCK, id: 0,
-                params: {protoVer: CURRENT_PROTOCOL_VERSION}}})
-        .body.toString('utf-8')).result.result;
-    validators = block.validators;
-    if (Object.keys(validators).length >= 2) {
-      blocksAfterStaking++;
-    }
-    count++;
-    sleep(6000);
-  }
-}
-
 function sendTransactions(sentOperations) {
   const txHashList = [];
   for (let i = 0; i < NUMBER_OF_TRANSACTIONS_SENT_BEFORE_TEST; i++) {
@@ -246,12 +227,12 @@ describe('Blockchain Cluster', () => {
 
     const promises = [];
     // Start up all servers
-    trackerProc = new Process(TRACKER_SERVER, {});
-    trackerProc.start(false);
+    trackerProc = new Process(TRACKER_SERVER, { CONSOLE_LOG: false });
+    trackerProc.start(true);
     sleep(2000);
     for (let i = 0; i < SERVER_PROCS.length; i++) {
       const proc = SERVER_PROCS[i];
-      proc.start(false);
+      proc.start(true);
       sleep(2000);
       const address =
           parseOrLog(syncRequest('GET', serverList[i] + '/get_address').body.toString('utf-8')).result;

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -8,7 +8,6 @@ const syncRequest = require('sync-request');
 const rimraf = require("rimraf")
 const jayson = require('jayson/promise');
 const ainUtil = require('@ainblockchain/ain-util');
-const Functions = require('../db/functions');
 const PROJECT_ROOT = require('path').dirname(__filename) + "/../"
 const TRACKER_SERVER = PROJECT_ROOT + "tracker-server/index.js"
 const APP_SERVER = PROJECT_ROOT + "client/index.js"
@@ -19,8 +18,6 @@ const {
   FunctionResultCode,
   GenesisAccounts,
   ProofProperties,
-  NativeFunctionIds,
-  GasFeeConstants,
   TX_BYTES_LIMIT,
   BATCH_TX_LIST_SIZE_LIMIT,
 } = require('../common/constants');
@@ -2829,9 +2826,9 @@ describe('Blockchain Node', () => {
         }}).body.toString('utf-8'));
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
-          ".func_results": {
+          "func_results": {
             "_transfer": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
                   "result": {
@@ -2874,9 +2871,9 @@ describe('Blockchain Node', () => {
         }}).body.toString('utf-8'));
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
-          ".func_results": {
+          "func_results": {
             "_transfer": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
                   "result": {
@@ -2919,15 +2916,15 @@ describe('Blockchain Node', () => {
         }}).body.toString('utf-8'));
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
-          ".func_results": {
+          "func_results": {
             "_stake": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/staking|test_service_gas_fee|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/value",
                   "result": {
-                    ".func_results": {
+                    "func_results": {
                       "_transfer": {
-                        ".op_results": [
+                        "op_results": [
                           {
                             "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
                             "result": {
@@ -3000,15 +2997,15 @@ describe('Blockchain Node', () => {
         }}).body.toString('utf-8'));
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
-          ".func_results": {
+          "func_results": {
             "_stake": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/staking|test_service_gas_fee|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890001/value",
                   "result": {
-                    ".func_results": {
+                    "func_results": {
                       "_transfer": {
-                        ".op_results": [
+                        "op_results": [
                           {
                             "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
                             "result": {
@@ -3079,7 +3076,7 @@ describe('Blockchain Node', () => {
         }}).body.toString('utf-8'));
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
-          ".func_results": {
+          "func_results": {
             "gas_amount": 10
           },
           "code": 0,

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -169,199 +169,6 @@ function cleanUp() {
   }
 }
 
-function setUpForFunctionTriggering() {
-  const res = parseOrLog(syncRequest('POST', server2 + '/set', {
-    json: {
-      op_list: [
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/allowed_path/value',
-          value: {
-            ".function": {
-              "_saveLastTx": {
-                "function_type": "NATIVE",
-                "function_id": "_saveLastTx"
-              }
-            }
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path/value',
-          value: {
-            ".write": true,
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path/.last_tx/value',
-          value: {
-            ".write": "auth.fid === '_saveLastTx'",
-          }
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/not_allowed_path/value',
-          value: {
-            ".function": {
-              "_saveLastTx": {
-                "function_type": "NATIVE",
-                "function_id": "_saveLastTx"
-              }
-            }
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path/value',
-          value: {
-            ".write": true,
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path/.last_tx/value',
-          value: {
-            ".write": "auth.fid === 'some function id'",
-          }
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/allowed_path_with_fids/value',
-          value: {
-            ".function": {
-              "_saveLastTx": {
-                "function_type": "NATIVE",
-                "function_id": "_saveLastTx"
-              }
-            }
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path_with_fids/value',
-          value: {
-            ".write": true,
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path_with_fids/.last_tx/value',
-          value: {
-            ".write": "util.includes(auth.fids, '_saveLastTx')",
-          }
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
-          value: {
-            ".function": {
-              "_saveLastTx": {
-                "function_type": "NATIVE",
-                "function_id": "_saveLastTx"
-              }
-            }
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
-          value: {
-            ".write": true,
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path_with_fids/.last_tx/value',
-          value: {
-            ".write": "util.includes(auth.fids, 'some function id')",
-          }
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/rest_function_path',
-          value: {
-            ".function": {
-              "0x11111": {
-                "function_type": "REST",
-                "event_listener": "https://events.ainetwork.ai/trigger",
-                "service_name": "https://ainetwork.ai",
-                "function_id": "0x11111"
-              }
-            }
-          }
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/rest_function_path',
-          value: {
-            ".write": true,
-          }
-        },
-      ],
-      nonce: -1,
-    }
-  }).body.toString('utf-8')).result;
-  assert.deepEqual(ChainUtil.isFailedTx(_.get(res, 'result')), false);
-  if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
-    console.error(`Failed to check finalization of setUpForFunctionTriggering() tx.`)
-  }
-}
-
-function cleanUpForFunctionTriggering() {
-  const res = parseOrLog(syncRequest('POST', server2 + '/set', {
-    json: {
-      op_list: [
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/allowed_path/value',
-          value: null
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path/value',
-          value: null
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/not_allowed_path/value',
-          value: null
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path/value',
-          value: null
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/allowed_path_with_fids/value',
-          value: null
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/allowed_path_with_fids/value',
-          value: null
-        },
-        {
-          type: 'SET_FUNCTION',
-          ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
-          value: null
-        },
-        {
-          type: 'SET_RULE',
-          ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
-          value: null
-        },
-      ],
-      nonce: -1,
-    }
-  }).body.toString('utf-8')).result;
-  assert.deepEqual(ChainUtil.isFailedTx(_.get(res, 'result')), false);
-  if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
-    console.error(`Failed to check finalization of cleanUpForFunctionTriggering() tx.`)
-  }
-}
-
 describe('Blockchain Node', () => {
   let tracker_proc, server1_proc, server2_proc, server3_proc, server4_proc
 
@@ -2625,9 +2432,9 @@ describe('Blockchain Node', () => {
           parseOrLog(syncRequest('GET', server2 + '/get_address').body.toString('utf-8')).result;
       serviceUserBad =
           parseOrLog(syncRequest('GET', server3 + '/get_address').body.toString('utf-8')).result;
-      stakingServiceAccountBalancePath = `/service_accounts/staking/test_service/${serviceUser}|0/balance`;
-      stakePath = `/staking/test_service/${serviceUser}/0/stake`;
-      unstakePath = `/staking/test_service/${serviceUser}/0/unstake`;
+      stakingServiceAccountBalancePath = `/service_accounts/staking/test_service_staking/${serviceUser}|0/balance`;
+      stakePath = `/staking/test_service_staking/${serviceUser}/0/stake`;
+      unstakePath = `/staking/test_service_staking/${serviceUser}/0/unstake`;
       serviceUserBalancePath = `/accounts/${serviceUser}/balance`;
 
       triggerTransferToIndividualAccountPath1 =
@@ -2641,11 +2448,196 @@ describe('Blockchain Node', () => {
     })
 
     beforeEach(() => {
-      setUpForFunctionTriggering();
+      const res = parseOrLog(syncRequest('POST', server2 + '/set', {
+        json: {
+          op_list: [
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/allowed_path/value',
+              value: {
+                ".function": {
+                  "_saveLastTx": {
+                    "function_type": "NATIVE",
+                    "function_id": "_saveLastTx"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path/value',
+              value: {
+                ".write": true,
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path/.last_tx/value',
+              value: {
+                ".write": "auth.fid === '_saveLastTx'",
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/not_allowed_path/value',
+              value: {
+                ".function": {
+                  "_saveLastTx": {
+                    "function_type": "NATIVE",
+                    "function_id": "_saveLastTx"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path/value',
+              value: {
+                ".write": true,
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path/.last_tx/value',
+              value: {
+                ".write": "auth.fid === 'some function id'",
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/allowed_path_with_fids/value',
+              value: {
+                ".function": {
+                  "_saveLastTx": {
+                    "function_type": "NATIVE",
+                    "function_id": "_saveLastTx"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path_with_fids/value',
+              value: {
+                ".write": true,
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path_with_fids/.last_tx/value',
+              value: {
+                ".write": "util.includes(auth.fids, '_saveLastTx')",
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
+              value: {
+                ".function": {
+                  "_saveLastTx": {
+                    "function_type": "NATIVE",
+                    "function_id": "_saveLastTx"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
+              value: {
+                ".write": true,
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fids/.last_tx/value',
+              value: {
+                ".write": "util.includes(auth.fids, 'some function id')",
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/rest_function_path',
+              value: {
+                ".function": {
+                  "0x11111": {
+                    "function_type": "REST",
+                    "event_listener": "https://events.ainetwork.ai/trigger",
+                    "service_name": "https://ainetwork.ai",
+                    "function_id": "0x11111"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/rest_function_path',
+              value: {
+                ".write": true,
+              }
+            },
+          ],
+          nonce: -1,
+        }
+      }).body.toString('utf-8')).result;
+      assert.deepEqual(ChainUtil.isFailedTx(_.get(res, 'result')), false);
+      if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
+        console.error(`Failed to check finalization of function triggering setup tx.`)
+      }
     })
 
     afterEach(() => {
-      cleanUpForFunctionTriggering();
+      const res = parseOrLog(syncRequest('POST', server2 + '/set', {
+        json: {
+          op_list: [
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/allowed_path/value',
+              value: null
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path/value',
+              value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/not_allowed_path/value',
+              value: null
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path/value',
+              value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/allowed_path_with_fids/value',
+              value: null
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/allowed_path_with_fids/value',
+              value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
+              value: null
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
+              value: null
+            },
+          ],
+          nonce: -1,
+        }
+      }).body.toString('utf-8')).result;
+      assert.deepEqual(ChainUtil.isFailedTx(_.get(res, 'result')), false);
+      if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
+        console.error(`Failed to check finalization of function triggering cleanup tx.`)
+      }
     })
 
     describe('Function permission', () => {
@@ -2726,11 +2718,29 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
-          if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
-            console.error(`Failed to check finalization of tx.`)
-          }
+          assert.deepEqual(body.code, 1);
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_saveLastTx": {
+                "code": "FAILURE",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/not_allowed_path/.last_tx/value",
+                    "result": {
+                      "code": 103,
+                      "error_message": "No .write permission on: /test/test_function_triggering/not_allowed_path/.last_tx/value",
+                      "gas_amount": 0,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 1,
+            "gas_cost_total": 0,
+          });
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPath + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -2746,7 +2756,27 @@ describe('Blockchain Node', () => {
             nonce: -1,
           }}).body.toString('utf-8'));
           assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_saveLastTx": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 2,
+            "gas_cost_total": 0,
+          });
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2766,11 +2796,29 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
-          if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
-            console.error(`Failed to check finalization of tx.`)
-          }
+          assert.deepEqual(body.code, 1);
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_saveLastTx": {
+                "code": "FAILURE",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/not_allowed_path_with_fids/.last_tx/value",
+                    "result": {
+                      "code": 103,
+                      "error_message": "No .write permission on: /test/test_function_triggering/not_allowed_path_with_fids/.last_tx/value",
+                      "gas_amount": 0,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 1,
+            "gas_cost_total": 0,
+          });
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPathWithFids + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -2786,7 +2834,27 @@ describe('Blockchain Node', () => {
             nonce: -1,
           }}).body.toString('utf-8'));
           assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_saveLastTx": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/allowed_path_with_fids/.last_tx/value",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 2,
+            "gas_cost_total": 0,
+          });
           if (!waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -2806,9 +2874,6 @@ describe('Blockchain Node', () => {
           ref: manageAppPath,
           value: {
             admin: { [serviceAdmin]: true },
-            service: {
-              staking: { lockup_duration: 1000 }
-            }
           },
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(0);
@@ -3077,7 +3142,10 @@ describe('Blockchain Node', () => {
         assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
-            "gas_amount": 10
+            "0x11111": {
+              "code": "SUCCESS",
+              "gas_amount": 10,
+            }
           },
           "code": 0,
           "gas_amount": 1,
@@ -3202,25 +3270,25 @@ describe('Blockchain Node', () => {
       });
     })
 
-    describe('Staking (_stake, _unstake)', () => {
-      describe('Stake', () => {
-        it('stake: setup app', () => {
-          const manageAppPath = '/manage_app/test_service/create/1'
-          const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
-            ref: manageAppPath,
-            value: {
-              admin: { [serviceAdmin]: true },
-              service: {
-                staking: { lockup_duration: 1000 }
-              }
+    describe('Staking: _stake, _unstake', () => {
+      before(() => {
+        const manageAppPath = '/manage_app/test_service_staking/create/1'
+        const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+          ref: manageAppPath,
+          value: {
+            admin: { [serviceAdmin]: true },
+            service: {
+              staking: { lockup_duration: 1000 }
             }
-          }}).body.toString('utf-8'));
-          expect(body.code).to.equals(0);
-          if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
-            console.error(`Failed to check finalization of tx.`)
           }
-        })
+        }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
+        if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
+          console.error(`Failed to check finalization of tx.`)
+        }
+      })
 
+      describe('Stake', () => {
         it('stake: stake', () => {
           let beforeBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${serviceUserBalancePath}`).body.toString('utf-8')).result;
@@ -3228,10 +3296,82 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${stakingServiceAccountBalancePath}`).body.toString('utf-8')).result;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: stakePath + '/1/value',
-            value: stakeAmount
+            value: stakeAmount,
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_stake": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/staking|test_service_staking|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 1000,
+                          "op_results": [
+                            {
+                              "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/service_accounts/staking/test_service_staking/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/staking|test_service_staking|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/staking/test_service_staking/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0/expire_at",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/staking/test_service_staking/balance_total",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/staking/test_service_staking/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0/stake/1/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 1008,
+            "gas_cost_total": 0,
+          });
           assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -3245,7 +3385,7 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${stakePath}/1/result/code`)
             .body.toString('utf-8')).result;
           const stakingAppBalanceTotal = parseOrLog(syncRequest('GET',
-              server2 + `/get_value?ref=/staking/test_service/balance_total`)
+              server2 + `/get_value?ref=/staking/test_service_staking/balance_total`)
             .body.toString('utf-8')).result;
           expect(resultCode).to.equal(FunctionResultCode.SUCCESS);
           expect(stakeValue).to.equal(stakeAmount);
@@ -3289,20 +3429,25 @@ describe('Blockchain Node', () => {
         });
 
         it('stake: stake with invalid timestamp', () => {
-          const account = ainUtil.createAccount();
+          const account = {
+            "address": "0x07A43138CC760C85A5B1F115aa60eADEaa0bf417",
+            "private_key": "0e9876c7e7966fb0237892eb2e890b4738d0e50adfcfe089ef31f5a1579d65cd",
+            "public_key": "1cc01c94edce1d5807685dc04de0a0e445b560090eb421fc087f95080eb7a12a41145cc17cf4476a1d2ec0c1f737f5d84e5d0fecbfb370869845714e4ecfdd53"
+          };
           const transferPath = `/transfer/${transferFrom}/${account.address}`;
-          const res = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+          const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: transferPath + '/100/value',
             value: 1000
-          }}).body.toString('utf-8')).result;
-          if (!waitUntilTxFinalized(serverList, _.get(res, 'tx_hash'))) {
+          }}).body.toString('utf-8'));
+          expect(body.code).to.equals(0);
+          if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
           const txBody = {
             operation: {
               type: 'SET_VALUE',
               value: stakeAmount,
-              ref: `/staking/test_service/${account.address}/0/stake/1/value`
+              ref: `/staking/test_service_staking/${account.address}/0/stake/1/value`
             },
             timestamp: Date.now() + 100000,
             nonce: 0
@@ -3316,10 +3461,27 @@ describe('Blockchain Node', () => {
             signature,
             protoVer: CURRENT_PROTOCOL_VERSION
           }).then(res => {
-            const stakeResult = parseOrLog(syncRequest('GET',
-                server2 + `/get_value?ref=/staking/test_service/${account.address}/0/stake/1/result/code`)
-                .body.toString('utf-8')).result;
-            expect(stakeResult).to.equal(FunctionResultCode.FAILURE);
+            assert.deepEqual(_.get(res, 'result.result.result'), {
+              "code": 0,
+              "func_results": {
+                "_stake": {
+                  "code": "FAILURE",
+                  "gas_amount": 0,
+                  "op_results": [
+                    {
+                      "path": "/staking/test_service_staking/0x07A43138CC760C85A5B1F115aa60eADEaa0bf417/0/stake/1/result",
+                      "result": {
+                        "code": 0,
+                        "gas_amount": 1,
+                      }
+                    }
+                  ]
+                }
+              },
+              "gas_amount": 1,
+              "gas_amount_total": 2,
+              "gas_cost_total": 0,
+            });
           });
         });
 
@@ -3399,10 +3561,75 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${stakingServiceAccountBalancePath}`).body.toString('utf-8')).result;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: `${unstakePath}/2/value`,
-            value: stakeAmount
+            value: stakeAmount,
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_unstake": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/staking|test_service_staking|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 0,
+                          "op_results": [
+                            {
+                              "path": "/service_accounts/staking/test_service_staking/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/staking|test_service_staking|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/staking/test_service_staking/balance_total",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/staking/test_service_staking/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0/unstake/2/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 7,
+            "gas_cost_total": 0,
+          });
           assert.deepEqual(body.code, 0);
-          assert.deepEqual(_.get(body, 'result.result.code'), 0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
@@ -3414,7 +3641,7 @@ describe('Blockchain Node', () => {
               server2 + `/get_value?ref=${unstakePath}/2/result/code`)
               .body.toString('utf-8')).result;
           const stakingAppBalanceTotal = parseOrLog(syncRequest('GET',
-              server2 + `/get_value?ref=/staking/test_service/balance_total`)
+              server2 + `/get_value?ref=/staking/test_service_staking/balance_total`)
             .body.toString('utf-8')).result;
           expect(resultCode).to.equal(FunctionResultCode.SUCCESS);
           expect(afterStakingAccountBalance).to.equal(beforeStakingAccountBalance - stakeAmount);
@@ -3454,10 +3681,24 @@ describe('Blockchain Node', () => {
       });
     });
 
-    describe('Payments (_pay, _claim)', () => {
+    describe('Payments: _pay, _claim', () => {
+      before(() => {
+        const manageAppPath = '/manage_app/test_service_payment/create/1'
+        const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+          ref: manageAppPath,
+          value: {
+            admin: { [serviceAdmin]: true },
+          },
+        }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
+        if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
+          console.error(`Failed to check finalization of tx.`)
+        }
+      });
+
       it('payments: non-app admin cannot write pay records', () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
-              ref: `/payments/test_service/${serviceUser}/0/pay/key1`,
+              ref: `/payments/test_service_payment/${serviceUser}/0/pay/key1`,
               value: {
                 amount: 100
               }
@@ -3466,9 +3707,9 @@ describe('Blockchain Node', () => {
       });
 
       it('payments: amount = 0', () => {
-        const paymentRef = `/payments/test_service/${serviceUser}/0/pay/key1`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+          ref: payRef,
           value: {
             amount: 0
           }
@@ -3477,9 +3718,9 @@ describe('Blockchain Node', () => {
       });
 
       it('payments: amount is not a number', () => {
-        const paymentRef = `/payments/test_service/${serviceUser}/0/pay/key1`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+          ref: payRef,
           value: {
             amount: 'test'
           }
@@ -3490,50 +3731,105 @@ describe('Blockchain Node', () => {
       it('payments: payment amount > admin balance', () => {
         const adminBalance = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-        const paymentRef = `/payments/test_service/${serviceUser}/0/pay/key1`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+          ref: payRef,
           value: {
             amount: adminBalance + 1
           }
         }}).body.toString('utf-8'));
-        if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
-          console.error(`Failed to check finalization of tx.`)
-        }
-        const paymentResult = parseOrLog(syncRequest('GET', server1 +
-            `/get_value?ref=${paymentRef}/result/code`).body.toString('utf-8')).result;
-        expect(paymentResult).to.equals(FunctionResultCode.INTERNAL_ERROR);
+        expect(body.code).to.equals(1);
       });
 
       it('payments: app admin can write pay records', () => {
         const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-        const paymentRef = `/payments/test_service/${serviceUser}/0/pay/key2`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key2`;
         const amount = adminBalanceBefore - 1;
-        const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+        const body = parseOrLog(syncRequest('POST', server1 + '/set_value', { json: {
+          ref: payRef,
           value: {
             amount
-          }
+          },
+          nonce: -1,
+          timestamp: 1234567890000,
         }}).body.toString('utf-8'));
+        assert.deepEqual(_.get(body, 'result.result'), {
+          "code": 0,
+          "func_results": {
+            "_pay": {
+              "code": "SUCCESS",
+              "gas_amount": 0,
+              "op_results": [
+                {
+                  "path": "/transfer/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/payments|test_service_payment|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/value",
+                  "result": {
+                    "code": 0,
+                    "func_results": {
+                      "_transfer": {
+                        "code": "SUCCESS",
+                        "gas_amount": 1000,
+                        "op_results": [
+                          {
+                            "path": "/accounts/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/balance",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          },
+                          {
+                            "path": "/service_accounts/payments/test_service_payment/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          },
+                          {
+                            "path": "/transfer/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/payments|test_service_payment|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/result",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "gas_amount": 1,
+                  }
+                },
+                {
+                  "path": "/payments/test_service_payment/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0/pay/key2/result",
+                  "result": {
+                    "code": 0,
+                    "gas_amount": 1,
+                  }
+                }
+              ]
+            }
+          },
+          "gas_amount": 1,
+          "gas_amount_total": 1006,
+          "gas_cost_total": 0,
+        });
+        expect(body.code).to.equals(0);
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
           console.error(`Failed to check finalization of tx.`)
         }
         const paymentResult = parseOrLog(syncRequest('GET', server1 +
-            `/get_value?ref=${paymentRef}/result/code`).body.toString('utf-8')).result;
+            `/get_value?ref=${payRef}/result/code`).body.toString('utf-8')).result;
         expect(paymentResult).to.equals(FunctionResultCode.SUCCESS);
         const adminBalanceAfter = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
         expect(adminBalanceAfter).to.equals(adminBalanceBefore - amount);
         const serviceAccountBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
         assert.deepEqual(serviceAccountBalance, amount);
       });
 
       it('payments: non-app admin cannot write claim records', () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
-              ref: `/payments/test_service/${serviceUser}/0/claim/key1`,
+              ref: `/payments/test_service_payment/${serviceUser}/0/claim/key1`,
               value: {
                 amount: 100,
                 target: serviceAdmin
@@ -3544,31 +3840,26 @@ describe('Blockchain Node', () => {
 
       it('payments: claim amount > payment balance', () => {
         const paymentBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
-        const paymentRef = `/payments/test_service/${serviceUser}/0/claim/key1`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/claim/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+          ref: payRef,
           value: {
             amount: paymentBalance + 1,
             target: serviceAdmin
           }
         }}).body.toString('utf-8'));
-        if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
-          console.error(`Failed to check finalization of tx.`)
-        }
-        const paymentResult = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=${paymentRef}/result/code`).body.toString('utf-8')).result;
-        expect(paymentResult).to.equals(FunctionResultCode.INTERNAL_ERROR);
+        expect(body.code).to.equals(1);
       });
 
       it('payments: invalid claim target', () => {
         const paymentBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
-        const paymentRef = `/payments/test_service/${serviceUser}/0/claim/key1`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/claim/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
-          ref: paymentRef,
+          ref: payRef,
           value: {
             amount: paymentBalance,
             target: 'INVALID_TARGET'
@@ -3577,20 +3868,80 @@ describe('Blockchain Node', () => {
         expect(body.code).to.equals(1);
       });
 
-      it('payments: app admin can claim payments (target = address)', () => {
+      it('payments: app admin can claim payments with individual account target', () => {
         const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-        const paymentClaimRef = `/payments/test_service/${serviceUser}/0/claim/key2`;
+        const paymentClaimRef = `/payments/test_service_payment/${serviceUser}/0/claim/key2`;
         const paymentBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: paymentClaimRef,
           value: {
             amount: paymentBalance,
             target: serviceAdmin
-          }
+          },
+          nonce: -1,
+          timestamp: 1234567890000,
         }}).body.toString('utf-8'));
+        assert.deepEqual(_.get(body, 'result.result'), {
+          "code": 0,
+          "func_results": {
+            "_claim": {
+              "code": "SUCCESS",
+              "gas_amount": 0,
+              "op_results": [
+                {
+                  "path": "/transfer/payments|test_service_payment|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1234567890000/value",
+                  "result": {
+                    "code": 0,
+                    "func_results": {
+                      "_transfer": {
+                        "code": "SUCCESS",
+                        "gas_amount": 0,
+                        "op_results": [
+                          {
+                            "path": "/service_accounts/payments/test_service_payment/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          },
+                          {
+                            "path": "/accounts/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/balance",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          },
+                          {
+                            "path": "/transfer/payments|test_service_payment|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1234567890000/result",
+                            "result": {
+                              "code": 0,
+                              "gas_amount": 1,
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "gas_amount": 1,
+                  }
+                },
+                {
+                  "path": "/payments/test_service_payment/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0/claim/key2/result",
+                  "result": {
+                    "code": 0,
+                    "gas_amount": 1,
+                  }
+                }
+              ]
+            }
+          },
+          "gas_amount": 1,
+          "gas_amount_total": 6,
+          "gas_cost_total": 0,
+        });
+        expect(body.code).to.equals(0);
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
           console.error(`Failed to check finalization of tx.`)
         }
@@ -3601,7 +3952,7 @@ describe('Blockchain Node', () => {
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
         expect(adminBalanceAfter).to.equals(adminBalanceBefore + paymentBalance);
         const serviceAccountBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
                 .body.toString('utf-8')).result;
         expect(serviceAccountBalance).to.equals(0);
       });
@@ -3610,7 +3961,7 @@ describe('Blockchain Node', () => {
         // pay
         const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-        const payRef = `/payments/test_service/${serviceUser}/0/pay/key4`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key4`;
         const amount = adminBalanceBefore - 1;
         let body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: payRef,
@@ -3618,6 +3969,7 @@ describe('Blockchain Node', () => {
             amount
           }
         }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
           console.error(`Failed to check finalization of tx.`)
         }
@@ -3625,7 +3977,7 @@ describe('Blockchain Node', () => {
             `/get_value?ref=${payRef}/result/code`).body.toString('utf-8')).result;
         expect(payResult).to.equals(FunctionResultCode.SUCCESS);
         // open escrow
-        const escrowConfigRef = `/escrow/payments|test_service|${serviceUser}|0/${serviceAdmin}/0/config`;
+        const escrowConfigRef = `/escrow/payments|test_service_payment|${serviceUser}|0/${serviceAdmin}/0/config`;
         body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: escrowConfigRef,
           value: {
@@ -3634,13 +3986,14 @@ describe('Blockchain Node', () => {
             }
           }
         }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
           console.error(`Failed to check finalization of tx.`)
         }
         // claim + hold in escrow
-        const claimRef = `/payments/test_service/${serviceUser}/0/claim/key4`;
+        const claimRef = `/payments/test_service_payment/${serviceUser}/0/claim/key4`;
         const paymentBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
         body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: claimRef,
@@ -3656,17 +4009,17 @@ describe('Blockchain Node', () => {
         const claimResult = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=${claimRef}/result/code`).body.toString('utf-8')).result;
         expect(claimResult).to.equals(FunctionResultCode.SUCCESS);
-        const serviceAccountName = `payments|test_service|${serviceUser}|0:${serviceAdmin}:0`;
+        const serviceAccountName = `payments|test_service_payment|${serviceUser}|0:${serviceAdmin}:0`;
         const escrowServiceAccountBalance = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/service_accounts/escrow/escrow/${serviceAccountName}/balance`)
             .body.toString('utf-8')).result;
         expect(escrowServiceAccountBalance).to.equals(paymentBalance);
         const userServiceAccountBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
                 .body.toString('utf-8')).result;
         expect(userServiceAccountBalance).to.equals(0);
         // release escrow
-        const releaseEscrowRef = `/escrow/payments|test_service|${serviceUser}|0/${serviceAdmin}/0/release/key0`;
+        const releaseEscrowRef = `/escrow/payments|test_service_payment|${serviceUser}|0/${serviceAdmin}/0/release/key0`;
         body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: releaseEscrowRef,
           value: {
@@ -3681,10 +4034,10 @@ describe('Blockchain Node', () => {
         expect(adminBalanceAfter).to.equals(adminBalanceBefore);
       });
 
-      it('payments: app admin can claim payments (target = service account)', () => {
+      it('payments: app admin can claim payments with service account target', () => {
         const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
-        const payRef = `/payments/test_service/${serviceUser}/0/pay/key3`;
+        const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key3`;
         const amount = adminBalanceBefore - 1;
         let body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: payRef,
@@ -3692,6 +4045,7 @@ describe('Blockchain Node', () => {
             amount
           }
         }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
           console.error(`Failed to check finalization of tx.`)
         }
@@ -3699,15 +4053,15 @@ describe('Blockchain Node', () => {
             `/get_value?ref=${payRef}/result/code`).body.toString('utf-8')).result;
         expect(payResult).to.equals(FunctionResultCode.SUCCESS);
 
-        const claimRef = `/payments/test_service/${serviceUser}/0/claim/key3`;
+        const claimRef = `/payments/test_service_payment/${serviceUser}/0/claim/key3`;
         const paymentBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
         body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: claimRef,
           value: {
             amount: paymentBalance,
-            target: `payments|test_service|${serviceAdmin}|0`
+            target: `payments|test_service_payment|${serviceAdmin}|0`
           }
         }}).body.toString('utf-8'));
         if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
@@ -3717,17 +4071,31 @@ describe('Blockchain Node', () => {
             `/get_value?ref=${claimRef}/result/code`).body.toString('utf-8')).result;
         expect(claimResult).to.equals(FunctionResultCode.SUCCESS);
         const adminServiceAccountBalanceAfter = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceAdmin}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceAdmin}|0/balance`)
                 .body.toString('utf-8')).result;
         expect(adminServiceAccountBalanceAfter).to.equals(paymentBalance);
         const userServiceAccountBalance = parseOrLog(syncRequest('GET',
-            server1 + `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+            server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
                 .body.toString('utf-8')).result;
         expect(userServiceAccountBalance).to.equals(0);
       });
     });
 
-    describe('Escrow (_hold, _release)', () => {
+    describe('Escrow: _hold, _release', () => {
+      before(() => {
+        const manageAppPath = '/manage_app/test_service_escrow/create/1'
+        const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+          ref: manageAppPath,
+          value: {
+            admin: { [serviceAdmin]: true },
+          },
+        }}).body.toString('utf-8'));
+        expect(body.code).to.equals(0);
+        if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
+          console.error(`Failed to check finalization of tx.`)
+        }
+      });
+
       describe('Escrow: individual -> individual', () => {
         it('escrow: individual -> individual: open escrow', () => {
           const configRef = `/escrow/${serviceUser}/${serviceAdmin}/0/config`;
@@ -3737,8 +4105,16 @@ describe('Blockchain Node', () => {
               admin: {
                 [serviceAdmin]: true
               }
-            }
+            },
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "gas_amount": 1,
+            "gas_amount_total": 1,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3762,7 +4138,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: non-source account cannot write hold", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 1;
           const holdRef = `/escrow/${serviceUser}/${serviceAdmin}/0/hold/${key}`;
           const userBalanceBefore = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=/accounts/${serviceUser}/balance`).body.toString('utf-8')).result;
@@ -3776,7 +4152,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: source account can write hold", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 2;
           const holdRef = `/escrow/${serviceUser}/${serviceAdmin}/0/hold/${key}`;
           const userBalanceBefore = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=/accounts/${serviceUser}/balance`).body.toString('utf-8')).result;
@@ -3784,8 +4160,67 @@ describe('Blockchain Node', () => {
             ref: holdRef,
             value: {
               amount: userBalanceBefore
-            }
+            },
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_hold": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/escrow|escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 1000,
+                          "op_results": [
+                            {
+                              "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/service_accounts/escrow/escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/escrow|escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/0/hold/1234567890002/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 1006,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3800,7 +4235,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: non-admin account cannot write release", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 3;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: releaseRef,
@@ -3812,7 +4247,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: invalid ratio (ratio = -1)", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 4;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: releaseRef,
@@ -3824,7 +4259,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: invalid ratio (ratio = 1.1)", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 5;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: releaseRef,
@@ -3836,7 +4271,7 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: individual -> individual: admin account can write release (ratio = 0)", () => {
-          const key = Date.now();
+          const key = 1234567890000 + 6;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const userBalanceBefore = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=/accounts/${serviceUser}/balance`).body.toString('utf-8')).result;
@@ -3847,8 +4282,67 @@ describe('Blockchain Node', () => {
             ref: releaseRef,
             value: {
               ratio: 0
-            }
+            },
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_release": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/escrow|escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 0,
+                          "op_results": [
+                            {
+                              "path": "/service_accounts/escrow/escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/accounts/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/escrow|escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:0/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/0/release/1234567890006/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 6,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3868,33 +4362,40 @@ describe('Blockchain Node', () => {
 
       describe('Escrow: service -> individual', () => {
         it('escrow: service -> individual: open escrow', () => {
-          const key = Date.now();
-          const payRef = `/payments/test_service/${serviceUser}/0/pay/${key}`;
+          const key = 1234567890000 + 101;
+          const payRef = `/payments/test_service_escrow/${serviceUser}/0/pay/${key}`;
           const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
           const amount = adminBalanceBefore;
-          let body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+          const payBody = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: payRef,
             value: {
               amount
             }
           }}).body.toString('utf-8'));
-          if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
+          if (!waitUntilTxFinalized(serverList, _.get(payBody, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
           }
           // open escrow
-          const source = `payments|test_service|${serviceUser}|0`;
+          const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
           const configRef = `/escrow/${source}/${target}/1/config`;
-          body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+          const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: configRef,
             value: {
               admin: {
                 [serviceAdmin]: true
               }
             },
-            nonce: -1
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "gas_amount": 1,
+            "gas_amount_total": 1,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3905,12 +4406,12 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: service -> individual: non-service admin cannot write hold", () => {
-          const key = Date.now();
-          const source = `payments|test_service|${serviceUser}|0`;
+          const key = 1234567890000 + 102;
+          const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
           const holdRef = `/escrow/${source}/${target}/1/hold/${key}`;
           const paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: holdRef,
@@ -3922,19 +4423,78 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: service -> individual: service admin can write hold", () => {
-          const key = Date.now();
-          const source = `payments|test_service|${serviceUser}|0`;
+          const key = 1234567890000 + 103;
+          const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
           const holdRef = `/escrow/${source}/${target}/1/hold/${key}`;
           const paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: holdRef,
             value: {
               amount: paymentBalanceBefore
-            }
+            },
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_hold": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/escrow|escrow|payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 1000,
+                          "op_results": [
+                            {
+                              "path": "/service_accounts/payments/test_service_escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/service_accounts/escrow/escrow/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/escrow|escrow|payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/escrow/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1/hold/1234567890103/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 1006,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3949,12 +4509,12 @@ describe('Blockchain Node', () => {
         });
 
         it("escrow: service -> individual: admin account can write release (ratio = 0, refund to payments via _transfer)", () => {
-          const key = Date.now();
-          const source = `payments|test_service|${serviceUser}|0`;
+          const key = 1234567890000 + 104;
+          const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
           const releaseRef = `/escrow/${source}/${target}/1/release/${key}`;
           const paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           const escrowServiceAccountBalanceBefore = parseOrLog(syncRequest('GET',
               server1 + `/get_value?ref=/service_accounts/escrow/escrow/${source}:${target}:1/balance`)
@@ -3963,8 +4523,67 @@ describe('Blockchain Node', () => {
             ref: releaseRef,
             value: {
               ratio: 0
-            }
+            },
+            nonce: -1,
+            timestamp: 1234567890000,
           }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_release": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/transfer/escrow|escrow|payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/value",
+                    "result": {
+                      "code": 0,
+                      "func_results": {
+                        "_transfer": {
+                          "code": "SUCCESS",
+                          "gas_amount": 0,
+                          "op_results": [
+                            {
+                              "path": "/service_accounts/escrow/escrow/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/service_accounts/payments/test_service_escrow/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/balance",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            },
+                            {
+                              "path": "/transfer/escrow|escrow|payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0:0x00ADEc28B6a845a085e03591bE7550dd68673C1C:1/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/1234567890000/result",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1,
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "gas_amount": 1,
+                    }
+                  },
+                  {
+                    "path": "/escrow/payments|test_service_escrow|0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204|0/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1/release/1234567890104/result",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 6,
+            "gas_cost_total": 0,
+          });
           expect(body.code).to.equals(0);
           if (!waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash'))) {
             console.error(`Failed to check finalization of tx.`)
@@ -3977,19 +4596,19 @@ describe('Blockchain Node', () => {
               .body.toString('utf-8')).result;
           expect(escrowServiceAccountBalanceAfter).to.equals(0);
           const paymentBalanceAfter = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           expect(paymentBalanceAfter).to.equals(paymentBalanceBefore + escrowServiceAccountBalanceBefore);
         });
 
         it("escrow: service -> individual: escrow admin account can write release (ratio = 0.5)", () => {
           // hold
-          let key = Date.now();
-          const source = `payments|test_service|${serviceUser}|0`;
+          const holdKey = 1234567890000 + 105;
+          const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
-          const holdRef = `/escrow/${source}/${target}/1/hold/${key}`;
+          const holdRef = `/escrow/${source}/${target}/1/hold/${holdKey}`;
           const paymentBalance = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           let body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
             ref: holdRef,
@@ -4002,10 +4621,10 @@ describe('Blockchain Node', () => {
             console.error(`Failed to check finalization of tx.`)
           }
           // release
-          key = Date.now();
-          const releaseRef = `/escrow/${source}/${target}/1/release/${key}`;
+          const releaseKey = 1234567890000 + 106;
+          const releaseRef = `/escrow/${source}/${target}/1/release/${releaseKey}`;
           const paymentBalanceBefore = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           const adminBalanceBefore = parseOrLog(syncRequest('GET', server1 +
               `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
@@ -4030,7 +4649,7 @@ describe('Blockchain Node', () => {
               .body.toString('utf-8')).result;
           expect(escrowServiceAccountBalanceAfter).to.equals(0);
           const paymentBalanceAfter = parseOrLog(syncRequest('GET', server1 +
-              `/get_value?ref=/service_accounts/payments/test_service/${serviceUser}|0/balance`)
+              `/get_value?ref=/service_accounts/payments/test_service_escrow/${serviceUser}|0/balance`)
                   .body.toString('utf-8')).result;
           expect(paymentBalanceAfter).to.equals(paymentBalanceBefore + escrowServiceAccountBalanceBefore / 2);
           const adminBalanceAfter = parseOrLog(syncRequest('GET', server1 +

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -40,38 +40,43 @@ const {
 const ENV_VARIABLES = [
   {
     // For parent chain poc node
-    MIN_NUM_VALIDATORS: 1, ACCOUNT_INDEX: 0, DEBUG: true, ENABLE_DEV_CLIENT_API: true,
-    ENABLE_GAS_FEE_WORKAROUND: true,
+    MIN_NUM_VALIDATORS: 1, ACCOUNT_INDEX: 0, DEBUG: true,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
   },
   {
     // For shard chain tracker
-    PORT: 9090, P2P_PORT: 6000
+    PORT: 9090, P2P_PORT: 6000,
+    CONSOLE_LOG: false
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
-    PORT: 9091, P2P_PORT: 6001, ENABLE_GAS_FEE_WORKAROUND: true,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0, ENABLE_DEV_CLIENT_API: true,
+    PORT: 9091, P2P_PORT: 6001,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 0,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
-    PORT: 9092, P2P_PORT: 6002, ENABLE_GAS_FEE_WORKAROUND: true,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1, ENABLE_DEV_CLIENT_API: true,
+    PORT: 9092, P2P_PORT: 6002,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 1,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
-    PORT: 9093, P2P_PORT: 6003, ENABLE_GAS_FEE_WORKAROUND: true,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2, ENABLE_DEV_CLIENT_API: true,
+    PORT: 9093, P2P_PORT: 6003,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 2,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
   {
     GENESIS_CONFIGS_DIR: 'genesis-configs/afan-shard',
-    PORT: 9094, P2P_PORT: 6004, ENABLE_GAS_FEE_WORKAROUND: true,
-    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3, ENABLE_DEV_CLIENT_API: true,
+    PORT: 9094, P2P_PORT: 6004,
+    MIN_NUM_VALIDATORS: 4, ACCOUNT_INDEX: 3,
+    CONSOLE_LOG: false, ENABLE_DEV_CLIENT_API: true, ENABLE_GAS_FEE_WORKAROUND: true,
     ADDITIONAL_OWNERS: 'test:unittest/data/owners_for_testing.json',
     ADDITIONAL_RULES: 'test:unittest/data/rules_for_testing.json'
   },
@@ -215,9 +220,10 @@ describe('Sharding', () => {
   before(() => {
     rimraf.sync(CHAINS_DIR)
 
-    parent_tracker_proc = startServer(TRACKER_SERVER, 'parent tracker server', {}, false);
+    parent_tracker_proc =
+        startServer(TRACKER_SERVER, 'parent tracker server', { CONSOLE_LOG: false }, true);
     sleep(2000);
-    parent_server_proc = startServer(APP_SERVER, 'parent server', ENV_VARIABLES[0], false);
+    parent_server_proc = startServer(APP_SERVER, 'parent server', ENV_VARIABLES[0], true);
     sleep(15000);
     // Give AIN to sharding owner and reporter
     const shardReportRes = parseOrLog(syncRequest(
@@ -239,16 +245,16 @@ describe('Sharding', () => {
     ).result;
     waitUntilTxFinalized(parentServerList, shardReportRes.tx_hash);
     
-    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', ENV_VARIABLES[1], false);
+    tracker_proc = startServer(TRACKER_SERVER, 'tracker server', ENV_VARIABLES[1], true);
     sleep(2000);
-    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2], false);
+    server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2], true);
     sleep(2000);
     waitUntilShardReporterStarts();
-    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[3], false);
+    server2_proc = startServer(APP_SERVER, 'server2', ENV_VARIABLES[3], true);
     sleep(2000);
-    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[4], false);
+    server3_proc = startServer(APP_SERVER, 'server3', ENV_VARIABLES[4], true);
     sleep(2000);
-    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[5], false);
+    server4_proc = startServer(APP_SERVER, 'server4', ENV_VARIABLES[5], true);
     sleep(2000);
   });
 

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -387,15 +387,15 @@ describe("ChainUtil", () => {
 
     it("when single set operation with function triggering", () => {
       expect(ChainUtil.isFailedTx({
-        ".func_results": {
+        "func_results": {
           "_saveLastTx": {
-            ".op_results": [
+            "op_results": [
               {
                 "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                 "result": {
-                  ".func_results": {
+                  "func_results": {
                     "_eraseValue": {
-                      ".op_results": [
+                      "op_results": [
                         {
                           "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                           "result": {
@@ -422,15 +422,15 @@ describe("ChainUtil", () => {
       })).to.equal(false);
 
       expect(ChainUtil.isFailedTx({
-        ".func_results": {
+        "func_results": {
           "_saveLastTx": {
-            ".op_results": [
+            "op_results": [
               {
                 "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                 "result": {
-                  ".func_results": {
+                  "func_results": {
                     "_eraseValue": {
-                      ".op_results": [
+                      "op_results": [
                         {
                           "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                           "result": {
@@ -503,15 +503,15 @@ describe("ChainUtil", () => {
             "gas_amount": 1
           },
           {
-            ".func_results": {
+            "func_results": {
               "_saveLastTx": {
-                ".op_results": [
+                "op_results": [
                   {
                     "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                     "result": {
-                      ".func_results": {
+                      "func_results": {
                         "_eraseValue": {
-                          ".op_results": [
+                          "op_results": [
                             {
                               "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                               "result": {
@@ -550,15 +550,15 @@ describe("ChainUtil", () => {
             "gas_amount": 1
           },
           {
-            ".func_results": {
+            "func_results": {
               "_saveLastTx": {
-                ".op_results": [
+                "op_results": [
                   {
                     "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                     "result": {
-                      ".func_results": {
+                      "func_results": {
                         "_eraseValue": {
-                          ".op_results": [
+                          "op_results": [
                             {
                               "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                               "result": {
@@ -609,15 +609,15 @@ describe("ChainUtil", () => {
 
     it("when single operation result input", () => {
       const result = {
-        ".func_results": {
+        "func_results": {
           "_saveLastTx": {
-            ".op_results": [
+            "op_results": [
               {
                 "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                 "result": {
-                  ".func_results": {
+                  "func_results": {
                     "_eraseValue": {
-                      ".op_results": [
+                      "op_results": [
                         {
                           "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                           "result": {
@@ -648,15 +648,15 @@ describe("ChainUtil", () => {
     it("when multiple operation result input", () => {
       const result = [
         {
-          ".func_results": {
+          "func_results": {
             "_saveLastTx": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                   "result": {
-                    ".func_results": {
+                    "func_results": {
                       "_eraseValue": {
-                        ".op_results": [
+                        "op_results": [
                           {
                             "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                             "result": {

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -385,7 +385,7 @@ describe("ChainUtil", () => {
       })).to.equal(true);
     });
 
-    it("when single set operation with function triggering", () => {
+    it("when single set operation with native function triggering", () => {
       expect(ChainUtil.isFailedTx({
         "func_results": {
           "_saveLastTx": {
@@ -452,13 +452,99 @@ describe("ChainUtil", () => {
             "gas_amount": 0,
           }
         },
-        "code": 201,
+        "code": 201,  // The root operation failed
         "error_message": "Not a number type: bar or 10",
+        "gas_amount": 1
+      })).to.equal(true);
+
+      expect(ChainUtil.isFailedTx({
+        "func_results": {
+          "_saveLastTx": {
+            "op_results": [
+              {
+                "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                "result": {
+                  "func_results": {
+                    "_eraseValue": {
+                      "op_results": [
+                        {
+                          "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                          "result": {
+                            "code": 201,  // A sub-operation failed
+                            "error_message": "Not a number type: bar or 10",
+                            "gas_amount": 1
+                          }
+                        }
+                      ],
+                      "code": "SUCCESS",
+                      "gas_amount": 0,
+                    }
+                  },
+                  "code": 0,
+                  "gas_amount": 1
+                }
+              }
+            ],
+            "code": "SUCCESS",
+            "gas_amount": 0,
+          }
+        },
+        "code": 0,
+        "gas_amount": 1
+      })).to.equal(true);
+
+      expect(ChainUtil.isFailedTx({
+        "func_results": {
+          "_saveLastTx": {
+            "op_results": [
+              {
+                "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                "result": {
+                  "func_results": {
+                    "_eraseValue": {
+                      "op_results": [
+                        {
+                          "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                          "result": {
+                            "code": 0,
+                            "gas_amount": 1
+                          }
+                        }
+                      ],
+                      "code": "FAILURE",  // A function failed.
+                      "gas_amount": 0,
+                    }
+                  },
+                  "code": 0,
+                  "gas_amount": 1
+                }
+              }
+            ],
+            "code": "SUCCESS",
+            "gas_amount": 0,
+          }
+        },
+        "code": 0,
         "gas_amount": 1
       })).to.equal(true);
     });
 
-    it("when multi set operation without function triggering", () => {
+    it("when single set operation with REST function triggering", () => {
+      expect(ChainUtil.isFailedTx({
+        "code": 0,
+        "func_results": {
+          "0x11111": {
+            "code": "SUCCESS",
+            "gas_amount": 10,
+          }
+        },
+        "gas_amount": 1,
+        "gas_amount_total": 11,
+        "gas_cost_total": 0,
+      })).to.equal(false);
+    });
+
+    it("when multi-set operation without function triggering", () => {
       expect(ChainUtil.isFailedTx({
         "result_list": [
           {
@@ -495,7 +581,7 @@ describe("ChainUtil", () => {
       })).to.equal(true);
     })
 
-    it("when multi set operation with function triggering", () => {
+    it("when multi-set operation with native function triggering", () => {
       expect(ChainUtil.isFailedTx({
         "result_list": [
           {
@@ -580,8 +666,103 @@ describe("ChainUtil", () => {
                 "gas_amount": 0,
               }
             },
-            "code": 201,
+            "code": 0,
+            "gas_amount": 0
+          },
+          {
+            "code": 201,  // One of the root operations failed.
             "error_message": "Not a number type: bar or 10",
+            "gas_amount": 1,
+          },
+        ]
+      })).to.equal(true);
+
+      expect(ChainUtil.isFailedTx({
+        "result_list": [
+          {
+            "code": 0,
+            "gas_amount": 1
+          },
+          {
+            "func_results": {
+              "_saveLastTx": {
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                    "result": {
+                      "func_results": {
+                        "_eraseValue": {
+                          "op_results": [
+                            {
+                              "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                              "result": {
+                                "code": 201,  // A sub-operation failed.
+                                "error_message": "Not a number type: bar or 10",
+                                "gas_amount": 1
+                              }
+                            }
+                          ],
+                          "code": "SUCCESS",
+                          "gas_amount": 0,
+                        }
+                      },
+                      "code": 0,
+                      "gas_amount": 1
+                    }
+                  }
+                ],
+                "code": "SUCCESS",
+                "gas_amount": 0,
+              }
+            },
+            "code": 0,
+            "gas_amount": 0
+          },
+          {
+            "code": 0,
+            "gas_amount": 1,
+          },
+        ]
+      })).to.equal(true);
+
+      expect(ChainUtil.isFailedTx({
+        "result_list": [
+          {
+            "code": 0,
+            "gas_amount": 1
+          },
+          {
+            "func_results": {
+              "_saveLastTx": {
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                    "result": {
+                      "func_results": {
+                        "_eraseValue": {
+                          "op_results": [
+                            {
+                              "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                              "result": {
+                                "code": 0,
+                                "gas_amount": 1
+                              }
+                            }
+                          ],
+                          "code": "FAILURE",  // A function failed.
+                          "gas_amount": 0,
+                        }
+                      },
+                      "code": 0,
+                      "gas_amount": 1
+                    }
+                  }
+                ],
+                "code": "SUCCESS",
+                "gas_amount": 0,
+              }
+            },
+            "code": 0,
             "gas_amount": 0
           },
           {
@@ -592,6 +773,32 @@ describe("ChainUtil", () => {
       })).to.equal(true);
     })
 
+    it("when multi-set operation with REST function triggering", () => {
+      expect(ChainUtil.isFailedTx({
+        "result_list": [
+          {
+            "code": 0,
+            "gas_amount": 1
+          },
+          {
+            "code": 0,
+            "func_results": {
+              "0x11111": {
+                "code": "SUCCESS",
+                "gas_amount": 10,
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": 11,
+            "gas_cost_total": 0,
+          },
+          {
+            "code": 0,
+            "gas_amount": 1,
+          },
+        ]
+      })).to.equal(false);
+    });
   })
 
   describe("getTotalGasAmount", () => {

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -1412,15 +1412,15 @@ describe("DB operations", () => {
 
         assert.deepEqual(node.db.executeSingleSetOperation(txBody.operation, { addr: 'abcd' },
             timestamp, tx), {
-          ".func_results": {
+          "func_results": {
             "_saveLastTx": {
-              ".op_results": [
+              "op_results": [
                 {
                   "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                   "result": {
-                    ".func_results": {
+                    "func_results": {
                       "_eraseValue": {
-                        ".op_results": [
+                        "op_results": [
                           {
                             "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                             "result": {
@@ -1654,15 +1654,15 @@ describe("DB operations", () => {
             { addr: 'abcd' }, timestamp, tx), {
           "result_list": [
             {
-              ".func_results": {
+              "func_results": {
                 "_saveLastTx": {
-                  ".op_results": [
+                  "op_results": [
                     {
                       "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                       "result": {
-                        ".func_results": {
+                        "func_results": {
                           "_eraseValue": {
-                            ".op_results": [
+                            "op_results": [
                               {
                                 "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
                                 "result": {
@@ -1757,12 +1757,17 @@ describe("DB operations", () => {
             ref: '/test/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20',
             value: 'some value',
           },
-          gas_price: 1,
+          gas_price: 0,
           nonce: -1,
           timestamp: 1568798344000,
         };
         const maxHeightTx = Transaction.fromTxBody(maxHeightTxBody, node.account.private_key);
-        assert.deepEqual(node.db.executeTransaction(maxHeightTx, node.bc.lastBlockNumber() + 1).code, 0);
+        assert.deepEqual(node.db.executeTransaction(maxHeightTx, node.bc.lastBlockNumber() + 1), {
+          code: 0,
+          gas_amount: 1,
+          gas_amount_total: 1,
+          gas_cost_total: 0,
+        });
 
         const overHeightTxBody = {
           operation: {
@@ -1770,12 +1775,16 @@ describe("DB operations", () => {
             ref: '/test/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21',
             value: 'some value',
           },
-          gas_price: 1,
+          gas_price: 0,
           nonce: -1,
           timestamp: 1568798344000,
         };
         const overHeightTx = Transaction.fromTxBody(overHeightTxBody, node.account.private_key);
-        assert.deepEqual(node.db.executeTransaction(overHeightTx, node.bc.lastBlockNumber() + 1).code, 23);
+        assert.deepEqual(node.db.executeTransaction(overHeightTx, node.bc.lastBlockNumber() + 1), {
+          code: 23,
+          error_message: "Out of tree height limit (21 > 20)",
+          gas_amount: 0,
+        });
       })
 
       it("rejects over-size transaction", () => {
@@ -1797,7 +1806,11 @@ describe("DB operations", () => {
           timestamp: 1568798344000,
         };
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
-        assert.deepEqual(node.db.executeTransaction(overSizeTx, node.bc.lastBlockNumber() + 1).code, 24);
+        assert.deepEqual(node.db.executeTransaction(overSizeTx, node.bc.lastBlockNumber() + 1), {
+          code: 24,
+          error_message: "Out of tree size limit (1001521 > 1000000)",
+          gas_amount: 0,
+        });
       })
     });
   });

--- a/unittest/functions.test.js
+++ b/unittest/functions.test.js
@@ -396,7 +396,7 @@ describe("Functions", () => {
             tx);
         assert.deepEqual(func_results, {
           "_transfer": {
-            ".op_results": [
+            "op_results": [
              {
                 "path": "/accounts/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1/balance",
                 "result": {
@@ -451,7 +451,7 @@ describe("Functions", () => {
             tx);
         assert.deepEqual(func_results, {
           "_transfer": {
-            ".op_results": [
+            "op_results": [
               {
                 "path": "/accounts/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1/balance",
                 "result": {

--- a/unittest/functions.test.js
+++ b/unittest/functions.test.js
@@ -145,7 +145,10 @@ describe("Functions", () => {
             ChainUtil.parsePath(refPathRest),
             null, null, null, transaction);
         assert.deepEqual(func_results, {
-          "gas_amount": 10
+          "0x11111": {
+            "code": "SUCCESS",
+            "gas_amount": 10,
+          }
         });
         promise_results.then((resp) => {
           assert.deepEqual(resp, {
@@ -508,7 +511,10 @@ describe("Functions", () => {
             ChainUtil.parsePath(refPathRest),
             null, null, null, transaction);
         assert.deepEqual(func_results, {
-          "gas_amount": 10
+          "0x11111": {
+            "code": "SUCCESS",
+            "gas_amount": 10,
+          }
         });
         promise_results.then((resp) => {
           assert.deepEqual(resp, {

--- a/unittest/transaction.test.js
+++ b/unittest/transaction.test.js
@@ -135,20 +135,22 @@ describe('Transaction', () => {
       assert.deepEqual(tx2, null);
     });
 
-    it('fail with missing gas_price', () => {
+    it('succeed with absent gas_price', () => {
       delete txBody.gas_price;
       const tx2 = Transaction.fromTxBody(txBody, node.account.private_key);
-      assert.deepEqual(tx2, null);
+      expect(tx2).to.not.equal(null);
+    });
+
+    it('succeed with zero gas_price', () => {
+      txBody.gas_price = 0;
+      tx2 = Transaction.fromTxBody(txBody, node.account.private_key);
+      expect(tx2).to.not.equal(null);
     });
 
     it('fail with invalid gas_price', () => {
       txBody.gas_price = -1;
       let tx3 = Transaction.fromTxBody(txBody, node.account.private_key);
       assert.deepEqual(tx3, null);
-
-      txBody.gas_price = 0;
-      tx2 = Transaction.fromTxBody(txBody, node.account.private_key);
-      assert.deepEqual(tx2, null);
     });
   });
 


### PR DESCRIPTION
Change summary:
- Update isFailedTx() to check function results as well
- Include REST function id in func_results
- Fix a bug in _updateLatestShardReport() result
- Don't use ExecResultProperties anymore
- Let ENABLE_GAS_FEE_WORKAROUND default to true
- Always set stdioInherit = true, CONSOLE_LOG = false in integration tests for tester's convenience

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/265 