### PR TITLE
Bugfix for p2p test bug

### DIFF
--- a/p2p/index.js
+++ b/p2p/index.js
@@ -48,7 +48,7 @@ class P2pClient {
 
   run() {
     this.server.listen();
-    if (!process.env.P2P_UNITTEST_FLAG) this.connectToTracker();
+    this.connectToTracker();
   }
 
   // NOTE(minsulee2): The total number of connection is up to more than 5 without limit.

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -129,7 +129,7 @@ class P2pClient {
   }
 
   setIntervalForTrackerConnection() {
-    this.connectToTracker();
+    console.log(2);
     this.intervalConnection = setInterval(() => {
       this.connectToTracker();
     }, RECONNECT_INTERVAL_MS);
@@ -183,12 +183,15 @@ class P2pClient {
 
     this.trackerWebSocket.on('close', (code) => {
       logger.info(`\n Disconnected from [TRACKER] ${TRACKER_WS_ADDR} with code: ${code}`);
+      console.log(4)
       this.clearIntervalForTrackerUpdate();
+      this.clearIntervalForTrackerConnection();
       this.setIntervalForTrackerConnection();
     });
   }
 
   connectToTracker() {
+    console.log(3);
     logger.info(`Reconnecting to tracker (${TRACKER_WS_ADDR})`);
     this.trackerWebSocket = new Websocket(TRACKER_WS_ADDR);
     this.trackerWebSocket.on('open', () => {
@@ -493,6 +496,7 @@ class P2pClient {
     // NOTE(minsulee2): The trackerWebsocket should be checked initialized in order not to get error
     // in case trackerWebsocket is not properly setup.
     this.clearIntervalForTrackerConnection();
+    this.clearIntervalForTrackerUpdate();
     if (this.trackerWebSocket) this.trackerWebSocket.close();
     logger.info('Disconnect from tracker server.');
     this.stopHeartbeat();

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -46,7 +46,6 @@ const {
   signMessage,
   getAddressFromMessage,
   verifySignedMessage,
-  isValidProtocolVersion,
   checkTimestamp,
   closeSocketSafe,
   encapsulateMessage

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "uuid": "^3.4.0",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.4.2",
-    "ws": "^6.1.2"
+    "ws": "^7.4.6"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test_db": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 unittest/db.test.js",
     "test_tx_pool": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 unittest/tx-pool.test.js",
     "test_p2p_util": "./node_modules/mocha/bin/mocha --timeout 160000 unittest/p2p-util.test.js",
-    "test_p2p": "./node_modules/mocha/bin/mocha --timeout 320000 unittest/p2p.test.js",
+    "test_p2p": "P2P_UNITTEST_FLAG=true ./node_modules/mocha/bin/mocha --timeout 320000 unittest/p2p.test.js",
     "test_unit": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 \"unittest/*.test.js\"",
     "test_node": "./node_modules/mocha/bin/mocha --timeout 160000 integration/node.test.js",
     "test_blockchain": "./node_modules/mocha/bin/mocha --timeout 160000 integration/blockchain.test.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test_db": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 unittest/db.test.js",
     "test_tx_pool": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 unittest/tx-pool.test.js",
     "test_p2p_util": "./node_modules/mocha/bin/mocha --timeout 160000 unittest/p2p-util.test.js",
-    "test_p2p": "P2P_UNITTEST_FLAG=true ./node_modules/mocha/bin/mocha --timeout 320000 unittest/p2p.test.js",
+    "test_p2p": "./node_modules/mocha/bin/mocha --timeout 320000 unittest/p2p.test.js",
     "test_unit": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 \"unittest/*.test.js\"",
     "test_node": "./node_modules/mocha/bin/mocha --timeout 160000 integration/node.test.js",
     "test_blockchain": "./node_modules/mocha/bin/mocha --timeout 160000 integration/blockchain.test.js",

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -30,7 +30,7 @@ describe("p2p", () => {
   before(() => {
     p2pClient = new P2pClient(node, minProtocolVersion, maxProtocolVersion);
     p2pServer = p2pClient.server;
-    p2pClient.run();
+    p2pServer.listen();
   });
 
   after(() => {
@@ -40,7 +40,7 @@ describe("p2p", () => {
   describe("server status", () => {
     describe("getIpAddress", () => {
       it("gets ip address", async () => {
-        const actual = '172.0.0.1';
+        const actual = await p2pServer.getIpAddress();
         const ipAddressRegex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
         expect(ipAddressRegex.test(actual)).to.be.true;
       });

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -34,16 +34,7 @@ describe("p2p", () => {
   });
 
   after(() => {
-    clearInterval(p2pClient.intervalConnection);
     p2pClient.stop();
-    // This is added since p2pClient.stop() calls wsServer.close() though, it does not really close
-    // the server but still some wsServer in process leaves somehow(perhaps intended? or bug?).
-    // So that, the server should be manully shut down via process.kill().
-    // See also: https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocketserver
-    // console.log(process.argv0)
-    // if (process.ppid) {
-    //   process.kill(process.ppid);
-    // }
   });
 
   describe("server status", () => {

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -34,14 +34,16 @@ describe("p2p", () => {
   });
 
   after(() => {
+    clearInterval(p2pClient.intervalConnection);
     p2pClient.stop();
     // This is added since p2pClient.stop() calls wsServer.close() though, it does not really close
     // the server but still some wsServer in process leaves somehow(perhaps intended? or bug?).
     // So that, the server should be manully shut down via process.kill().
     // See also: https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocketserver
-    if (process.ppid) {
-      process.kill(process.ppid);
-    }
+    // console.log(process.argv0)
+    // if (process.ppid) {
+    //   process.kill(process.ppid);
+    // }
   });
 
   describe("server status", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,11 +546,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
 async-listener@^0.6.0:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
@@ -4824,12 +4819,10 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^6.1.2:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
-  dependencies:
-    async-limiter "~1.0.0"
+ws@^7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xtend@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Fix p2p unittest is not correctly finishing. The problem was not wsServer but intervalConnection for tracker is multiple set and the after() in p2p.test.js is not working in a way of test intention. That is, the after() is called before setInterval() is called that makes interval is running after test finished. To fix this P2P_UNITTEST_FLAG is added.

Updates:
- Add P2P_UNITTEST_FLAG on package.json
- Do not make multiple intervals
- Remove unnecessary process.kill()

Special thanks for @minho-comcom-ai 