### PR TITLE
Add `ain_getRemainingTransactionPoolSize` to json_rpc

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -16,8 +16,6 @@ const {
   BlockchainNodeStates,
   WriteDbOperations,
   TransactionStatus,
-  TX_POOL_SIZE_LIMIT,
-  TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
 } = require('../common/constants');
 const { ConsensusStatus } = require('../consensus/constants');
 
@@ -382,19 +380,10 @@ app.get('/dump_final_version', (req, res) => {
 
 app.get('/tx_pool_size_util', (req, res) => {
   const address = req.query.address;
-  const result = {};
-
-  if (address) { // Per account
-    result.limit = TX_POOL_SIZE_LIMIT_PER_ACCOUNT;
-    result.used = node.tp.getPerAccountPoolSize(address);
-  } else {
-    result.limit = TX_POOL_SIZE_LIMIT;
-    result.used = node.tp.getPoolSize();
-  }
-
+  const txPoolSizeUtil = node.getTxPoolSizeUtilization(address);
   res.status(200)
     .set('Content-Type', 'application/json')
-    .send({code: 0, result})
+    .send({code: 0, result: txPoolSizeUtil})
     .end();
 });
 

--- a/client/index.js
+++ b/client/index.js
@@ -16,6 +16,8 @@ const {
   BlockchainNodeStates,
   WriteDbOperations,
   TransactionStatus,
+  TX_POOL_SIZE_LIMIT,
+  TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
 } = require('../common/constants');
 const { ConsensusStatus } = require('../consensus/constants');
 
@@ -372,6 +374,24 @@ app.get('/state_versions', (req, res) => {
 // TODO(platfowner): Support for subtree dumping (i.e. with ref path).
 app.get('/dump_final_version', (req, res) => {
   const result = node.dumpFinalVersion(true);
+  res.status(200)
+    .set('Content-Type', 'application/json')
+    .send({code: 0, result})
+    .end();
+});
+
+app.get('/tx_pool_size_util', (req, res) => {
+  const address = req.query.address;
+  const result = {};
+
+  if (address) { // Per account
+    result.limit = TX_POOL_SIZE_LIMIT_PER_ACCOUNT;
+    result.used = node.tp.getPerAccountPoolSize(address);
+  } else {
+    result.limit = TX_POOL_SIZE_LIMIT;
+    result.used = node.tp.getPoolSize();
+  }
+
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -11,8 +11,6 @@ const {
   TX_BYTES_LIMIT,
   BATCH_TX_LIST_SIZE_LIMIT,
   NETWORK_ID,
-  TX_POOL_SIZE_LIMIT,
-  TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
 } = require('../common/constants');
 const Transaction = require('../tx-pool/transaction');
 const ChainUtil = require('../common/chain-util');
@@ -126,21 +124,9 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     },
 
     ain_getTransactionPoolSizeUtilization: function(args, done) {
-      if (args.address) { // Per account
-        done(null, addProtocolVersion({
-          result: {
-            limit: TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
-            used: node.tp.getPerAccountPoolSize(args.address),
-          }
-        }));
-      } else {
-        done(null, addProtocolVersion({
-          result: {
-            limit: TX_POOL_SIZE_LIMIT,
-            used: node.tp.getPoolSize(),
-          }
-        }));
-      }
+      const address = args.address;
+      const txPoolSizeUtil = node.getTxPoolSizeUtilization(address);
+      done(null, addProtocolVersion({result: txPoolSizeUtil}));
     },
 
     // TODO(platfowner): Instantly reject requests with invalid signatures.

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -11,6 +11,8 @@ const {
   TX_BYTES_LIMIT,
   BATCH_TX_LIST_SIZE_LIMIT,
   NETWORK_ID,
+  TX_POOL_SIZE_LIMIT,
+  TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
 } = require('../common/constants');
 const Transaction = require('../tx-pool/transaction');
 const ChainUtil = require('../common/chain-util');
@@ -121,6 +123,18 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     // Transaction API
     ain_getPendingTransactions: function(args, done) {
       done(null, addProtocolVersion({result: node.tp.transactions}));
+    },
+
+    ain_getRemainingTransactionPoolSize: function(args, done) {
+      if (args.address) { // Per account
+        const remainingSizePerAccount = TX_POOL_SIZE_LIMIT_PER_ACCOUNT -
+            node.tp.getPerAccountPoolSize(args.address);
+        done(null, addProtocolVersion({result: remainingSizePerAccount}));
+      } else {
+        const remainingSize = TX_POOL_SIZE_LIMIT -
+            node.tp.getPoolSize();
+        done(null, addProtocolVersion({result: remainingSize}));
+      }
     },
 
     // TODO(platfowner): Instantly reject requests with invalid signatures.

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -125,15 +125,21 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
       done(null, addProtocolVersion({result: node.tp.transactions}));
     },
 
-    ain_getRemainingTransactionPoolSize: function(args, done) {
+    ain_getTransactionPoolSizeUtilization: function(args, done) {
       if (args.address) { // Per account
-        const remainingSizePerAccount = TX_POOL_SIZE_LIMIT_PER_ACCOUNT -
-            node.tp.getPerAccountPoolSize(args.address);
-        done(null, addProtocolVersion({result: remainingSizePerAccount}));
+        done(null, addProtocolVersion({
+          result: {
+            limit: TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
+            used: node.tp.getPerAccountPoolSize(args.address),
+          }
+        }));
       } else {
-        const remainingSize = TX_POOL_SIZE_LIMIT -
-            node.tp.getPoolSize();
-        done(null, addProtocolVersion({result: remainingSize}));
+        done(null, addProtocolVersion({
+          result: {
+            limit: TX_POOL_SIZE_LIMIT,
+            used: node.tp.getPoolSize(),
+          }
+        }));
       }
     },
 

--- a/node/index.js
+++ b/node/index.js
@@ -22,7 +22,9 @@ const {
   GenesisSharding,
   StateVersions,
   SyncModeOptions,
-  LIGHTWEIGHT
+  LIGHTWEIGHT,
+  TX_POOL_SIZE_LIMIT,
+  TX_POOL_SIZE_LIMIT_PER_ACCOUNT,
 } = require('../common/constants');
 const FileUtil = require('../common/file-util');
 const ChainUtil = require('../common/chain-util');
@@ -261,6 +263,18 @@ class BlockchainNode {
       }
     }
     return shardingInfo;
+  }
+
+  getTxPoolSizeUtilization(address) {
+    const result = {};
+    if (address) { // Per account
+      result.limit = TX_POOL_SIZE_LIMIT_PER_ACCOUNT;
+      result.used = this.tp.getPerAccountPoolSize(address);
+    } else { // Total
+      result.limit = TX_POOL_SIZE_LIMIT;
+      result.used = this.tp.getPoolSize();
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Description
- Now we can check remaining pool size per account and total remaining pool size
- `address` args is optional (undefined: total, address: per account)

Resolve: #444 