### PR TITLE
Move state access methods to DB

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -409,7 +409,7 @@ if (ENABLE_DEV_CLIENT_API) {
   });
 
   app.get('/get_nonce', (req, res, next) => {
-    const result = node.nonce;
+    const result = node.getNonceForAddr(req.query.address, req.query.from === 'pending');
     res.status(200)
       .set('Content-Type', 'application/json')
       .send({code: 0, result})

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -67,7 +67,7 @@ class ChainUtil {
           ainUtil.pubToAddress(publicKey, publicKey.length === 65)));
     } catch (err) {
       logger.error(
-          `[${LOG_HEADER}] Failed to extract address with error: ${JSON.stringify(err)}.`);
+          `[${LOG_HEADER}] Failed to extract address with error: ${err} ${err.stack}.`);
     }
     return address;
   }

--- a/common/constants.js
+++ b/common/constants.js
@@ -435,6 +435,7 @@ const StateVersions = {
   SEGMENT: 'SEGMENT',
   SNAP: 'SNAP',
   START: 'START',
+  TX_POOL: 'TX_POOL',
 };
 
 /**

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -182,6 +182,11 @@ class PathUtil {
     return PathUtil.getServiceAccountPath(PredefinedDbPaths.STAKING, PredefinedDbPaths.CONSENSUS, `${address}|0`);
   }
 
+  static getConsensusStakingAccountBalancePath(address) {
+    const accountPath =  PathUtil.getServiceAccountPath(PredefinedDbPaths.STAKING, PredefinedDbPaths.CONSENSUS, `${address}|0`);
+    return ChainUtil.appendPath(accountPath, PredefinedDbPaths.BALANCE)
+  }
+
   static getConsensusProposePath(blockNumber) {
     return ChainUtil.formatPath([
         PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -8,6 +8,14 @@ class PathUtil {
     return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, PredefinedDbPaths.BALANCE]);
   }
 
+  static getAccountNoncePath(address) {
+    return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, PredefinedDbPaths.ACCOUNTS_NONCE]);
+  }
+
+  static getAccountTimestampPath(address) {
+    return ChainUtil.formatPath([PredefinedDbPaths.ACCOUNTS, address, PredefinedDbPaths.ACCOUNTS_TIMESTAMP]);
+  }
+
   static getServiceAccountPath(serviceType, serviceName, accountKey) {
     return ChainUtil.formatPath([PredefinedDbPaths.SERVICE_ACCOUNTS, serviceType, serviceName, accountKey]);
   }

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -932,10 +932,10 @@ class Consensus {
     return validators;
   }
 
-  getWhitelist() {
+  getWhitelist(stateVersion) {
     const LOG_HEADER = 'getWhitelist';
     const whitelist = this.node.getValueWithStateVersion(
-        PathUtil.getConsensusWhitelistPath(), false, this.node.stateManager.getFinalVersion());
+        PathUtil.getConsensusWhitelistPath(), false, stateVersion);
     logger.debug(`[${LOG_HEADER}] whitelist: ${JSON.stringify(whitelist, null, 2)}`);
     return whitelist || {};
   }
@@ -950,8 +950,7 @@ class Consensus {
       logger.error(err);
       throw Error(err);
     }
-    const whitelist = this.node.getValueWithStateVersion(
-        PathUtil.getConsensusWhitelistPath(), false, stateVersion) || {};
+    const whitelist = this.getWhitelist(stateVersion);
     const validators = {};
     Object.keys(whitelist).forEach((address) => {
       const stakingAccount = this.node.getValueWithStateVersion(

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -348,7 +348,7 @@ class Consensus {
       }
     }
 
-    const transactions = this.node.tp.getValidTransactions(tempDb, longestNotarizedChain);
+    const transactions = this.node.tp.getValidTransactions(longestNotarizedChain, tempVersion);
     const validTransactions = [];
     const invalidTransactions = [];
     const resList = [];

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -348,8 +348,7 @@ class Consensus {
       }
     }
 
-    // TODO(liayoo): Restrict the size / number of txs.
-    const transactions = this.node.tp.getValidTransactions(longestNotarizedChain, tempVersion);
+    const transactions = this.node.tp.getValidTransactions(tempDb, longestNotarizedChain);
     const validTransactions = [];
     const invalidTransactions = [];
     const resList = [];

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -96,8 +96,8 @@ class Consensus {
       this.startEpochTransition();
       logger.info(`[${LOG_HEADER}] Initialized to number ${finalizedNumber} and ` +
           `epoch ${this.state.epoch}`);
-    } catch (e) {
-      logger.error(`[${LOG_HEADER}] Init error: ${e}`);
+    } catch (err) {
+      logger.error(`[${LOG_HEADER}] Init error: ${err} ${err.stack}`);
       this.setStatus(ConsensusStatus.STARTING, 'init');
     }
   }
@@ -130,8 +130,8 @@ class Consensus {
           const iNTPData = await ntpsync.ntpLocalClockDeltaPromise();
           logger.debug(`(Local Time - NTP Time) Delta = ${iNTPData.minimalNTPLatencyDelta} ms`);
           this.timeAdjustment = iNTPData.minimalNTPLatencyDelta;
-        } catch (e) {
-          logger.error(`ntpsync error: ${e}`);
+        } catch (err) {
+          logger.error(`ntpsync error: ${err} ${err.stack}`);
         }
       }
       currentTime -= this.timeAdjustment;
@@ -728,8 +728,8 @@ class Consensus {
               proposal, ConsensusMessageTypes.PROPOSE);
           this.handleConsensusMessage(consensusMsg);
         }
-      } catch (e) {
-        logger.error(`[${LOG_HEADER}] Error while creating a proposal: ${e}`);
+      } catch (err) {
+        logger.error(`[${LOG_HEADER}] Error while creating a proposal: ${err} ${err.stack}`);
       }
     } else {
       logger.info(`[${LOG_HEADER}] Not my turn ${this.node.account.address}`);
@@ -1068,8 +1068,8 @@ class Consensus {
         // the child state.
         await signAndSendTx(parentChainEndpoint, tx, this.node.account.private_key);
       }
-    } catch (e) {
-      logger.error(`Failed to report state proof hashes: ${e}`);
+    } catch (err) {
+      logger.error(`Failed to report state proof hashes: ${err} ${err.stack}`);
     }
     this.isReporting = false;
   }

--- a/db/functions.js
+++ b/db/functions.js
@@ -868,7 +868,7 @@ class Functions {
       });
       return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
     } catch (err) {
-      logger.error(`  => _openCheckin failed with error: ${JSON.stringify(err)}`);
+      logger.error(`  => _openCheckin failed with error: ${err} ${err.stack}`);
       return this.returnFuncResult(context, FunctionResultCode.FAILURE);
     }
   }
@@ -927,7 +927,7 @@ class Functions {
       signAndSendTx(endpoint, transferTx, ownerPrivateKey);
       return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
     } catch (err) {
-      logger.error(`  => _closeCheckin failed with error: ${JSON.stringify(err)}`);
+      logger.error(`  => _closeCheckin failed with error: ${err} ${err.stack}`);
       return this.returnFuncResult(context, FunctionResultCode.FAILURE);
     }
   }

--- a/db/index.js
+++ b/db/index.js
@@ -262,7 +262,7 @@ class DB {
   /**
    * Returns reference to the input path for reading if exists, otherwise null.
    */
-  static getRefForReading(stateRoot, fullPath) {
+  static getRefForReadingFromStateRoot(stateRoot, fullPath) {
     let node = stateRoot;
     for (let i = 0; i < fullPath.length; i++) {
       const label = fullPath[i];
@@ -291,7 +291,7 @@ class DB {
   // - Reference from root_a: child_1a -> child_2a -> child_3a
   // - Reference from root_b: child_1b -> child_2 -> child_3 (not affected)
   //
-  static getRefForWriting(stateRoot, fullPath) {
+  static getRefForWritingToStateRoot(stateRoot, fullPath) {
     let node = stateRoot;
     let hasMultipleRoots = node.numParents() > 1;
     for (let i = 0; i < fullPath.length; i++) {
@@ -336,11 +336,11 @@ class DB {
       stateRoot = stateTree;
     } else {
       const label = fullPath[fullPath.length - 1];
-      const parent = DB.getRefForWriting(stateRoot, pathToParent);
+      const parent = DB.getRefForWritingToStateRoot(stateRoot, pathToParent);
       parent.setChild(label, stateTree);
     }
     if (isEmptyNode(stateTree)) {
-      DB.removeEmptyNodes(stateRoot, fullPath);
+      DB.removeEmptyNodesFromStateRoot(stateRoot, fullPath);
     } else if (!LIGHTWEIGHT) {
       setProofHashForStateTree(stateTree);
     }
@@ -371,7 +371,7 @@ class DB {
     }
   }
 
-  static removeEmptyNodes(stateRoot, fullPath) {
+  static removeEmptyNodesFromStateRoot(stateRoot, fullPath) {
     return DB.removeEmptyNodesRecursive(fullPath, 0, stateRoot);
   }
 
@@ -384,7 +384,7 @@ class DB {
       return null;
     }
     const fullPath = DB.getFullPath(localPath, rootLabel);
-    const stateNode = DB.getRefForReading(stateRoot, fullPath);
+    const stateNode = DB.getRefForReadingFromStateRoot(stateRoot, fullPath);
     return stateNode !== null ? stateNode.toJsObject() : null;
   }
 
@@ -445,7 +445,7 @@ class DB {
    */
   getStateInfo(statePath) {
     const parsedPath = ChainUtil.parsePath(statePath);
-    const stateNode = DB.getRefForReading(this.stateRoot, parsedPath);
+    const stateNode = DB.getRefForReadingFromStateRoot(this.stateRoot, parsedPath);
     if (stateNode === null) {
       return null;
     }
@@ -592,7 +592,7 @@ class DB {
   }
 
   // TODO(platfowner): Use shallow fetch once available.
-  static getAppStakesTotal(stateRoot) {
+  static getAppStakesTotalFromStateRoot(stateRoot) {
     const appStakes = DB.getValueFromStateRoot(stateRoot, PredefinedDbPaths.STAKING) || {};
     return Object.keys(appStakes).reduce((acc, cur) => {
       if (cur === PredefinedDbPaths.CONSENSUS) return acc;
@@ -600,7 +600,7 @@ class DB {
     }, 0);
   }
 
-  static getAppStake(stateRoot, appName) {
+  static getAppStakeFromStateRoot(stateRoot, appName) {
     const appStakePath = PathUtil.getStakingBalanceTotalPath(appName);
     return DB.getValueFromStateRoot(stateRoot, appStakePath) || 0;
   }

--- a/db/index.js
+++ b/db/index.js
@@ -600,9 +600,17 @@ class DB {
     }, 0);
   }
 
+  getAppStakesTotal() {
+    return DB.getAppStakesTotalFromStateRoot(this.stateRoot);
+  }
+
   static getAppStakeFromStateRoot(stateRoot, appName) {
     const appStakePath = PathUtil.getStakingBalanceTotalPath(appName);
     return DB.getValueFromStateRoot(stateRoot, appStakePath) || 0;
+  }
+
+  getAppStake(appName) {
+    return DB.getAppStakeFromStateRoot(this.stateRoot, appName);
   }
 
   // TODO(platfowner): Define error code explicitly.

--- a/db/index.js
+++ b/db/index.js
@@ -275,6 +275,10 @@ class DB {
     return node;
   }
 
+  getRefForReading(fullPath) {
+    return DB.getRefForReadingFromStateRoot(this.stateRoot, fullPath);
+  }
+
   /**
    * Returns reference to the input path for writing if exists, otherwise creates path.
    */
@@ -327,6 +331,10 @@ class DB {
       }
     }
     return node;
+  }
+
+  getRefForWriting(fullPath) {
+    return DB.getRefForWritingToStateRoot(this.stateRoot, fullPath);
   }
 
   static writeToStateRoot(stateRoot, stateVersion, fullPath, stateObj) {
@@ -445,7 +453,7 @@ class DB {
    */
   getStateInfo(statePath) {
     const parsedPath = ChainUtil.parsePath(statePath);
-    const stateNode = DB.getRefForReadingFromStateRoot(this.stateRoot, parsedPath);
+    const stateNode = this.getRefForReading(parsedPath);
     if (stateNode === null) {
       return null;
     }

--- a/db/index.js
+++ b/db/index.js
@@ -554,8 +554,7 @@ class DB {
       const fullNoncePath =
           DB.getFullPath(ChainUtil.parsePath(noncePath), PredefinedDbPaths.VALUES_ROOT);
       this.writeDatabase(fullNoncePath, nonce + 1);
-    }
-    if (nonce === -2) { // ordered nonce
+    } else if (nonce === -2) { // ordered nonce
       if (!ChainUtil.isNumber(timestamp)) {
         logger.error(`[${LOG_HEADER}] Invalid timestamp: ${timestamp} for address: ${address}`);
         return;
@@ -805,10 +804,13 @@ class DB {
     if (tx && auth && auth.addr && !auth.fid) {
       const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (tx.tx_body.nonce >= 0 && tx.tx_body.nonce !== nonce) {
-        return ChainUtil.returnTxResult(12, `Invalid nonce: ${tx.tx_body.nonce}`);
+        return ChainUtil.returnTxResult(
+          12, `Invalid nonce (!== ${nonce}) of transaction: ${JSON.stringify(tx)}`);
       }
       if (tx.tx_body.nonce === -2 && tx.tx_body.timestamp <= accountTimestamp) {
-        return ChainUtil.returnTxResult(13, `Invalid timestamp: ${tx.tx_body.timestamp}`);
+        return ChainUtil.returnTxResult(
+          13, `Invalid timestamp (<= ${accountTimestamp}) of transaction: ` +
+          `${JSON.stringify(tx)}`);
       }
     }
     let result;
@@ -926,11 +928,11 @@ class DB {
           `newData: ${JSON.stringify(newData)}, auth: ${JSON.stringify(auth)}, ` +
           `timestamp: ${timestamp}\n`);
       }
-    } catch (e) {
+    } catch (err) {
       logger.debug(`[${LOG_HEADER}] Failed to eval rule.\n` +
           `matched: ${JSON.stringify(matched, null, 2)}, data: ${JSON.stringify(data)}, ` +
           `newData: ${JSON.stringify(newData)}, auth: ${JSON.stringify(auth)}, ` +
-          `timestamp: ${timestamp}\nError: ${e}`);
+          `timestamp: ${timestamp}\nError: ${err} ${err.stack}`);
     }
     return evalRuleRes;
   }

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -81,7 +81,7 @@ class RuleUtil {
   toCksumAddr(addr) {
     try {
       return ainUtil.toChecksumAddress(addr);
-    } catch (e) {
+    } catch (err) {
       return '';
     }
   }

--- a/db/state-manager.js
+++ b/db/state-manager.js
@@ -11,7 +11,6 @@ const {
   StateVersions,
 } = require('../common/constants');
 
-// TODO(seo): Consider introducing cloneToTempVersion().
 class StateManager {
   constructor() {
     this.rootMap = new Map();
@@ -238,6 +237,24 @@ class StateManager {
       index++;
     } while (this.hasVersion(version));
     return version;
+  }
+
+  cloneToTempVersion(stateVersion, versionPrefix) {
+    const LOG_HEADER = 'cloneToTempVersion';
+    const tempVersion = this.createUniqueVersionName(versionPrefix);
+    const tempRoot = this.cloneVersion(stateVersion, tempVersion);
+    if (!tempRoot) {
+      logger.error(
+          `[${LOG_HEADER}] Failed to clone state version: ${stateVersion}`);
+      return {
+        tempVersion: null,
+        tempRoot: null,
+      };
+    }
+    return {
+      tempVersion,
+      tempRoot,
+    };
   }
 }
 

--- a/db/state-manager.js
+++ b/db/state-manager.js
@@ -11,6 +11,7 @@ const {
   StateVersions,
 } = require('../common/constants');
 
+// TODO(seo): Consider introducing cloneToTempVersion().
 class StateManager {
   constructor() {
     this.rootMap = new Map();
@@ -51,7 +52,7 @@ class StateManager {
    * Returns the final state root.
    */
   getFinalRoot() {
-    return this.getRoot(this.finalVersion);
+    return this.getRoot(this.getFinalVersion());
   }
 
   /**
@@ -182,7 +183,7 @@ class StateManager {
       logger.error(`[${LOG_HEADER}] Non-existing version: ${version}`);
       return false;
     }
-    if (version === this.finalVersion) {
+    if (version === this.getFinalVersion()) {
       logger.error(`[${LOG_HEADER}] Not allowed to delete final version: ${version}`);
       return false;
     }
@@ -212,7 +213,7 @@ class StateManager {
     logger.debug(`[${LOG_HEADER}] Finalizing version '${version}' among ` +
         `${this.numVersions()} versions: ${JSON.stringify(this.getVersionList())}` +
         ` with latest final version: '${this.getFinalVersion()}'`);
-    if (version === this.finalVersion) {
+    if (version === this.getFinalVersion()) {
       logger.error(`[${LOG_HEADER}] Already final version: ${version}`);
       return false;
     }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -1367,6 +1367,8 @@ describe('Blockchain Node', () => {
 
     describe('/batch', () => {
       it('batch with successful transactions', async () => {
+        const address = parseOrLog(syncRequest(
+            'GET', server1 + '/get_address').body.toString('utf-8')).result;
         // Check the original value.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=test/test_value/some200/path')
@@ -1377,7 +1379,8 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8')).result;
         assert.deepEqual(resultBefore2, null);
 
-        const nonce = parseOrLog(syncRequest('GET', server1 + '/get_nonce').body.toString('utf-8')).result;
+        const nonce = parseOrLog(syncRequest(
+            'GET', server1 + `/get_nonce?address=${address}`).body.toString('utf-8')).result;
         const request = {
           tx_list: [
             {
@@ -1620,6 +1623,8 @@ describe('Blockchain Node', () => {
       });
 
       it('batch with a failing transaction', async () => {
+        const address = parseOrLog(syncRequest(
+            'GET', server1 + '/get_address').body.toString('utf-8')).result;
         // Check the original values.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=test/test_value/some202/path')
@@ -1629,7 +1634,8 @@ describe('Blockchain Node', () => {
             'GET', server1 + '/get_value?ref=test/test_value/some203/path')
             .body.toString('utf-8')).result;
         assert.deepEqual(resultBefore2, null);
-        const nonce = parseOrLog(syncRequest('GET', server1 + '/get_nonce').body.toString('utf-8')).result;
+        const nonce = parseOrLog(syncRequest(
+            'GET', server1 + `/get_nonce?address=${address}`).body.toString('utf-8')).result;
 
         const request = {
           tx_list: [

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -771,12 +771,12 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, "some value with nonce unordered");
       })
 
-      it('set_value with nonce strictly ordered', async () => {
+      it('set_value with numbered nonce', async () => {
         const nonce = parseOrLog(
             syncRequest('GET', server1 + '/get_nonce').body.toString('utf-8')).result;
         const request = {
           ref: 'test/test_value/some/path',
-          value: "some value with nonce strictly ordered",
+          value: "some value with numbered nonce",
           nonce,
         };
         const body = parseOrLog(syncRequest(
@@ -792,7 +792,7 @@ describe('Blockchain Node', () => {
         const resultAfter = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=test/test_value/some/path')
             .body.toString('utf-8')).result;
-        assert.deepEqual(resultAfter, "some value with nonce strictly ordered");
+        assert.deepEqual(resultAfter, "some value with numbered nonce");
       })
 
       it('set_value with failing operation', () => {
@@ -1935,7 +1935,7 @@ describe('Blockchain Node', () => {
         })
       })
 
-      it('accepts a transaction with nonce strictly ordered', () => {
+      it('accepts a transaction with numbered nonce', () => {
         const account = ainUtil.createAccount();
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request('ain_getNonce', {
@@ -1952,7 +1952,7 @@ describe('Blockchain Node', () => {
               ref: `test/test_value/some/path`
             },
             timestamp: Date.now(),
-            nonce,  // strictly ordered nonce
+            nonce,  // numbered nonce
           };
           const signature =
               ainUtil.ecSignTransaction(txBody, Buffer.from(account.private_key, 'hex'));

--- a/node/index.js
+++ b/node/index.js
@@ -82,9 +82,7 @@ class BlockchainNode {
     this.executeChainOnDb(startingDb);
     this.nonce = this.getNonceFromChain();
     this.cloneAndFinalizeVersion(StateVersions.START, this.bc.lastBlockNumber());
-    this.db.executeTransactionList(
-        this.tp.getValidTransactions(null, this.stateManager.finalVersion),
-        this.bc.lastBlockNumber() + 1);
+    this.db.executeTransactionList(this.tp.getValidTransactions(), this.bc.lastBlockNumber() + 1);
     this.state = BlockchainNodeStates.SYNCING;
     return lastBlockWithoutProposal;
   }

--- a/node/index.js
+++ b/node/index.js
@@ -205,10 +205,10 @@ class BlockchainNode {
     return nonce;
   }
 
-  getNonceForAddr(address, pending) {
+  getNonceForAddr(address, fromPending) {
     if (!isValAddr(address)) return -1;
     const cksumAddr = toCksumAddr(address);
-    if (pending) {
+    if (fromPending) {
       const { nonce } = this.db.getAccountNonceAndTimestamp(cksumAddr);
       return nonce;
     }

--- a/node/index.js
+++ b/node/index.js
@@ -3,6 +3,7 @@ const ainUtil = require('@ainblockchain/ain-util');
 const _ = require('lodash');
 const logger = require('../logger')('NODE');
 const {
+  FeatureFlags,
   PORT,
   ACCOUNT_INDEX,
   TX_NONCE_ERROR_CODE,
@@ -14,7 +15,6 @@ const {
   GenesisAccounts,
   GenesisSharding,
   StateVersions,
-  FeatureFlags,
   LIGHTWEIGHT
 } = require('../common/constants');
 const ChainUtil = require('../common/chain-util');
@@ -82,7 +82,9 @@ class BlockchainNode {
     this.executeChainOnDb(startingDb);
     this.nonce = this.getNonceFromChain();
     this.cloneAndFinalizeVersion(StateVersions.START, this.bc.lastBlockNumber());
-    this.db.executeTransactionList(this.tp.getValidTransactions(), this.bc.lastBlockNumber() + 1);
+    this.db.executeTransactionList(
+        this.tp.getValidTransactions(null, this.stateManager.finalVersion),
+        this.bc.lastBlockNumber() + 1);
     this.state = BlockchainNodeStates.SYNCING;
     return lastBlockWithoutProposal;
   }

--- a/node/index.js
+++ b/node/index.js
@@ -176,24 +176,6 @@ class BlockchainNode {
         versionRoot, PredefinedDbPaths.VALUES_ROOT, refPath, isGlobal, this.db.shardingPath);
   }
 
-  getFunctionWithStateVersion(refPath, isGlobal, version) {
-    const versionRoot = this.stateManager.getRoot(version);
-    return DB.readFromStateRoot(
-        versionRoot, PredefinedDbPaths.FUNCTIONS_ROOT, refPath, isGlobal, this.db.shardingPath);
-  }
-
-  getRuleWithStateVersion(refPath, isGlobal, version) {
-    const versionRoot = this.stateManager.getRoot(version);
-    return DB.readFromStateRoot(
-        versionRoot, PredefinedDbPaths.RULES_ROOT, refPath, isGlobal, this.db.shardingPath);
-  }
-
-  getOwnerWithStateVersion(refPath, isGlobal, version) {
-    const versionRoot = this.stateManager.getRoot(version);
-    return DB.readFromStateRoot(
-        versionRoot, PredefinedDbPaths.OWNERS_ROOT, refPath, isGlobal, this.db.shardingPath);
-  }
-
   getNonceFromChain() {
     const LOG_HEADER = 'getNonceFromChain';
 

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -177,8 +177,8 @@ class P2pClient {
             node.init(false);
           }
         }
-      } catch (error) {
-        logger.error(error.stack);
+      } catch (err) {
+        logger.error(`Error: ${err} ${err.stack}`);
       }
     });
 

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -179,7 +179,7 @@ class P2pServer {
       const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
       return Object.assign({}, diskUsage, { used });
     } catch (err) {
-      logger.error(err);
+      logger.error(`Error: ${err} ${err.stack}`);
       return {};
     }
   }
@@ -528,8 +528,8 @@ class P2pServer {
             logger.error('Ignore the message.');
             break;
         }
-      } catch (error) {
-        logger.error(error.stack);
+      } catch (err) {
+        logger.error(`Error: ${err} ${err.stack}`);
       }
     });
 

--- a/tracker-server/index.js
+++ b/tracker-server/index.js
@@ -263,7 +263,7 @@ function getDiskUsage() {
     const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
     return Object.assign({}, diskUsage, { used });
   } catch (err) {
-    logger.error(err);
+    logger.error(`Error: ${err} ${err.stack}`);
     return {};
   }
 }

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -153,18 +153,16 @@ class TransactionPool {
     }
   }
 
-  getValidTransactions(excludeBlockList, stateVersion) {
-    if (!stateVersion) {
-      stateVersion = this.node.db.stateVersion;
+  getValidTransactions(excludeBlockList, baseVersion) {
+    const LOG_HEADER = 'getValidTransactions';
+    if (!baseVersion) {
+      baseVersion = this.node.db.stateVersion;
     }
-    let tempVersion = null;
-    let tempRoot = null;
-    tempVersion = this.node.stateManager.createUniqueVersionName(
-        `${StateVersions.TX_POOL}:${this.node.bc.lastBlockNumber()}`);
-    tempRoot = this.node.stateManager.cloneVersion(stateVersion, tempVersion);
+    const { tempVersion, tempRoot } = this.node.stateManager.cloneToTempVersion(
+        baseVersion, `${StateVersions.TX_POOL}:${this.node.bc.lastBlockNumber()}`);
     if (!tempRoot) {
       logger.error(
-          `[${LOG_HEADER}] Failed to clone state version: ${stateVersion}`);
+          `[${LOG_HEADER}] Failed to clone state version: ${baseVersion}`);
       return null;
     }
 

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -7,14 +7,13 @@ const {
   TRANSACTION_TRACKER_TIMEOUT_MS,
   LIGHTWEIGHT,
   BANDWIDTH_BUDGET_PER_BLOCK,
-	SERVICE_BANDWIDTH_BUDGET_PER_BLOCK,
+  SERVICE_BANDWIDTH_BUDGET_PER_BLOCK,
   GenesisSharding,
   GenesisAccounts,
   ShardingProperties,
   TransactionStatus,
   WriteDbOperations,
   AccountProperties,
-  PredefinedDbPaths,
   StateVersions,
 } = require('../common/constants');
 const ChainUtil = require('../common/chain-util');
@@ -197,7 +196,7 @@ class TransactionPool {
   }
 
   getAppBandwidthAllocated(stateRoot, appStakesTotal, appName) {
-    const appStake = DB.getAppStake(stateRoot, appName);
+    const appStake = DB.getAppStakeFromStateRoot(stateRoot, appName);
     return appStakesTotal > 0 ? APP_BANDWIDTH_BUDGET_PER_BLOCK * appStake / appStakesTotal : 0;
   }
 
@@ -209,7 +208,7 @@ class TransactionPool {
     let serviceBandwidthSum = 0;
     const appBandwidthSum = {};
     // Sum of all apps' staked AIN
-    const appStakesTotal = DB.getAppStakesTotal(stateRoot);
+    const appStakesTotal = DB.getAppStakesTotalFromStateRoot(stateRoot);
     // NOTE(liayoo): Keeps track of whether an address's nonced tx has been discarded. If true, any
     // nonced txs from the same address that come after the discarded tx need to be dropped as well.
     const addrToDiscardedNoncedTx = {};

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -515,8 +515,8 @@ class TransactionPool {
     }
     try {
       value = action.valueFunction(success);
-    } catch (e) {
-      logger.info(`  =>> valueFunction() failed: ${e}`);
+    } catch (err) {
+      logger.info(`  =>> valueFunction() failed: ${err} ${err.stack}`);
       return;
     }
     const actionTxBody = {

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3657,14 +3657,16 @@ describe("State version handling", () => {
   describe("getRefForWriting()", () => {
     it("the nodes of single access path are not cloned", () => {
       // First referencing to make the number of access paths = 1.
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
       const child2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
       // Second referencing.
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path are not cloned.
@@ -3684,7 +3686,8 @@ describe("State version handling", () => {
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path are cloned.
@@ -3703,7 +3706,8 @@ describe("State version handling", () => {
       // Make child21's number of parents = 2.
       const clonedChild2 = child2.clone('new version');
 
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // Only the nodes of multiple paths are cloned.
@@ -3722,7 +3726,8 @@ describe("State version handling", () => {
       // Make child212's number of parents = 2.
       const clonedChild21 = child21.clone('new version');
 
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // Only the nodes of multiple paths are cloned.
@@ -3741,7 +3746,8 @@ describe("State version handling", () => {
       const beforeOtherChild21 = beforeOtherChild2.getChild('child_21');
       const beforeOtherChild212 = beforeOtherChild21.getChild('child_212');
 
-      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(DB.getRefForWriting(
+          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path from other roots are not affected.

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3377,10 +3377,10 @@ describe("Proof hash", () => {
 
   describe("Check proof for setValue(), setOwner(), setRule(), and setFunction()", () => {
     it("checks proof hash of under $root_path/test", () => {
-      const valuesNode = DB.getRefForReading(node.db.stateRoot, ['values', 'test']);
-      const ownersNode = DB.getRefForReading(node.db.stateRoot, ['owners', 'test']);
-      const rulesNode = DB.getRefForReading(node.db.stateRoot, ['rules', 'test']);
-      const functionNode = DB.getRefForReading(node.db.stateRoot, ['functions', 'test']);
+      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values', 'test']);
+      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners', 'test']);
+      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules', 'test']);
+      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions', 'test']);
       expect(valuesNode.getProofHash()).to.equal(valuesNode.buildProofHash());
       expect(ownersNode.getProofHash()).to.equal(ownersNode.buildProofHash());
       expect(rulesNode.getProofHash()).to.equal(rulesNode.buildProofHash());
@@ -3429,10 +3429,10 @@ describe("Proof hash", () => {
       node.db.setOwner("test/empty_owners/.owner/owners/*/write_function", false);
       node.db.setRule("test/test_rules", nestedRules);
       node.db.setFunction("test/test_functions", dbFuncs);
-      const valuesNode = DB.getRefForReading(node.db.stateRoot, ['values', 'test']);
-      const ownersNode = DB.getRefForReading(node.db.stateRoot, ['owners', 'test']);
-      const rulesNode = DB.getRefForReading(node.db.stateRoot, ['rules', 'test']);
-      const functionNode = DB.getRefForReading(node.db.stateRoot, ['functions', 'test']);
+      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values', 'test']);
+      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners', 'test']);
+      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules', 'test']);
+      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions', 'test']);
       expect(valuesNode.getProofHash()).to.equal(valuesNode.buildProofHash());
       expect(ownersNode.getProofHash()).to.equal(ownersNode.buildProofHash());
       expect(rulesNode.getProofHash()).to.equal(rulesNode.buildProofHash());
@@ -3448,10 +3448,10 @@ describe("Proof hash", () => {
 
     it("tests proof with owners, rules, values and functions", () => {
       const rootNode = node.db.stateRoot;
-      const ownersNode = DB.getRefForReading(node.db.stateRoot, ['owners']);
-      const rulesNode = DB.getRefForReading(node.db.stateRoot, ['rules']);
-      const valuesNode = DB.getRefForReading(node.db.stateRoot, ['values']);
-      const functionNode = DB.getRefForReading(node.db.stateRoot, ['functions']);
+      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners']);
+      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules']);
+      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values']);
+      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions']);
       const rootProof = { [ProofProperties.PROOF_HASH]: rootNode.getProofHash() };
       const secondLevelProof = JSON.parse(JSON.stringify(rootProof));
       rootNode.getChildLabels().forEach(label => {
@@ -3633,7 +3633,7 @@ describe("State version handling", () => {
     rimraf.sync(CHAINS_DIR);
   });
 
-  describe("getRefForReading()", () => {
+  describe("getRefForReadingFromStateRoot()", () => {
     it("the nodes on the path are not affected", () => {
       expect(node.db.deleteBackupStateVersion()).to.equal(true);
       const child2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
@@ -3641,7 +3641,7 @@ describe("State version handling", () => {
       const child212 = child21.getChild('child_212');
 
       expect(
-          DB.getRefForReading(node.db.stateRoot,
+          DB.getRefForReadingFromStateRoot(node.db.stateRoot,
           ['values', 'test', 'child_2', 'child_21', 'child_212'])).to.not.equal(null);
 
       // The nodes on the path are not affected.
@@ -3654,10 +3654,10 @@ describe("State version handling", () => {
     });
   });
 
-  describe("getRefForWriting()", () => {
+  describe("getRefForWritingToStateRoot()", () => {
     it("the nodes of single access path are not cloned", () => {
       // First referencing to make the number of access paths = 1.
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
       const child2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
@@ -3665,7 +3665,7 @@ describe("State version handling", () => {
       const child212 = child21.getChild('child_212');
 
       // Second referencing.
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
@@ -3686,7 +3686,7 @@ describe("State version handling", () => {
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
@@ -3706,7 +3706,7 @@ describe("State version handling", () => {
       // Make child21's number of parents = 2.
       const clonedChild2 = child2.clone('new version');
 
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
@@ -3726,7 +3726,7 @@ describe("State version handling", () => {
       // Make child212's number of parents = 2.
       const clonedChild21 = child21.clone('new version');
 
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
@@ -3746,7 +3746,7 @@ describe("State version handling", () => {
       const beforeOtherChild21 = beforeOtherChild2.getChild('child_21');
       const beforeOtherChild212 = beforeOtherChild21.getChild('child_212');
 
-      expect(DB.getRefForWriting(
+      expect(DB.getRefForWritingToStateRoot(
           node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -3377,10 +3377,10 @@ describe("Proof hash", () => {
 
   describe("Check proof for setValue(), setOwner(), setRule(), and setFunction()", () => {
     it("checks proof hash of under $root_path/test", () => {
-      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values', 'test']);
-      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners', 'test']);
-      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules', 'test']);
-      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions', 'test']);
+      const valuesNode = node.db.getRefForReading(['values', 'test']);
+      const ownersNode = node.db.getRefForReading(['owners', 'test']);
+      const rulesNode = node.db.getRefForReading(['rules', 'test']);
+      const functionNode = node.db.getRefForReading(['functions', 'test']);
       expect(valuesNode.getProofHash()).to.equal(valuesNode.buildProofHash());
       expect(ownersNode.getProofHash()).to.equal(ownersNode.buildProofHash());
       expect(rulesNode.getProofHash()).to.equal(rulesNode.buildProofHash());
@@ -3429,10 +3429,10 @@ describe("Proof hash", () => {
       node.db.setOwner("test/empty_owners/.owner/owners/*/write_function", false);
       node.db.setRule("test/test_rules", nestedRules);
       node.db.setFunction("test/test_functions", dbFuncs);
-      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values', 'test']);
-      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners', 'test']);
-      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules', 'test']);
-      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions', 'test']);
+      const valuesNode = node.db.getRefForReading(['values', 'test']);
+      const ownersNode = node.db.getRefForReading(['owners', 'test']);
+      const rulesNode = node.db.getRefForReading(['rules', 'test']);
+      const functionNode = node.db.getRefForReading(['functions', 'test']);
       expect(valuesNode.getProofHash()).to.equal(valuesNode.buildProofHash());
       expect(ownersNode.getProofHash()).to.equal(ownersNode.buildProofHash());
       expect(rulesNode.getProofHash()).to.equal(rulesNode.buildProofHash());
@@ -3448,10 +3448,10 @@ describe("Proof hash", () => {
 
     it("tests proof with owners, rules, values and functions", () => {
       const rootNode = node.db.stateRoot;
-      const ownersNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['owners']);
-      const rulesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['rules']);
-      const valuesNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['values']);
-      const functionNode = DB.getRefForReadingFromStateRoot(node.db.stateRoot, ['functions']);
+      const ownersNode = node.db.getRefForReading(['owners']);
+      const rulesNode = node.db.getRefForReading(['rules']);
+      const valuesNode = node.db.getRefForReading(['values']);
+      const functionNode = node.db.getRefForReading(['functions']);
       const rootProof = { [ProofProperties.PROOF_HASH]: rootNode.getProofHash() };
       const secondLevelProof = JSON.parse(JSON.stringify(rootProof));
       rootNode.getChildLabels().forEach(label => {
@@ -3633,16 +3633,15 @@ describe("State version handling", () => {
     rimraf.sync(CHAINS_DIR);
   });
 
-  describe("getRefForReadingFromStateRoot()", () => {
+  describe("getRefForReading()", () => {
     it("the nodes on the path are not affected", () => {
       expect(node.db.deleteBackupStateVersion()).to.equal(true);
       const child2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
-      expect(
-          DB.getRefForReadingFromStateRoot(node.db.stateRoot,
-          ['values', 'test', 'child_2', 'child_21', 'child_212'])).to.not.equal(null);
+      expect(node.db.getRefForReading(['values', 'test', 'child_2', 'child_21', 'child_212']))
+          .to.not.equal(null);
 
       // The nodes on the path are not affected.
       const newChild2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
@@ -3654,19 +3653,17 @@ describe("State version handling", () => {
     });
   });
 
-  describe("getRefForWritingToStateRoot()", () => {
+  describe("getRefForWriting()", () => {
     it("the nodes of single access path are not cloned", () => {
       // First referencing to make the number of access paths = 1.
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
       const child2 = node.db.stateRoot.getChild('values').getChild('test').getChild('child_2');
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
       // Second referencing.
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path are not cloned.
@@ -3686,8 +3683,7 @@ describe("State version handling", () => {
       const child21 = child2.getChild('child_21');
       const child212 = child21.getChild('child_212');
 
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path are cloned.
@@ -3706,8 +3702,7 @@ describe("State version handling", () => {
       // Make child21's number of parents = 2.
       const clonedChild2 = child2.clone('new version');
 
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // Only the nodes of multiple paths are cloned.
@@ -3726,8 +3721,7 @@ describe("State version handling", () => {
       // Make child212's number of parents = 2.
       const clonedChild21 = child21.clone('new version');
 
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // Only the nodes of multiple paths are cloned.
@@ -3746,8 +3740,7 @@ describe("State version handling", () => {
       const beforeOtherChild21 = beforeOtherChild2.getChild('child_21');
       const beforeOtherChild212 = beforeOtherChild21.getChild('child_212');
 
-      expect(DB.getRefForWritingToStateRoot(
-          node.db.stateRoot, ['values', 'test', 'child_2', 'child_21', 'child_212']))
+      expect(node.db.getRefForWriting(['values', 'test', 'child_2', 'child_21', 'child_212']))
           .to.not.equal(null);
 
       // The nodes on the path from other roots are not affected.

--- a/unittest/state-manager.test.js
+++ b/unittest/state-manager.test.js
@@ -14,7 +14,7 @@ describe("state-manager", () => {
 
   describe("Initialize", () => {
     it("finalVersion", () => {
-      expect(manager.finalVersion).to.equal(null);
+      expect(manager.getFinalVersion()).to.equal(null);
     });
 
     it("rootMap", () => {

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -461,7 +461,7 @@ describe('TransactionPool', async () => {
       const APP_BANDWIDTH_BUDGET_PER_BLOCK = BANDWIDTH_BUDGET_PER_BLOCK - SERVICE_BANDWIDTH_BUDGET_PER_BLOCK;
       it('empty array', () => {
         assert.deepEqual(
-          node.tp.performBandwidthChecks([]),
+          node.tp.performBandwidthChecks([], node.db.stateRoot),
           []
         );
       });
@@ -472,7 +472,7 @@ describe('TransactionPool', async () => {
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ]),
+          ], node.db.stateRoot),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
@@ -483,7 +483,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK - 1}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}}
-          ]),
+          ], node.db.stateRoot),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK - 1}}},
@@ -497,14 +497,14 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: BANDWIDTH_BUDGET_PER_BLOCK + 1}}}
-          ]),
+          ], node.db.stateRoot),
           []
         );
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ]),
+          ], node.db.stateRoot),
           [{tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}}]
         );
       });
@@ -513,7 +513,7 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ]),
+          ], node.db.stateRoot),
           [{tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}]
         );
       });
@@ -522,7 +522,7 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK + 1}}}
-          ]),
+          ], node.db.stateRoot),
           []
         );
       });
@@ -535,7 +535,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
-          ]),
+          ], node.db.stateRoot),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}},
@@ -547,7 +547,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: (APP_BANDWIDTH_BUDGET_PER_BLOCK / 2) + 1}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
-          ]),
+          ], node.db.stateRoot),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
@@ -561,7 +561,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 0}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 1}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 2}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}}
-          ]),
+          ], node.db.stateRoot),
           [{tx_body: {timestamp: 1, gas_price: 1, nonce: 0}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}}]
         );
       });

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -39,7 +39,7 @@ describe('TransactionPool', async () => {
 
     beforeEach(async () => {
       for (let i = 0; i < 10; i++) {
-        t = getTransaction(node, {
+        const tx = getTransaction(node, {
           operation: {
             type: 'SET_VALUE',
             ref: 'REF',
@@ -48,9 +48,11 @@ describe('TransactionPool', async () => {
           nonce: node.nonce++,
           gas_price: 1
         });
-        node.tp.addTransaction(t);
+        node.tp.addTransaction(tx);
         await ChainUtil.sleep(1);
       }
+      // NOTE: Shuffle transactions and see if the transaction-pool can re-sort them according to
+      // their proper ordering
       node.tp.transactions[node.account.address] =
           shuffleSeed.shuffle(node.tp.transactions[node.account.address]);
 
@@ -63,7 +65,7 @@ describe('TransactionPool', async () => {
       const nodes = [node2, node3, node4];
       for (let j = 0; j < nodes.length; j++) {
         for (let i = 0; i < 11; i++) {
-          t = getTransaction(nodes[j], {
+          const tx = getTransaction(nodes[j], {
             operation: {
               type: 'SET_VALUE',
               ref: 'REF',
@@ -72,45 +74,46 @@ describe('TransactionPool', async () => {
             nonce: nodes[j].nonce++,
             gas_price: 1
           });
-          node.tp.addTransaction(t);
+          node.tp.addTransaction(tx);
           await ChainUtil.sleep(1);
         }
+        // NOTE: Shuffle transactions and see if the transaction-pool can re-sort them according to
+        // their proper ordering
         node.tp.transactions[nodes[j].account.address] =
             shuffleSeed.shuffle(node.tp.transactions[nodes[j].account.address]);
       }
-
-      // Shuffle transactions and see if the transaction-pool can re-sort them according to them according to their proper ordering
     });
 
     describe('getValidTransactions()', () => {
       it('transactions are correctly ordered by nonces', () => {
-        const sortedNonces1 = node.tp.getValidTransactions().filter((transaction) => {
-          if (ChainUtil.areSameAddrs(transaction.address, node.account.address)) {
-            return transaction;
+        const validTransactions = node.tp.getValidTransactions();
+        const sortedNonces1 = validTransactions.filter((tx) => {
+          if (ChainUtil.areSameAddrs(tx.address, node.account.address)) {
+            return tx;
           }
-        }).map((transaction) => {
-          return transaction.tx_body.nonce;
+        }).map((tx) => {
+          return tx.tx_body.nonce;
         });
-        const sortedNonces2 = node.tp.getValidTransactions().filter((transaction) => {
-          if (ChainUtil.areSameAddrs(transaction.address, node2.account.address)) {
-            return transaction;
+        const sortedNonces2 = validTransactions.filter((tx) => {
+          if (ChainUtil.areSameAddrs(tx.address, node2.account.address)) {
+            return tx;
           }
-        }).map((transaction) => {
-          return transaction.tx_body.nonce;
+        }).map((tx) => {
+          return tx.tx_body.nonce;
         });
-        const sortedNonces3 = node.tp.getValidTransactions().filter((transaction) => {
-          if (ChainUtil.areSameAddrs(transaction.address, node3.account.address)) {
-            return transaction;
+        const sortedNonces3 = validTransactions.filter((tx) => {
+          if (ChainUtil.areSameAddrs(tx.address, node3.account.address)) {
+            return tx;
           }
-        }).map((transaction) => {
-          return transaction.tx_body.nonce;
+        }).map((tx) => {
+          return tx.tx_body.nonce;
         });
-        const sortedNonces4 = node.tp.getValidTransactions().filter((transaction) => {
-          if (ChainUtil.areSameAddrs(transaction.address, node4.account.address)) {
-            return transaction;
+        const sortedNonces4 = validTransactions.filter((tx) => {
+          if (ChainUtil.areSameAddrs(tx.address, node4.account.address)) {
+            return tx;
           }
-        }).map((transaction) => {
-          return transaction.tx_body.nonce;
+        }).map((tx) => {
+          return tx.tx_body.nonce;
         });
         assert.deepEqual(sortedNonces1, [...Array(11).keys()]);
         assert.deepEqual(sortedNonces2, [...Array(11).keys()]);

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -461,7 +461,7 @@ describe('TransactionPool', async () => {
       const APP_BANDWIDTH_BUDGET_PER_BLOCK = BANDWIDTH_BUDGET_PER_BLOCK - SERVICE_BANDWIDTH_BUDGET_PER_BLOCK;
       it('empty array', () => {
         assert.deepEqual(
-          node.tp.performBandwidthChecks([], node.db.stateRoot),
+          node.tp.performBandwidthChecks([], node.db),
           []
         );
       });
@@ -472,7 +472,7 @@ describe('TransactionPool', async () => {
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
@@ -483,7 +483,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK - 1}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK}}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK - 1}}},
@@ -497,14 +497,14 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: BANDWIDTH_BUDGET_PER_BLOCK + 1}}}
-          ], node.db.stateRoot),
+          ], node.db),
           []
         );
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 2, gas_price: 1}, extra: {gas: {service: BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [{tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: 1}}}]
         );
       });
@@ -513,7 +513,7 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [{tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}}]
         );
       });
@@ -522,7 +522,7 @@ describe('TransactionPool', async () => {
         assert.deepEqual(
           node.tp.performBandwidthChecks([
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK + 1}}}
-          ], node.db.stateRoot),
+          ], node.db),
           []
         );
       });
@@ -535,7 +535,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}},
@@ -547,7 +547,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app1: (APP_BANDWIDTH_BUDGET_PER_BLOCK / 2) + 1}}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1}, extra: {gas: {app: {app2: APP_BANDWIDTH_BUDGET_PER_BLOCK / 2}}}}
@@ -561,7 +561,7 @@ describe('TransactionPool', async () => {
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 0}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}},
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 1}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: SERVICE_BANDWIDTH_BUDGET_PER_BLOCK}}},
             {tx_body: {timestamp: 1, gas_price: 1, nonce: 2}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}}
-          ], node.db.stateRoot),
+          ], node.db),
           [{tx_body: {timestamp: 1, gas_price: 1, nonce: 0}, address: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', extra: {gas: {service: 1}}}]
         );
       });


### PR DESCRIPTION
Change summary:
- Use db's methods to get/set account nonce and timestamp
- Move getValueWithStateVersion() from node to DB (getValueFromStateRoot())
- Move getAppStakesTotal() from TransactionPool to DB
- Add cloneToTempVersion() and simplify temp db creation logic
- Log stack trace for errors
- Remove some unused methods
- Log stack trace in exceptional cases.

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/388