### PR TITLE
Allow function IDs (auth.fid) in owner config

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -237,6 +237,7 @@ const AccountProperties = {
 const OwnerProperties = {
   ANYONE: '*',
   BRANCH_OWNER: 'branch_owner',
+  FID_PREFIX: 'fid:',
   OWNER: '.owner',
   OWNERS: 'owners',
   WRITE_FUNCTION: 'write_function',
@@ -312,6 +313,7 @@ const NativeFunctionIds = {
   PAY: '_pay',
   RELEASE: '_release',
   SAVE_LAST_TX: '_saveLastTx',
+  SET_OWNER_CONFIG: '_setOwnerConfig',
   STAKE: '_stake',
   TRANSFER: '_transfer',
   UNSTAKE: '_unstake',

--- a/db/functions.js
+++ b/db/functions.js
@@ -40,45 +40,45 @@ const EventListenerWhitelist = {
  * Built-in functions with function paths.
  */
 // NOTE(platfowner): ownerOnly means that the function can be set only by the blockchain owner.
-// NOTE(platfowner): execGasAmount means the amount of gas required to execute the function, which
-//                   reflects the number of database write operations and external RPC calls.
+// NOTE(platfowner): extraGasAmount means the extra gas amount required to execute the function,
+// which often reflects the external RPC calls needed.
 class Functions {
   constructor(db, tp) {
     this.db = db;
     this.tp = tp;
     this.nativeFunctionMap = {
       [NativeFunctionIds.CLAIM]: {
-        func: this._claim.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._claim.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.CLOSE_CHECKIN]: {
-        func: this._closeCheckin.bind(this), ownerOnly: true, execGasAmount: 10 },
+        func: this._closeCheckin.bind(this), ownerOnly: true, extraGasAmount: 10 },
       [NativeFunctionIds.COLLECT_FEE]: {
-        func: this._collectFee.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._collectFee.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.CREATE_APP]: {
-        func: this._createApp.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._createApp.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.DISTRIBUTE_FEE]: {
-        func: this._distributeFee.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._distributeFee.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.ERASE_VALUE]: {
-        func: this._eraseValue.bind(this), ownerOnly: false, execGasAmount: 0 },
+        func: this._eraseValue.bind(this), ownerOnly: false, extraGasAmount: 0 },
       [NativeFunctionIds.HOLD]: {
-        func: this._hold.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._hold.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.OPEN_CHECKIN]: {
-        func: this._openCheckin.bind(this), ownerOnly: true, execGasAmount: 60 },
+        func: this._openCheckin.bind(this), ownerOnly: true, extraGasAmount: 60 },
       [NativeFunctionIds.PAY]: {
-        func: this._pay.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._pay.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.RELEASE]: {
-        func: this._release.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._release.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.SAVE_LAST_TX]: {
-        func: this._saveLastTx.bind(this), ownerOnly: false, execGasAmount: 0 },
+        func: this._saveLastTx.bind(this), ownerOnly: false, extraGasAmount: 0 },
       [NativeFunctionIds.SET_OWNER_CONFIG]: {
-        func: this._setOwnerConfig.bind(this), ownerOnly: false, execGasAmount: 0 },
+        func: this._setOwnerConfig.bind(this), ownerOnly: false, extraGasAmount: 0 },
       [NativeFunctionIds.STAKE]: {
-        func: this._stake.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._stake.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.UNSTAKE]: {
-        func: this._unstake.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._unstake.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.TRANSFER]: {
-        func: this._transfer.bind(this), ownerOnly: true, execGasAmount: 0 },
+        func: this._transfer.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: {
-        func: this._updateLatestShardReport.bind(this), ownerOnly: false, execGasAmount: 0 },
+        func: this._updateLatestShardReport.bind(this), ownerOnly: false, extraGasAmount: 0 },
     };
     this.callStack = [];
   }
@@ -223,7 +223,7 @@ class Functions {
     const fidList = topCall ? Array.from(topCall.fidList) : [];
     fidList.push(fid);
     const callDepth = this.callStackSize();
-    const gasAmount = nativeFunction.execGasAmount;
+    const gasAmount = nativeFunction.extraGasAmount;
     this.callStack.push({
       fid,
       fidList,
@@ -434,7 +434,7 @@ class Functions {
   buildFuncResultToReturn(context, code, extraGasAmount = 0) {
     const result = {
       code,
-      gas_amount: this.nativeFunctionMap[context.fid].execGasAmount
+      gas_amount: this.nativeFunctionMap[context.fid].extraGasAmount
     };
     if (ChainUtil.isNumber(extraGasAmount) && extraGasAmount > 0) {
       result.gas_amount += extraGasAmount;

--- a/db/index.js
+++ b/db/index.js
@@ -1387,7 +1387,11 @@ class DB {
     let permissions = null;
     // Step 1: Check if the given address or fid exists in owners.
     if (auth) {
-      if (auth.addr) {
+      // Step 1.1: Try to use the auth fid first.
+      if (auth.fid) {
+        permissions = owners[OwnerProperties.FID_PREFIX + auth.fid];
+      // Step 1.2: Try to use the auth address then.
+      } else if (auth.addr) {
         permissions = owners[auth.addr];
       } else {
         return null;

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -715,8 +715,8 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
-        expect(body.code).to.equal(0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
@@ -736,8 +736,8 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -758,8 +758,8 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -782,8 +782,8 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_value', {json: request}).body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
 
         // Confirm that the value is set properly.
@@ -806,7 +806,6 @@ describe('Blockchain Node', () => {
         const request = {ref: 'some/wrong/path', value: "some other value"};
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: request})
           .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 103,
           "error_message": "No .write permission on: some/wrong/path",
@@ -817,6 +816,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -837,8 +837,8 @@ describe('Blockchain Node', () => {
         const request = {ref: "test/test_value/some/path2", value: 10};
         const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
           .body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -861,7 +861,6 @@ describe('Blockchain Node', () => {
         const request = {ref: "some/wrong/path2", value: 10};
         const body = parseOrLog(syncRequest('POST', server1 + '/inc_value', {json: request})
           .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 103,
           "error_message": "No .write permission on: some/wrong/path2",
@@ -872,6 +871,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -892,8 +892,8 @@ describe('Blockchain Node', () => {
         const request = {ref: "test/test_value/some/path3", value: 10};
         const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
           .body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -916,7 +916,6 @@ describe('Blockchain Node', () => {
         const request = {ref: "some/wrong/path3", value: 10};
         const body = parseOrLog(syncRequest('POST', server1 + '/dec_value', {json: request})
           .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 103,
           "error_message": "No .write permission on: some/wrong/path3",
@@ -927,6 +926,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -995,7 +995,6 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest(
             'POST', server1 + '/set_function', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 404,
           "error_message": "No write_function permission on: /some/wrong/path",
@@ -1006,6 +1005,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original function is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1033,8 +1033,8 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1064,7 +1064,6 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set_rule', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 503,
           "error_message": "No write_rule permission on: /some/wrong/path",
@@ -1075,6 +1074,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original rule is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1120,8 +1120,8 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1160,7 +1160,6 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set_owner', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "code": 603,
           "error_message": "No write_owner or branch_owner permission on: /some/wrong/path",
@@ -1171,6 +1170,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original owner is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1230,7 +1230,6 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "result_list": [
             {
@@ -1264,6 +1263,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(0);
 
         // Confirm that the original value is set properly.
         expect(_.get(body, 'result.tx_hash')).to.not.equal(null);
@@ -1330,7 +1330,6 @@ describe('Blockchain Node', () => {
         };
         const body = parseOrLog(syncRequest('POST', server1 + '/set', {json: request})
             .body.toString('utf-8'));
-        expect(body.code).to.equal(1);
         assert.deepEqual(_.get(body, 'result.result'), {
           "result_list": [
             {
@@ -1357,6 +1356,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0
         });
+        expect(body.code).to.equal(1);
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1494,7 +1494,6 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/batch', {json: request})
             .body.toString('utf-8'));
         expect(body).to.not.equal(null);
-        expect(body.code).to.equal(0);
         expect(ChainUtil.isArray(body.result)).to.equal(true);
         for (let i = 0; i < body.result.length; i++) {
           const result = body.result[i];
@@ -1610,6 +1609,7 @@ describe('Blockchain Node', () => {
             "tx_hash": "erased"
           }
         ]);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         await ChainUtil.sleep(3);
@@ -1759,7 +1759,6 @@ describe('Blockchain Node', () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/batch', {json: request})
             .body.toString('utf-8'));
         expect(body).to.not.equal(null);
-        expect(body.code).to.equal(0);
         expect(ChainUtil.isArray(body.result)).to.equal(true);
         for (let i = 0; i < body.result.length; i++) {
           const result = body.result[i];
@@ -1888,6 +1887,7 @@ describe('Blockchain Node', () => {
             "tx_hash": "erased"
           }
         ]);
+        expect(body.code).to.equal(0);
 
         // Confirm that the value is set properly.
         await ChainUtil.sleep(3);
@@ -2544,11 +2544,13 @@ describe('Blockchain Node', () => {
   })
 
   describe('Function triggering', () => {
-    const saveLastTxAllowedPath = '/test/test_function_triggering/allowed_path';
-    const saveLastTxNotAllowedPath = '/test/test_function_triggering/not_allowed_path';
+    const setFunctionWithOwnerOnlyPath = '/test/test_function_triggering/owner_only';
+    const saveLastTxAllowedPath = '/test/test_function_triggering/allowed_path_with_fid';
+    const saveLastTxNotAllowedPath = '/test/test_function_triggering/not_allowed_path_with_fid';
     const saveLastTxAllowedPathWithFids = '/test/test_function_triggering/allowed_path_with_fids';
     const saveLastTxNotAllowedPathWithFids = '/test/test_function_triggering/not_allowed_path_with_fids';
-    const setFunctionWithOwnerOnlyPath = '/test/test_function_triggering/owner_only';
+    const setOwnerConfigAllowedPath = '/test/test_function_triggering/set_owner_allowed_path_with_fid';
+    const setOwnerConfigNotAllowedPath = '/test/test_function_triggering/set_owner_not_allowed_path_with_fid';
     const triggerRestFunctionPath = '/test/test_function_triggering/rest_function_path';
 
     let transferFrom; // = server1
@@ -2608,7 +2610,7 @@ describe('Blockchain Node', () => {
           op_list: [
             {
               type: 'SET_FUNCTION',
-              ref: '/test/test_function_triggering/allowed_path/value',
+              ref: '/test/test_function_triggering/allowed_path_with_fid/value',
               value: {
                 ".function": {
                   "_saveLastTx": {
@@ -2620,21 +2622,21 @@ describe('Blockchain Node', () => {
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/allowed_path/value',
+              ref: '/test/test_function_triggering/allowed_path_with_fid/value',
               value: {
                 ".write": true,
               }
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/allowed_path/.last_tx/value',
+              ref: '/test/test_function_triggering/allowed_path_with_fid/.last_tx/value',
               value: {
                 ".write": "auth.fid === '_saveLastTx'",
               }
             },
             {
               type: 'SET_FUNCTION',
-              ref: '/test/test_function_triggering/not_allowed_path/value',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fid/value',
               value: {
                 ".function": {
                   "_saveLastTx": {
@@ -2646,14 +2648,14 @@ describe('Blockchain Node', () => {
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/not_allowed_path/value',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fid/value',
               value: {
                 ".write": true,
               }
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/not_allowed_path/.last_tx/value',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fid/.last_tx/value',
               value: {
                 ".write": "auth.fid === 'some function id'",
               }
@@ -2712,6 +2714,74 @@ describe('Blockchain Node', () => {
             },
             {
               type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/set_owner_allowed_path_with_fid/value',
+              value: {
+                ".function": {
+                  "_setOwnerConfig": {
+                    "function_type": "NATIVE",
+                    "function_id": "_setOwnerConfig"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_OWNER',
+              ref: '/test/test_function_triggering/set_owner_allowed_path_with_fid',
+              value: {
+                ".owner": {
+                  "owners": {
+                    "fid:_setOwnerConfig": {
+                      "branch_owner": true,  // allow branching
+                      "write_function": false,
+                      "write_owner": false,
+                      "write_rule": false,
+                    },
+                    "*": {
+                      "branch_owner": false,  // not allow branching
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": true,
+                    }
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/set_owner_not_allowed_path_with_fid/value',
+              value: {
+                ".function": {
+                  "_setOwnerConfig": {
+                    "function_type": "NATIVE",
+                    "function_id": "_setOwnerConfig"
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_OWNER',
+              ref: '/test/test_function_triggering/set_owner_not_allowed_path_with_fid',
+              value: {
+                ".owner": {
+                  "owners": {
+                    "fid:_setOwnerConfig": {
+                      "branch_owner": false,  // not allow branching
+                      "write_function": false,
+                      "write_owner": false,
+                      "write_rule": false,
+                    },
+                    "*": {
+                      "branch_owner": false,  // not allow branching
+                      "write_function": true,
+                      "write_owner": true,
+                      "write_rule": true,
+                    }
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_FUNCTION',
               ref: '/test/test_function_triggering/rest_function_path',
               value: {
                 ".function": {
@@ -2747,22 +2817,22 @@ describe('Blockchain Node', () => {
           op_list: [
             {
               type: 'SET_FUNCTION',
-              ref: '/test/test_function_triggering/allowed_path/value',
+              ref: '/test/test_function_triggering/allowed_path_with_fid/value',
               value: null
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/allowed_path/value',
+              ref: '/test/test_function_triggering/allowed_path_with_fid/value',
               value: null
             },
             {
               type: 'SET_FUNCTION',
-              ref: '/test/test_function_triggering/not_allowed_path/value',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fid/value',
               value: null
             },
             {
               type: 'SET_RULE',
-              ref: '/test/test_function_triggering/not_allowed_path/value',
+              ref: '/test/test_function_triggering/not_allowed_path_with_fid/value',
               value: null
             },
             {
@@ -2784,6 +2854,36 @@ describe('Blockchain Node', () => {
               type: 'SET_RULE',
               ref: '/test/test_function_triggering/not_allowed_path_with_fids/value',
               value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/set_owner_allowed_path_with_fid/value',
+              value: null
+            },
+            {
+              type: 'SET_OWNER',
+              ref: '/test/test_function_triggering/set_owner_allowed_path_with_fid',
+              value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/set_owner_not_allowed_path_with_fid/value',
+              value: null
+            },
+            {
+              type: 'SET_OWNER',
+              ref: '/test/test_function_triggering/set_owner_not_allowed_path_with_fid',
+              value: null
+            },
+            {
+              type: 'SET_FUNCTION',
+              ref: '/test/test_function_triggering/rest_function_path',
+              value: null,
+            },
+            {
+              type: 'SET_RULE',
+              ref: '/test/test_function_triggering/rest_function_path',
+              value: null,
             },
           ],
           nonce: -1,
@@ -2826,8 +2926,8 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 0);
           assert.deepEqual(_.get(body, 'result.result.code'), 0);
+          assert.deepEqual(body.code, 0);
           if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
             console.error(`Failed to check finalization of tx.`);
           }
@@ -2878,7 +2978,6 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 1);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {
@@ -2887,10 +2986,10 @@ describe('Blockchain Node', () => {
                 "gas_amount": 0,
                 "op_results": [
                   {
-                    "path": "/test/test_function_triggering/not_allowed_path/.last_tx/value",
+                    "path": "/test/test_function_triggering/not_allowed_path_with_fid/.last_tx/value",
                     "result": {
                       "code": 103,
-                      "error_message": "No .write permission on: /test/test_function_triggering/not_allowed_path/.last_tx/value",
+                      "error_message": "No .write permission on: /test/test_function_triggering/not_allowed_path_with_fid/.last_tx/value",
                       "gas_amount": 0,
                     }
                   }
@@ -2904,6 +3003,7 @@ describe('Blockchain Node', () => {
             },
             "gas_cost_total": 0,
           });
+          assert.deepEqual(body.code, 1);
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPath + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -2918,7 +3018,6 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 0);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {
@@ -2927,7 +3026,7 @@ describe('Blockchain Node', () => {
                 "gas_amount": 0,
                 "op_results": [
                   {
-                    "path": "/test/test_function_triggering/allowed_path/.last_tx/value",
+                    "path": "/test/test_function_triggering/allowed_path_with_fid/.last_tx/value",
                     "result": {
                       "code": 0,
                       "gas_amount": 1,
@@ -2943,6 +3042,7 @@ describe('Blockchain Node', () => {
             },
             "gas_cost_total": 0,
           });
+          assert.deepEqual(body.code, 0);
           if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
             console.error(`Failed to check finalization of tx.`);
           }
@@ -2962,7 +3062,6 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 1);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {
@@ -2988,6 +3087,7 @@ describe('Blockchain Node', () => {
             },
             "gas_cost_total": 0,
           });
+          assert.deepEqual(body.code, 1);
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPathWithFids + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -3002,7 +3102,6 @@ describe('Blockchain Node', () => {
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
-          assert.deepEqual(body.code, 0);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {
@@ -3027,6 +3126,7 @@ describe('Blockchain Node', () => {
             },
             "gas_cost_total": 0,
           });
+          assert.deepEqual(body.code, 0);
           if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
             console.error(`Failed to check finalization of tx.`);
           }
@@ -3035,6 +3135,90 @@ describe('Blockchain Node', () => {
             .body.toString('utf-8')).result
           // Should be the tx hash value.
           assert.deepEqual(_.get(lastTx, 'tx_hash', null), body.result.tx_hash);
+        });
+      });
+
+      describe('Owner rule: auth.fid', () => {
+        it('owner rule: auth.fid: without function permission', () => {
+          const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+            ref: setOwnerConfigNotAllowedPath + '/value',
+            value: 'some value',
+            timestamp: Date.now(),
+            nonce: -1,
+          }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_setOwnerConfig": {
+                "code": "FAILURE",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/set_owner_not_allowed_path_with_fid/value",
+                    "result": {
+                      "code": 603,
+                      "error_message": "No write_owner or branch_owner permission on: /test/test_function_triggering/set_owner_not_allowed_path_with_fid/value",
+                      "gas_amount": 0,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": {
+              "app": {},
+              "service": 1
+            },
+            "gas_cost_total": 0,
+          });
+          assert.deepEqual(body.code, 1);
+          const ownerConfig = parseOrLog(syncRequest('GET',
+              server2 + `/get_owner?ref=${setOwnerConfigNotAllowedPath + '/value'}`)
+            .body.toString('utf-8')).result
+          // Should be null.
+          expect(ownerConfig).to.equal(null);
+        });
+
+        it('owner rule: auth.fid: with function permission', async () => {
+          const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+            ref: setOwnerConfigAllowedPath + '/value',
+            value: 'some value',
+            timestamp: Date.now(),
+            nonce: -1,
+          }}).body.toString('utf-8'));
+          assert.deepEqual(_.get(body, 'result.result'), {
+            "code": 0,
+            "func_results": {
+              "_setOwnerConfig": {
+                "code": "SUCCESS",
+                "gas_amount": 0,
+                "op_results": [
+                  {
+                    "path": "/test/test_function_triggering/set_owner_allowed_path_with_fid/value",
+                    "result": {
+                      "code": 0,
+                      "gas_amount": 1,
+                    }
+                  }
+                ]
+              }
+            },
+            "gas_amount": 1,
+            "gas_amount_total": {
+              "app": {},
+              "service": 2
+            },
+            "gas_cost_total": 0,
+          });
+          assert.deepEqual(body.code, 0);
+          if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
+          const ownerConfig = parseOrLog(syncRequest('GET',
+              server2 + `/get_owner?ref=${setOwnerConfigAllowedPath + '/value'}`)
+            .body.toString('utf-8')).result
+          // Should be not null.
+          expect(ownerConfig).to.not.equal(null);
         });
       });
     });
@@ -3378,7 +3562,6 @@ describe('Blockchain Node', () => {
           timestamp: 1234567890000,
           nonce: -1,
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
             "_transfer": {
@@ -3417,6 +3600,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0,
         });
+        assert.deepEqual(body.code, 0);
       });
 
       it("native function (_transfer) without individual account registration", () => {
@@ -3426,7 +3610,6 @@ describe('Blockchain Node', () => {
           timestamp: 1234567890000,
           nonce: -1,
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
             "_transfer": {
@@ -3465,6 +3648,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0,
         });
+        assert.deepEqual(body.code, 0);
       });
 
       it("native function (_transfer) with service account registration", () => {
@@ -3474,7 +3658,6 @@ describe('Blockchain Node', () => {
           timestamp: 1234567890000,
           nonce: -1,
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
             "_stake": {
@@ -3549,6 +3732,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0,
         });
+        assert.deepEqual(body.code, 0);
       });
 
       it("native function (_transfer) without service account registration", () => {
@@ -3558,7 +3742,6 @@ describe('Blockchain Node', () => {
           timestamp: 1234567890001,
           nonce: -1,
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
             "_stake": {
@@ -3633,6 +3816,7 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0,
         });
+        assert.deepEqual(body.code, 0);
       });
 
       it("REST function with external RPC call", () => {
@@ -3640,7 +3824,6 @@ describe('Blockchain Node', () => {
           ref: triggerRestFunctionPath,
           value: 'some value',
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result'), {
           "func_results": {
             "0x11111": {
@@ -3656,10 +3839,11 @@ describe('Blockchain Node', () => {
           },
           "gas_cost_total": 0,
         });
+        assert.deepEqual(body.code, 0);
       });
     });
 
-    describe('Transfer (_transfer)', () => {
+    describe('Transfer: _transfer', () => {
       it('transfer: transfer', async () => {
         let fromBeforeBalance = parseOrLog(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
@@ -3669,8 +3853,8 @@ describe('Blockchain Node', () => {
           ref: transferPath + '/1/value',
           value: transferAmount
         }}).body.toString('utf-8'));
-        assert.deepEqual(body.code, 0);
         assert.deepEqual(_.get(body, 'result.result.code'), 0);
+        assert.deepEqual(body.code, 0);
         if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
           console.error(`Failed to check finalization of tx.`);
         }


### PR DESCRIPTION
Change summary:
- Allow function IDs (auth.fid) in owner config
- Add _setOwnerConfig native function for testing
- Rename execGasAmount -> extraGasAmount

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/406 