### PR TITLE
Bugfix/null ip addresses

### DIFF
--- a/p2p/index.js
+++ b/p2p/index.js
@@ -46,8 +46,8 @@ class P2pClient {
     this.startHeartbeat();
   }
 
-  run() {
-    this.server.listen();
+  async run() {
+    await this.server.listen();
     this.connectToTracker();
   }
 

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -1,7 +1,6 @@
 /* eslint no-mixed-operators: "off" */
 const _ = require('lodash');
 const P2pServer = require('./server');
-const url = require('url');
 const Websocket = require('ws');
 const semver = require('semver');
 const logger = require('../logger')('P2P_CLIENT');
@@ -97,31 +96,26 @@ class P2pClient {
   }
 
   getNetworkStatus() {
+    const extIp = this.server.getExternalIp();
+    const url = new URL(`ws://${extIp}:${P2P_PORT}`);
+    const p2pUrl = url.toString();
+    url.protocol = 'http:';
+    url.port = PORT;
+    const clientApiUrl = url.toString();
+    url.pathname = 'json-rpc';
+    const jsonRpcUrl = url.toString();
     return {
-      ip: this.server.getExternalIp(),
+      ip: extIp,
       p2p: {
-        url: url.format({
-          protocol: 'ws',
-          hostname: this.server.getExternalIp(),
-          port: P2P_PORT
-        }),
+        url: p2pUrl,
         port: P2P_PORT,
       },
       clientApi: {
-        url: url.format({
-          protocol: 'http',
-          hostname: this.server.getExternalIp(),
-          port: PORT
-        }),
+        url: clientApiUrl,
         port: PORT,
       },
       jsonRpc: {
-        url: url.format({
-          protocol: 'http',
-          hostname: this.server.getExternalIp(),
-          port: PORT,
-          pathname: '/json-rpc',
-        }),
+        url: jsonRpcUrl,
         port: PORT,
       },
       connectionStatus: this.getConnectionStatus()

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -76,7 +76,7 @@ class P2pServer {
     this.maxInbound = maxInbound;
   }
 
-  listen() {
+  async listen() {
     this.wsServer = new Websocket.Server({
       port: P2P_PORT,
       // Enables server-side compression. For option details, see
@@ -106,7 +106,7 @@ class P2pServer {
       this.setPeerEventHandlers(socket);
     });
     logger.info(`Listening to peer-to-peer connections on: ${P2P_PORT}\n`);
-    this.setUpIpAddresses().then(() => { });
+    await this.setUpIpAddresses();
   }
 
   getNodeAddress() {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "seedrandom": "^2.4.4",
     "semver": "^6.3.0",
     "shuffle-seed": "^1.1.6",
-    "url": "^0.11.0",
     "util": "^0.11.1",
     "uuid": "^3.4.0",
     "valid-url": "^1.0.9",

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -1,5 +1,4 @@
 const chai = require('chai');
-const url = require('url');
 
 const BlockchainNode = require('../node');
 const VersionUtil = require('../common/version-util');
@@ -270,31 +269,26 @@ describe("p2p", () => {
 
     describe("getNetworkStatus", () => {
       it("shows initial values of connection status", () => {
+        const extIp = p2pClient.server.getExternalIp();
+        const url = new URL(`ws://${extIp}:${P2P_PORT}`);
+        const p2pUrl = url.toString();
+        url.protocol = 'http:';
+        url.port = PORT;
+        const clientApiUrl = url.toString();
+        url.pathname = 'json-rpc';
+        const jsonRpcUrl = url.toString();
         const actual = {
-          ip: p2pClient.server.getExternalIp(),
+          ip: extIp,
           p2p: {
-            url: url.format({
-              protocol: 'ws',
-              hostname: p2pClient.server.getExternalIp(),
-              port: P2P_PORT
-            }),
+            url: p2pUrl,
             port: P2P_PORT,
           },
           clientApi: {
-            url: url.format({
-              protocol: 'http',
-              hostname: p2pClient.server.getExternalIp(),
-              port: PORT
-            }),
+            url: clientApiUrl,
             port: PORT,
           },
           jsonRpc: {
-            url: url.format({
-              protocol: 'http',
-              hostname: p2pClient.server.getExternalIp(),
-              port: PORT,
-              pathname: '/json-rpc',
-            }),
+            url: jsonRpcUrl,
             port: PORT,
           },
           connectionStatus: p2pClient.getConnectionStatus()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,11 +3707,6 @@ pumpify@^2.0.1:
     inherits "^2.0.3"
     pump "^3.0.0"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -3736,11 +3731,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -4652,14 +4642,6 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
-
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Background: In GCP, a node is initially connecting to the tracker before setting its IP addresses (reporting them as nulls)

- Updated to wait until the IP addresses are set
- Replaced a [deprecated](https://nodejs.org/docs/latest-v12.x/api/url.html#url_url_format_urlobject) function (`url.format()`) with a [WHATWG URL API](https://nodejs.org/docs/latest-v12.x/api/url.html#url_the_whatwg_url_api)