### PR TITLE
Feature/billing accounts

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -480,6 +480,9 @@ function createSingleSetTxBody(input, opType) {
   if (input.gas_price !== undefined) {
     txBody.gas_price = input.gas_price;
   }
+  if (input.billing !== undefined) {
+    txBody.billing = input.billing;
+  }
   return txBody;
 }
 
@@ -501,6 +504,9 @@ function createMultiSetTxBody(input) {
   }
   if (input.gas_price !== undefined) {
     txBody.gas_price = input.gas_price;
+  }
+  if (input.billing !== undefined) {
+    txBody.billing = input.billing;
   }
   return txBody;
 }

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -365,14 +365,14 @@ class ChainUtil {
       return [];
     }
     if (op.op_list) {
-      const appNames = {};
+      const appNames = new Set();
       for (const innerOp of op.op_list) {
         const name = ChainUtil.getDependentAppNameFromRef(innerOp.ref);
         if (name) {
-          appNames[name] = true;
+          appNames.add(name);
         }
       }
-      return Object.keys(appNames);
+      return [...appNames];
     }
     const name = ChainUtil.getDependentAppNameFromRef(op.ref);
     return name ? [name] : [];

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -150,6 +150,12 @@ class ChainUtil {
     return ruleUtil.toServiceAccountName(serviceType, serviceName, key);
   }
 
+  // NOTE(liayoo): billing is in the form <app name>|<billing id>
+  static toBillingAccountName(billing) {
+    const { PredefinedDbPaths } = require('../common/constants');
+    return `${PredefinedDbPaths.BILLING}|${billing}`;
+  }
+
   static toEscrowAccountName(source, target, escrowKey) {
     return ruleUtil.toEscrowAccountName(source, target, escrowKey);
   }

--- a/common/chain-util.js
+++ b/common/chain-util.js
@@ -350,6 +350,34 @@ class ChainUtil {
     return isServiceType(_.get(parsedPath, 0));
   }
 
+  static getDependentAppNameFromRef(ref) {
+    const { isAppDependentServiceType } = require('../common/constants');
+    const parsedPath = ChainUtil.parsePath(ref);
+    const type = _.get(parsedPath, 0);
+    if (!type || !isAppDependentServiceType(type)) {
+      return null;
+    }
+    return _.get(parsedPath, 1, null);
+  }
+
+  static getServiceDependentAppNameList(op) {
+    if (!op) {
+      return [];
+    }
+    if (op.op_list) {
+      const appNames = {};
+      for (const innerOp of op.op_list) {
+        const name = ChainUtil.getDependentAppNameFromRef(innerOp.ref);
+        if (name) {
+          appNames[name] = true;
+        }
+      }
+      return Object.keys(appNames);
+    }
+    const name = ChainUtil.getDependentAppNameFromRef(op.ref);
+    return name ? [name] : [];
+  }
+
   static getSingleOpGasAmount(parsedPath, value) {
     const gasAmount = {
       service: 0,

--- a/common/constants.js
+++ b/common/constants.js
@@ -492,7 +492,7 @@ function isServiceAccountServiceType(type) {
 }
 
 /**
- * Service types that are NOT app-dependent.
+ * Service types that are app-dependent.
  */
 const APP_DEPENDENT_SERVICE_TYPES = [
   PredefinedDbPaths.MANAGE_APP,

--- a/common/constants.js
+++ b/common/constants.js
@@ -133,6 +133,7 @@ const PredefinedDbPaths = {
   // Gas fee
   GAS_FEE: 'gas_fee',
   COLLECT: 'collect',
+  BILLING: 'billing',
   // Token
   TOKEN: 'token',
   TOKEN_NAME: 'name',
@@ -460,7 +461,6 @@ const GasFeeConstants = {
 const SERVICE_TYPES = [
   PredefinedDbPaths.ACCOUNTS,
   PredefinedDbPaths.CHECKIN,
-  PredefinedDbPaths.CONSENSUS,
   PredefinedDbPaths.ESCROW,
   PredefinedDbPaths.GAS_FEE,
   PredefinedDbPaths.MANAGE_APP,
@@ -484,10 +484,24 @@ const SERVICE_ACCOUNT_SERVICE_TYPES = [
   PredefinedDbPaths.GAS_FEE,
   PredefinedDbPaths.PAYMENTS,
   PredefinedDbPaths.STAKING,
+  PredefinedDbPaths.BILLING,
 ];
 
 function isServiceAccountServiceType(type) {
   return SERVICE_ACCOUNT_SERVICE_TYPES.includes(type);
+}
+
+/**
+ * Service types that are NOT app-dependent.
+ */
+const APP_DEPENDENT_SERVICE_TYPES = [
+  PredefinedDbPaths.MANAGE_APP,
+  PredefinedDbPaths.PAYMENTS,
+  PredefinedDbPaths.STAKING,
+];
+
+function isAppDependentServiceType(type) {
+  return APP_DEPENDENT_SERVICE_TYPES.includes(type);
 }
 
 /**
@@ -763,6 +777,7 @@ module.exports = {
   SyncModeOptions,
   isServiceType,
   isServiceAccountServiceType,
+  isAppDependentServiceType,
   buildOwnerPermissions,
   buildRulePermission,
   ...GenesisParams.blockchain,

--- a/common/constants.js
+++ b/common/constants.js
@@ -480,11 +480,11 @@ function isServiceType(type) {
  * Service types allowed to create service accounts.
  */
 const SERVICE_ACCOUNT_SERVICE_TYPES = [
+  PredefinedDbPaths.BILLING,
   PredefinedDbPaths.ESCROW,
   PredefinedDbPaths.GAS_FEE,
   PredefinedDbPaths.PAYMENTS,
   PredefinedDbPaths.STAKING,
-  PredefinedDbPaths.BILLING,
 ];
 
 function isServiceAccountServiceType(type) {

--- a/db/index.js
+++ b/db/index.js
@@ -910,7 +910,6 @@ class DB {
       if (blockNumber > 0) {
         // Use only the service gas amount total
         result.gas_cost_total = ChainUtil.getTotalGasCost(gasPrice, gasAmountTotal.service);
-        logger.error(`gas_cost_total: ${result.gas_cost_total} (${gasPrice}, ${gasAmountTotal.service})`);
         const collectFeeRes = this.checkBillingAndCollectFee(op, auth, timestamp, tx, blockNumber, result);
         if (collectFeeRes !== true) {
           return collectFeeRes;

--- a/db/index.js
+++ b/db/index.js
@@ -942,11 +942,11 @@ class DB {
     if (appNameList.length > 1) {
       // More than 1 apps are involved. Cannot charge an app-related billing account.
       const reason = 'Multiple app-dependent service operations for a billing account';
-      return ChainUtil.returnTxResult(15, `Failed to collect gas fee: ${reason}`, 0);
+      return ChainUtil.returnTxResult(16, `Failed to collect gas fee: ${reason}`, 0);
     } else if (appNameList.length === 1 && appNameList[0] !== billingAppName) {
       // Tx app name doesn't match the billing account.
       const reason = 'Invalid billing account';
-      return ChainUtil.returnTxResult(15, `Failed to collect gas fee: ${reason}`, 0);
+      return ChainUtil.returnTxResult(17, `Failed to collect gas fee: ${reason}`, 0);
     }
     // Either app-independent or app name matches the billing account.
     return this.collectFee(
@@ -959,7 +959,7 @@ class DB {
         gasFeeCollectPath, { amount: gasCost }, auth, timestamp, tx, false);
     if (ChainUtil.isFailedTx(gasFeeCollectRes)) {
       return ChainUtil.returnTxResult(
-          15, `Failed to collect gas fee: ${JSON.stringify(gasFeeCollectRes, null, 2)}`, 0);
+          18, `Failed to collect gas fee: ${JSON.stringify(gasFeeCollectRes, null, 2)}`, 0);
     }
     return true;
   }

--- a/db/index.js
+++ b/db/index.js
@@ -937,7 +937,7 @@ class DB {
       return ChainUtil.returnTxResult(15, `Failed to collect gas fee: ${reason}`, 0);
     }
     const billingAppName = billingParsed[0];
-    const billingServiceAcntName = `billing|${billing}`;
+    const billingServiceAcntName = ChainUtil.toBillingAccountName(billing);
     const appNameList = ChainUtil.getServiceDependentAppNameList(op);
     if (appNameList.length > 1) {
       // More than 1 apps are involved. Cannot charge an app-related billing account.

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -146,6 +146,16 @@ class RuleUtil {
     }
   }
 
+  getBillingUserPath(billingServAcntName, userAddr) {
+    const { PredefinedDbPaths } = require('../common/constants');
+    const parsed = this.parseServAcntName(billingServAcntName);
+    const appName = parsed[1];
+    const billingId = parsed[2];
+    return `/${PredefinedDbPaths.MANAGE_APP}/${appName}/${PredefinedDbPaths.MANAGE_APP_CONFIG}/` +
+        `${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING}/${billingId}/` +
+        `${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING_USERS}/${userAddr}`;
+  }
+
   getOwnerAddr() {
     const { GenesisAccounts, AccountProperties } = require('../common/constants');
     return _.get(GenesisAccounts, `${AccountProperties.OWNER}.${AccountProperties.ADDRESS}`, null);

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -75,7 +75,7 @@
       "$from": {
         "$block_number": {
           "$tx_hash": {
-            ".write": "(auth.addr === $from || (util.isServAcntName($from) && getValue(util.getBillingUserPath($from, auth.addr)))) && data === null && util.isDict(newData) && util.isNumber(newData.amount) && newData.amount <= getValue(util.getBalancePath($from))"
+            ".write": "(auth.addr === $from || (util.isServAcntName($from) && getValue(util.getBillingUserPath($from, auth.addr)) === true)) && data === null && util.isDict(newData) && util.isNumber(newData.amount) && newData.amount <= getValue(util.getBalancePath($from))"
           }
         }
       }

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -75,7 +75,7 @@
       "$from": {
         "$block_number": {
           "$tx_hash": {
-            ".write": "auth.addr === $from && data === null && util.isDict(newData) && util.isNumber(newData.amount) && newData.amount <= getValue(util.getBalancePath($from))"
+            ".write": "(auth.addr === $from || (util.isServAcntName($from) && getValue(util.getBillingUserPath($from, auth.addr)))) && data === null && util.isDict(newData) && util.isNumber(newData.amount) && newData.amount <= getValue(util.getBalancePath($from))"
           }
         }
       }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -5932,7 +5932,6 @@ describe('Blockchain Node', () => {
     });
 
     it('app-dependent service tx: individual account', async () => {
-      const balanceBefore = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
       const gasPrice = 1;
       const txRes = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: '/manage_app/test_billing/config/service/staking/lockup_duration',
@@ -5945,11 +5944,12 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
-      const balanceAfter = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
-      assert.deepEqual(
-        balanceAfter,
-        balanceBefore - (gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service)
-      );
+      const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
+      const gasFeeCollected = parseOrLog(syncRequest(
+        'GET',
+        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+      ).body.toString('utf-8')).result;
+      assert.deepEqual(gasFeeCollected, gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service);
     });
 
     it('app-dependent service tx: invalid billing param', async () => {
@@ -6010,7 +6010,6 @@ describe('Blockchain Node', () => {
     });
 
     it('app-independent service tx: individual account', async () => {
-      const balanceBefore = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
       const gasPrice = 1;
       const txRes = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: `/transfer/${billingUserA}/${billingUserB}/${Date.now()}/value`,
@@ -6023,11 +6022,12 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
-      const balanceAfter = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
-      assert.deepEqual(
-        balanceAfter,
-        balanceBefore - (gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service) - 1
-      );
+      const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
+      const gasFeeCollected = parseOrLog(syncRequest(
+        'GET',
+        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+      ).body.toString('utf-8')).result;
+      assert.deepEqual(gasFeeCollected, gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service);
     });
 
     it('app-independent service tx: billing account', async () => {
@@ -6055,7 +6055,6 @@ describe('Blockchain Node', () => {
     });
 
     it('multi-set service tx: individual account', async () => {
-      const balanceBefore = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
       const gasPrice = 1;
       const txRes = parseOrLog(syncRequest('POST', server2 + '/set', {json: {
           op_list: [
@@ -6078,11 +6077,12 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
-      const balanceAfter = parseOrLog(syncRequest('GET', server2 + userBalancePathA).body.toString('utf-8')).result;
-      assert.deepEqual(
-        balanceAfter,
-        balanceBefore - (gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service) - 1,
-      );
+      const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
+      const gasFeeCollected = parseOrLog(syncRequest(
+        'GET',
+        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+      ).body.toString('utf-8')).result;
+      assert.deepEqual(gasFeeCollected, gasPrice * MICRO_AIN * txRes.result.gas_amount_total.service);
     });
 
     it('multi-set service tx: billing account', async () => {

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -5944,6 +5944,8 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
+      // NOTE(liayoo): Checking the gas fee was collected instead of account balances, since the
+      // nodes also participate in consensus & get the collected fees as rewards.
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',
@@ -6017,6 +6019,8 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
+      // NOTE(liayoo): Checking the gas fee was collected instead of account balances, since the
+      // nodes also participate in consensus & get the collected fees as rewards.
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',
@@ -6072,6 +6076,8 @@ describe('Blockchain Node', () => {
       if (!(await waitUntilTxFinalized(serverList, txRes.tx_hash))) {
         console.error(`Failed to check finalization of app tx.`);
       }
+      // NOTE(liayoo): Checking the gas fee was collected instead of account balances, since the
+      // nodes also participate in consensus & get the collected fees as rewards.
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -5962,12 +5962,7 @@ describe('Blockchain Node', () => {
           timestamp: Date.now(),
         }
       }).body.toString('utf-8'));
-      expect(txResBody.code).to.equals(1);
-      assert.deepEqual(txResBody.result.result, {
-        "error_message": "Failed to collect gas fee: Invalid billing param",
-        "code": 15,
-        "gas_amount": 0
-      });
+      assert.deepEqual(txResBody, {code: 1, result: { tx_hash: null, result: false }});
     });
 
     it('app-dependent service tx: not a billing account user', async () => {
@@ -5981,7 +5976,7 @@ describe('Blockchain Node', () => {
         }
       }).body.toString('utf-8'));
       expect(txResBody.code).to.equals(1);
-      expect(txResBody.result.result.code, 15);
+      expect(txResBody.result.result.code, 18);
       expect(txResBody.result.result.error_message.includes('No .write permission on: /gas_fee/collect/billing|test_billing|B'), true);
     });
 
@@ -6175,7 +6170,7 @@ describe('Blockchain Node', () => {
       }).body.toString('utf-8'));
       assert.deepEqual(txResBody.result.result, {
         "error_message": "Failed to collect gas fee: Multiple app-dependent service operations for a billing account",
-        "code": 15,
+        "code": 16,
         "gas_amount": 0
       });
     });

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -126,6 +126,7 @@ printf "Starting up Node server.."
 nohup node --async-stack-traces client/index.js >/dev/null 2>error_logs.txt &
 
 # 7. Wait until the new node catches up
+SECONDS=0
 loopCount=0
 
 generate_post_data()
@@ -142,7 +143,8 @@ do
     printf "\nconsensusState = ${consensusState}"
     printf "\nlastBlockNumber = ${lastBlockNumber}"
     if [ "$consensusState" == "RUNNING" ]; then
-        printf "\nNode is synced & running!\n\n"
+        printf "\nNode is synced & running!"
+        printf "Time it took to sync in seconds: $SECONDS\n\n"
         break
     fi
     ((loopCount++))

--- a/tx-pool/transaction.js
+++ b/tx-pool/transaction.js
@@ -208,6 +208,11 @@ class Transaction {
           `Transaction body has invalid gas price: ${JSON.stringify(txBody, null, 2)}`);
       return false;
     }
+    if (!Transaction.isValidBilling(txBody.billing)) {
+      logger.info(
+          `Transaction body has invalid billing: ${JSON.stringify(txBody, null, 2)}`);
+      return false;
+    }
     return Transaction.isInStandardFormat(txBody);
   }
 
@@ -223,6 +228,10 @@ class Transaction {
   static isValidGasPrice(gasPrice) {
     // NOTE(platfowner): Allow 'undefined' value for backward compatibility.
     return gasPrice > 0 || ENABLE_GAS_FEE_WORKAROUND && (gasPrice === undefined || gasPrice === 0);
+  }
+
+  static isValidBilling(billing) {
+    return billing === undefined || (ChainUtil.isString(billing) && billing.split('|').length === 2);
   }
 
   static isInStandardFormat(txBody) {

--- a/tx-pool/transaction.js
+++ b/tx-pool/transaction.js
@@ -170,6 +170,9 @@ class Transaction {
     if (txBody.gas_price !== undefined) {
       sanitized.gas_price = ChainUtil.numberOrZero(txBody.gas_price);
     }
+    if (txBody.billing !== undefined) {
+      sanitized.billing = ChainUtil.stringOrEmpty(txBody.billing);
+    }
     // A devel method for bypassing the transaction verification.
     if (txBody.address !== undefined) {
       sanitized.address = ChainUtil.stringOrEmpty(txBody.address);

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -1166,6 +1166,7 @@ describe("ChainUtil", () => {
       assert.deepEqual(ChainUtil.getServiceDependentAppNameList(undefined), []);
       assert.deepEqual(ChainUtil.getServiceDependentAppNameList({}), []);
     });
+
     it("when normal input", () => {
       assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
         ref: '/'

--- a/unittest/chain-util.test.js
+++ b/unittest/chain-util.test.js
@@ -1131,4 +1131,94 @@ describe("ChainUtil", () => {
       assert.deepEqual(ChainUtil.getTotalGasCost(undefined, 1), 0);
     })
   })
+
+  describe('getDependentAppNameFromRef', () => {
+    it("when abnormal input", () => {
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef(), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef(null), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef(undefined), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef(''), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/'), null);
+    });
+
+    it("when normal input (app-dependent service path)", () => {
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/manage_app/app_a'), 'app_a');
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/payments/app_a'), 'app_a');
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/staking/app_a'), 'app_a');
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/staking/app_a/some/nested/path'), 'app_a');
+    });
+    
+    it("when normal input (app-independent service path)", () => {
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/accounts/0xabcd/value'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/service_accounts/staking'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/gas_fee/gas_fee'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/escrow/source/target/id/key/value'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/sharding/config'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/transfer'), null);
+      assert.deepEqual(ChainUtil.getDependentAppNameFromRef('/transfer/from/to/key/value'), null);
+    });
+  })
+
+  describe('getServiceDependentAppNameList', () => { 
+    it("when abnormal input", () => {
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList(), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList(null), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList(undefined), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({}), []);
+    });
+    it("when normal input", () => {
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        ref: '/'
+      }), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        ref: '/transfer/from/to/key/value'
+      }), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        ref: '/manage_app/app_a/create/key'
+      }), ['app_a']);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        op_list: [
+          {
+            ref: '/'
+          }
+        ]
+      }), []);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        op_list: [
+          {
+            ref: '/transfer/from/to/key/value'
+          },
+          {
+            ref: '/manage_app/app_a/create/key'
+          }
+        ]
+      }), ['app_a']);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        op_list: [
+          {
+            ref: '/transfer/from/to/key/value'
+          },
+          {
+            ref: '/manage_app/app_a/create/key'
+          },
+          {
+            ref: '/payments/app_a/user/id/pay/key'
+          }
+        ]
+      }), ['app_a']);
+      assert.deepEqual(ChainUtil.getServiceDependentAppNameList({
+        op_list: [
+          {
+            ref: '/transfer/from/to/key/value'
+          },
+          {
+            ref: '/manage_app/app_a/create/key'
+          },
+          {
+            ref: '/payments/app_b/user/id/pay/key'
+          }
+        ]
+      }), ['app_a', 'app_b']);
+    });
+  })
 })

--- a/unittest/transaction.test.js
+++ b/unittest/transaction.test.js
@@ -18,11 +18,11 @@ describe('Transaction', () => {
   let txBodyCustomAddress;
   let txCustomAddress;
   let txBodyParentHash;
-  let txBodyBilling;
   let txParentHash;
+  let txBodyBilling;
+  let txBilling;
   let txBodyForNode;
   let txForNode;
-  let txBilling;
 
   beforeEach(() => {
     rimraf.sync(CHAINS_DIR);


### PR DESCRIPTION
- Added an optional `billing` field to `tx_body`
  - app txs: not billed
  - app-dependent service txs: billed to the specified billing account (default: tx signer)
    - tx ref app name must equal billing account app name
    - tx signer must be listed as the billing account user
  - app-independent service txs: billed to the specified billing account (default: tx signer)
     - tx signer must be listed as the billing account user
- Added test cases
- Updated incremental deploy script to print the sync time in seconds