### PR TITLE
Feature/shallow get

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -77,8 +77,8 @@ app.get('/metrics', (req, res, next) => {
 });
 
 app.get('/get_value', (req, res, next) => {
-  const result = node.db.getValue(req.query.ref, ChainUtil.toBool(req.query.is_global),
-      ChainUtil.toBool(req.query.is_shallow));
+  const result = node.db.getValue(req.query.ref, ChainUtil.toBool(req.query.is_shallow),
+      ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -86,8 +86,8 @@ app.get('/get_value', (req, res, next) => {
 });
 
 app.get('/get_function', (req, res, next) => {
-  const result = node.db.getFunction(req.query.ref, ChainUtil.toBool(req.query.is_global),
-      ChainUtil.toBool(req.query.is_shallow));
+  const result = node.db.getFunction(req.query.ref, ChainUtil.toBool(req.query.is_shallow),
+      ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -95,8 +95,8 @@ app.get('/get_function', (req, res, next) => {
 });
 
 app.get('/get_rule', (req, res, next) => {
-  const result = node.db.getRule(req.query.ref, ChainUtil.toBool(req.query.is_global),
-      ChainUtil.toBool(req.query.is_shallow));
+  const result = node.db.getRule(req.query.ref, ChainUtil.toBool(req.query.is_shallow),
+      ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})
@@ -104,8 +104,8 @@ app.get('/get_rule', (req, res, next) => {
 });
 
 app.get('/get_owner', (req, res, next) => {
-  const result = node.db.getOwner(req.query.ref, ChainUtil.toBool(req.query.is_global),
-      ChainUtil.toBool(req.query.is_shallow));
+  const result = node.db.getOwner(req.query.ref, ChainUtil.toBool(req.query.is_shallow),
+      ChainUtil.toBool(req.query.is_global));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})

--- a/client/index.js
+++ b/client/index.js
@@ -95,7 +95,8 @@ app.get('/get_function', (req, res, next) => {
 });
 
 app.get('/get_rule', (req, res, next) => {
-  const result = node.db.getRule(req.query.ref, ChainUtil.toBool(req.query.is_global));
+  const result = node.db.getRule(req.query.ref, ChainUtil.toBool(req.query.is_global),
+      ChainUtil.toBool(req.query.is_shallow));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})

--- a/client/index.js
+++ b/client/index.js
@@ -104,7 +104,8 @@ app.get('/get_rule', (req, res, next) => {
 });
 
 app.get('/get_owner', (req, res, next) => {
-  const result = node.db.getOwner(req.query.ref, ChainUtil.toBool(req.query.is_global));
+  const result = node.db.getOwner(req.query.ref, ChainUtil.toBool(req.query.is_global),
+      ChainUtil.toBool(req.query.is_shallow));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})

--- a/client/index.js
+++ b/client/index.js
@@ -86,7 +86,8 @@ app.get('/get_value', (req, res, next) => {
 });
 
 app.get('/get_function', (req, res, next) => {
-  const result = node.db.getFunction(req.query.ref, ChainUtil.toBool(req.query.is_global));
+  const result = node.db.getFunction(req.query.ref, ChainUtil.toBool(req.query.is_global),
+      ChainUtil.toBool(req.query.is_shallow));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})

--- a/client/index.js
+++ b/client/index.js
@@ -77,7 +77,8 @@ app.get('/metrics', (req, res, next) => {
 });
 
 app.get('/get_value', (req, res, next) => {
-  const result = node.db.getValue(req.query.ref, ChainUtil.toBool(req.query.is_global));
+  const result = node.db.getValue(req.query.ref, ChainUtil.toBool(req.query.is_global),
+      ChainUtil.toBool(req.query.is_shallow));
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: result !== null ? 0 : 1, result})

--- a/db/index.js
+++ b/db/index.js
@@ -408,9 +408,8 @@ class DB {
     if (stateNode === null) {
       return null;
     }
-    if (isShallow === true) {
-      const childLabels = stateNode.getChildLabels();
-      return childLabels.length > 0 ? childLabels : null;
+    if (isShallow) {
+      return stateNode.toJsObjectShallow();
     } else {
       return stateNode.toJsObject();
     }

--- a/db/index.js
+++ b/db/index.js
@@ -542,7 +542,7 @@ class DB {
       if (op.type === undefined || op.type === ReadDbOperations.GET_VALUE) {
         resultList.push(this.getValue(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.GET_RULE) {
-        resultList.push(this.getRule(op.ref, op.is_global));
+        resultList.push(this.getRule(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.GET_FUNCTION) {
         resultList.push(this.getFunction(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.GET_OWNER) {

--- a/db/index.js
+++ b/db/index.js
@@ -395,7 +395,7 @@ class DB {
     return DB.removeEmptyNodesRecursive(fullPath, 0, stateRoot);
   }
 
-  static readFromStateRoot(stateRoot, rootLabel, refPath, isGlobal, shardingPath, isShallow) {
+  static readFromStateRoot(stateRoot, rootLabel, refPath, isShallow, isGlobal, shardingPath) {
     if (!stateRoot) return null;
     const parsedPath = ChainUtil.parsePath(refPath);
     const localPath = isGlobal === true ? DB.toLocalPath(parsedPath, shardingPath) : parsedPath;
@@ -416,25 +416,25 @@ class DB {
     }
   }
 
-  readDatabase(refPath, rootLabel, isGlobal, isShallow) {
-    return DB.readFromStateRoot(this.stateRoot, rootLabel, refPath, isGlobal, this.shardingPath, isShallow);
+  readDatabase(refPath, rootLabel, isShallow, isGlobal) {
+    return DB.readFromStateRoot(this.stateRoot, rootLabel, refPath, isShallow, isGlobal, this.shardingPath);
   }
 
   // TODO(platfowner): Support lookups on the final version.
-  getValue(valuePath, isGlobal, isShallow) {
-    return this.readDatabase(valuePath, PredefinedDbPaths.VALUES_ROOT, isGlobal, isShallow);
+  getValue(valuePath, isShallow, isGlobal) {
+    return this.readDatabase(valuePath, PredefinedDbPaths.VALUES_ROOT, isShallow, isGlobal);
   }
 
-  getFunction(functionPath, isGlobal, isShallow) {
-    return this.readDatabase(functionPath, PredefinedDbPaths.FUNCTIONS_ROOT, isGlobal, isShallow);
+  getFunction(functionPath, isShallow, isGlobal) {
+    return this.readDatabase(functionPath, PredefinedDbPaths.FUNCTIONS_ROOT, isShallow, isGlobal);
   }
 
-  getRule(rulePath, isGlobal, isShallow) {
-    return this.readDatabase(rulePath, PredefinedDbPaths.RULES_ROOT, isGlobal, isShallow);
+  getRule(rulePath, isShallow, isGlobal) {
+    return this.readDatabase(rulePath, PredefinedDbPaths.RULES_ROOT, isShallow, isGlobal);
   }
 
-  getOwner(ownerPath, isGlobal, isShallow) {
-    return this.readDatabase(ownerPath, PredefinedDbPaths.OWNERS_ROOT, isGlobal, isShallow);
+  getOwner(ownerPath, isShallow, isGlobal) {
+    return this.readDatabase(ownerPath, PredefinedDbPaths.OWNERS_ROOT, isShallow, isGlobal);
   }
 
   /**
@@ -539,13 +539,13 @@ class DB {
     const resultList = [];
     opList.forEach((op) => {
       if (op.type === undefined || op.type === ReadDbOperations.GET_VALUE) {
-        resultList.push(this.getValue(op.ref, op.is_global, op.is_shallow));
+        resultList.push(this.getValue(op.ref, op.is_shallow, op.is_global));
       } else if (op.type === ReadDbOperations.GET_RULE) {
-        resultList.push(this.getRule(op.ref, op.is_global, op.is_shallow));
+        resultList.push(this.getRule(op.ref, op.is_shallow, op.is_global));
       } else if (op.type === ReadDbOperations.GET_FUNCTION) {
-        resultList.push(this.getFunction(op.ref, op.is_global, op.is_shallow));
+        resultList.push(this.getFunction(op.ref, op.is_shallow, op.is_global));
       } else if (op.type === ReadDbOperations.GET_OWNER) {
-        resultList.push(this.getOwner(op.ref, op.is_global, op.is_shallow));
+        resultList.push(this.getOwner(op.ref, op.is_shallow, op.is_global));
       } else if (op.type === ReadDbOperations.MATCH_FUNCTION) {
         resultList.push(this.matchFunction(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.MATCH_RULE) {
@@ -688,7 +688,7 @@ class DB {
   }
 
   incValue(valuePath, delta, auth, timestamp, transaction, isGlobal) {
-    const valueBefore = this.getValue(valuePath, isGlobal, false);
+    const valueBefore = this.getValue(valuePath, false, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
       return ChainUtil.returnTxResult(201, `Not a number type: ${valueBefore} or ${delta}`);
@@ -698,7 +698,7 @@ class DB {
   }
 
   decValue(valuePath, delta, auth, timestamp, transaction, isGlobal) {
-    const valueBefore = this.getValue(valuePath, isGlobal, false);
+    const valueBefore = this.getValue(valuePath, false, isGlobal);
     logger.debug(`VALUE BEFORE:  ${JSON.stringify(valueBefore)}`);
     if ((valueBefore && typeof valueBefore !== 'number') || typeof delta !== 'number') {
       return ChainUtil.returnTxResult(301, `Not a number type: ${valueBefore} or ${delta}`);
@@ -737,7 +737,7 @@ class DB {
     if (!this.getPermissionForFunction(localPath, auth)) {
       return ChainUtil.returnTxResult(404, `No write_function permission on: ${functionPath}`);
     }
-    const curFunction = this.getFunction(functionPath, isGlobal, false);
+    const curFunction = this.getFunction(functionPath, false, isGlobal);
     const newFunction = applyFunctionChange(curFunction, func);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     this.writeDatabase(fullPath, newFunction);
@@ -797,7 +797,7 @@ class DB {
       return ChainUtil.returnTxResult(
           603, `No write_owner or branch_owner permission on: ${ownerPath}`);
     }
-    const curOwner = this.getOwner(ownerPath, isGlobal, false);
+    const curOwner = this.getOwner(ownerPath, false, isGlobal);
     const newOwner = applyOwnerChange(curOwner, owner);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     this.writeDatabase(fullPath, newOwner);

--- a/db/index.js
+++ b/db/index.js
@@ -412,8 +412,7 @@ class DB {
       const childLabels = stateNode.getChildLabels();
       return childLabels.length > 0 ? childLabels : null;
     } else {
-      const stateObj = stateNode.toJsObject();
-      return stateObj;
+      return stateNode.toJsObject();
     }
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -544,7 +544,7 @@ class DB {
       } else if (op.type === ReadDbOperations.GET_RULE) {
         resultList.push(this.getRule(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.GET_FUNCTION) {
-        resultList.push(this.getFunction(op.ref, op.is_global));
+        resultList.push(this.getFunction(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.GET_OWNER) {
         resultList.push(this.getOwner(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.MATCH_FUNCTION) {
@@ -738,7 +738,7 @@ class DB {
     if (!this.getPermissionForFunction(localPath, auth)) {
       return ChainUtil.returnTxResult(404, `No write_function permission on: ${functionPath}`);
     }
-    const curFunction = this.getFunction(functionPath, isGlobal);
+    const curFunction = this.getFunction(functionPath, isGlobal, false);
     const newFunction = applyFunctionChange(curFunction, func);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
     this.writeDatabase(fullPath, newFunction);

--- a/db/index.js
+++ b/db/index.js
@@ -546,7 +546,7 @@ class DB {
       } else if (op.type === ReadDbOperations.GET_FUNCTION) {
         resultList.push(this.getFunction(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.GET_OWNER) {
-        resultList.push(this.getOwner(op.ref, op.is_global));
+        resultList.push(this.getOwner(op.ref, op.is_global, op.is_shallow));
       } else if (op.type === ReadDbOperations.MATCH_FUNCTION) {
         resultList.push(this.matchFunction(op.ref, op.is_global));
       } else if (op.type === ReadDbOperations.MATCH_RULE) {
@@ -798,7 +798,7 @@ class DB {
       return ChainUtil.returnTxResult(
           603, `No write_owner or branch_owner permission on: ${ownerPath}`);
     }
-    const curOwner = this.getOwner(ownerPath, isGlobal);
+    const curOwner = this.getOwner(ownerPath, isGlobal, false);
     const newOwner = applyOwnerChange(curOwner, owner);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
     this.writeDatabase(fullPath, newOwner);

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -103,9 +103,9 @@ class StateNode {
     if (this.getIsLeaf()) {
       return this.getValue();
     }
-    return this.getChildLabels().reduce((shallowTable, label) => {
-      shallowTable[label] = true;
-      return shallowTable;
+    return this.getChildLabels().reduce((shallowCopy, label) => {
+      shallowCopy[label] = true;
+      return shallowCopy;
     }, {});
   }
 

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -99,6 +99,13 @@ class StateNode {
     return obj;
   }
 
+  toJsObjectShallow() {
+    if (this.getIsLeaf()) {
+      return null;
+    }
+    return this.getChildLabels();
+  }
+
   getIsLeaf() {
     return this.isLeaf;
   }

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -101,9 +101,12 @@ class StateNode {
 
   toJsObjectShallow() {
     if (this.getIsLeaf()) {
-      return null;
+      return this.getValue();
     }
-    return this.getChildLabels();
+    return this.getChildLabels().reduce((shallowTable, label) => {
+      shallowTable[label] = true;
+      return shallowTable;
+    }, {});
   }
 
   getIsLeaf() {

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -271,22 +271,22 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
       switch (args.type) {
         case ReadDbOperations.GET_VALUE:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getValue(args.ref, args.is_global, args.is_shallow)
+            result: p2pServer.node.db.getValue(args.ref, args.is_shallow, args.is_global)
           }));
           return;
         case ReadDbOperations.GET_RULE:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getRule(args.ref, args.is_global, args.is_shallow)
+            result: p2pServer.node.db.getRule(args.ref, args.is_shallow, args.is_global)
           }));
           return;
         case ReadDbOperations.GET_FUNCTION:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getFunction(args.ref, args.is_global, args.is_shallow)
+            result: p2pServer.node.db.getFunction(args.ref, args.is_shallow, args.is_global)
           }));
           return;
         case ReadDbOperations.GET_OWNER:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getOwner(args.ref, args.is_global, args.is_shallow)
+            result: p2pServer.node.db.getOwner(args.ref, args.is_shallow, args.is_global)
           }));
           return;
         case ReadDbOperations.GET:

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -271,7 +271,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
       switch (args.type) {
         case ReadDbOperations.GET_VALUE:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getValue(args.ref, args.is_global)
+            result: p2pServer.node.db.getValue(args.ref, args.is_global, args.is_shallow)
           }));
           return;
         case ReadDbOperations.GET_RULE:

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -286,7 +286,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
           return;
         case ReadDbOperations.GET_OWNER:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getOwner(args.ref, args.is_global)
+            result: p2pServer.node.db.getOwner(args.ref, args.is_global, args.is_shallow)
           }));
           return;
         case ReadDbOperations.GET:

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -276,7 +276,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
           return;
         case ReadDbOperations.GET_RULE:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getRule(args.ref, args.is_global)
+            result: p2pServer.node.db.getRule(args.ref, args.is_global, args.is_shallow)
           }));
           return;
         case ReadDbOperations.GET_FUNCTION:

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -281,7 +281,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
           return;
         case ReadDbOperations.GET_FUNCTION:
           done(null, addProtocolVersion({
-            result: p2pServer.node.db.getFunction(args.ref, args.is_global)
+            result: p2pServer.node.db.getFunction(args.ref, args.is_global, args.is_shallow)
           }));
           return;
         case ReadDbOperations.GET_OWNER:

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -111,7 +111,7 @@ describe("DB initialization", () => {
 })
 
 describe("DB operations", () => {
-  let node, dbValues, dbRules, dbOwners;
+  let node, dbValues, dbFuncs, dbRules, dbOwners;
 
   beforeEach(() => {
     let result;
@@ -319,6 +319,10 @@ describe("DB operations", () => {
             }
           }
         });
+      })
+
+      it("when retrieving existing function config with is_shallow", () => {
+        assert.deepEqual(node.db.getFunction("test/test_function", false, true), Object.keys(dbFuncs));
       })
     })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -328,7 +328,9 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing function config with is_shallow", () => {
-        assert.deepEqual(Object.keys(node.db.getFunction("test/test_function", true, false)), Object.keys(dbFuncs));
+        assert.deepEqual(node.db.getFunction('test/test_function', true, false), {
+          some: true,
+        });
       })
     })
 
@@ -349,9 +351,11 @@ describe("DB operations", () => {
         });
       })
 
-      it("when retrieving existing rule config with is_shallow", () => {
-        assert.deepEqual(Object.keys(node.db.getRule("test/test_rule", true, false)), Object.keys(dbRules));
-      })
+      it('when retrieving existing rule config with is_shallow', () => {
+        assert.deepEqual(node.db.getRule('test/test_rule', true, false), {
+          some: true,
+        });
+      });
     })
 
     describe("getOwner()", () => {
@@ -401,7 +405,9 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing owner config with is_shallow", () => {
-        assert.deepEqual(Object.keys(node.db.getOwner("test/test_owner", true, false)), Object.keys(dbOwners))
+        assert.deepEqual(node.db.getOwner("test/test_owner", true, false), {
+          some: true,
+        })
       })
     })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -269,7 +269,7 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getValue("test"), dbValues)
       })
 
-      it("when retrieving high value near top of database with is_shallow", () => {
+      it("when retrieving value near top of database with is_shallow", () => {
         assert.deepEqual(Object.keys(node.db.getValue("test", true, false)), Object.keys(dbValues))
       })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -269,6 +269,10 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getValue("test"), dbValues)
       })
 
+      it("when retrieving high value near top of database with is_shallow", () => {
+        assert.deepEqual(node.db.getValue("test", false, true), Object.keys(dbValues))
+      })
+
       it("when retrieving shallow nested value", () => {
         assert.deepEqual(node.db.getValue("test/ai/comcom"), dbValues["ai"]["comcom"])
       })
@@ -279,6 +283,10 @@ describe("DB operations", () => {
 
       it("by failing when value is not present", () => {
         expect(node.db.getValue("test/nested/far/down/to/nowhere")).to.equal(null)
+      })
+
+      it("by failing when value is not present with is_shallow", () => {
+        expect(node.db.getValue("test/nested/far/down/to/nowhere", false, true)).to.equal(null)
       })
     })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -270,7 +270,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving high value near top of database with is_shallow", () => {
-        assert.deepEqual(node.db.getValue("test", true, false), Object.keys(dbValues))
+        assert.deepEqual(Object.keys(node.db.getValue("test", true, false)), Object.keys(dbValues))
       })
 
       it("when retrieving shallow nested value", () => {
@@ -322,7 +322,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing function config with is_shallow", () => {
-        assert.deepEqual(node.db.getFunction("test/test_function", true, false), Object.keys(dbFuncs));
+        assert.deepEqual(Object.keys(node.db.getFunction("test/test_function", true, false)), Object.keys(dbFuncs));
       })
     })
 
@@ -344,7 +344,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing rule config with is_shallow", () => {
-        assert.deepEqual(node.db.getRule("test/test_rule", true, false), Object.keys(dbRules));
+        assert.deepEqual(Object.keys(node.db.getRule("test/test_rule", true, false)), Object.keys(dbRules));
       })
     })
 
@@ -395,7 +395,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing owner config with is_shallow", () => {
-        assert.deepEqual(node.db.getOwner("test/test_owner", true, false), Object.keys(dbOwners))
+        assert.deepEqual(Object.keys(node.db.getOwner("test/test_owner", true, false)), Object.keys(dbOwners))
       })
     })
 

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -269,9 +269,15 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getValue("test"), dbValues)
       })
 
-      it("when retrieving value near top of database with is_shallow", () => {
-        assert.deepEqual(Object.keys(node.db.getValue("test", true, false)), Object.keys(dbValues))
-      })
+      it('when retrieving value near top of database with is_shallow', () => {
+        assert.deepEqual(node.db.getValue('test', true, false), {
+          'ai': true,
+          'increment': true,
+          'decrement': true,
+          'nested': true,
+          'shards': true,
+        })
+      });
 
       it("when retrieving shallow nested value", () => {
         assert.deepEqual(node.db.getValue("test/ai/comcom"), dbValues["ai"]["comcom"])

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -342,6 +342,10 @@ describe("DB operations", () => {
           }
         });
       })
+
+      it("when retrieving existing rule config with is_shallow", () => {
+        assert.deepEqual(node.db.getRule("test/test_rule", false, true), Object.keys(dbRules));
+      })
     })
 
     describe("getOwner()", () => {

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -270,7 +270,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving high value near top of database with is_shallow", () => {
-        assert.deepEqual(node.db.getValue("test", false, true), Object.keys(dbValues))
+        assert.deepEqual(node.db.getValue("test", true, false), Object.keys(dbValues))
       })
 
       it("when retrieving shallow nested value", () => {
@@ -286,7 +286,7 @@ describe("DB operations", () => {
       })
 
       it("by failing when value is not present with is_shallow", () => {
-        expect(node.db.getValue("test/nested/far/down/to/nowhere", false, true)).to.equal(null)
+        expect(node.db.getValue("test/nested/far/down/to/nowhere", true, false)).to.equal(null)
       })
     })
 
@@ -322,7 +322,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing function config with is_shallow", () => {
-        assert.deepEqual(node.db.getFunction("test/test_function", false, true), Object.keys(dbFuncs));
+        assert.deepEqual(node.db.getFunction("test/test_function", true, false), Object.keys(dbFuncs));
       })
     })
 
@@ -344,7 +344,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing rule config with is_shallow", () => {
-        assert.deepEqual(node.db.getRule("test/test_rule", false, true), Object.keys(dbRules));
+        assert.deepEqual(node.db.getRule("test/test_rule", true, false), Object.keys(dbRules));
       })
     })
 
@@ -395,7 +395,7 @@ describe("DB operations", () => {
       })
 
       it("when retrieving existing owner config with is_shallow", () => {
-        assert.deepEqual(node.db.getOwner("test/test_owner", false, true), Object.keys(dbOwners))
+        assert.deepEqual(node.db.getOwner("test/test_owner", true, false), Object.keys(dbOwners))
       })
     })
 
@@ -3162,13 +3162,13 @@ describe("DB sharding config", () => {
     })
 
     it("getValue with isGlobal = true", () => {
-      expect(node.db.getValue("test/test_sharding/some/path/to/value", true)).to.equal(null);
-      expect(node.db.getValue("apps/afan/test/test_sharding/some/path/to/value", true))
+      expect(node.db.getValue("test/test_sharding/some/path/to/value", false, true)).to.equal(null);
+      expect(node.db.getValue("apps/afan/test/test_sharding/some/path/to/value", false, true))
           .to.equal(value);
     })
 
     it("getValue with isGlobal = true and non-existing path", () => {
-      expect(node.db.getValue("some/non-existing/path", true)).to.equal(null);
+      expect(node.db.getValue("some/non-existing/path", false, true)).to.equal(null);
     })
 
     it("setValue with isGlobal = false", () => {
@@ -3207,7 +3207,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/shards/enabled_shard/path", 20, '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1', null, null,
           true).code)
               .to.equal(0);
-      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", true))
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", false, true))
           .to.equal(10);  // value unchanged
     })
 
@@ -3222,7 +3222,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 20, { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' },
           null, { extra: { executed_at: 1234567890000 }}, true).code)
               .to.equal(0);
-      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", false, true))
           .to.equal(20);  // value changed
     })
 
@@ -3261,7 +3261,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/shards/enabled_shard/path", 5, { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' },
           null, null, true).code)
               .to.equal(0);
-      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", true))
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/enabled_shard/path", false, true))
           .to.equal(10);  // value unchanged
     })
 
@@ -3276,7 +3276,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 5, { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' },
           null, { extra: { executed_at: 1234567890000 }}, true).code)
               .to.equal(0);
-      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", false, true))
           .to.equal(15);  // value changed
     })
 
@@ -3316,7 +3316,7 @@ describe("DB sharding config", () => {
           null, null, true).code)
               .to.equal(0);
       expect(node.db.getValue(
-          "apps/afan/test/test_sharding/shards/enabled_shard/path", true))
+          "apps/afan/test/test_sharding/shards/enabled_shard/path", false, true))
               .to.equal(10);  // value unchanged
     })
 
@@ -3332,7 +3332,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/shards/disabled_shard/path", 5, { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' },
           null, { extra: { executed_at: 1234567890000 }}, true).code)
               .to.equal(0);
-      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", true))
+      expect(node.db.getValue("apps/afan/test/test_sharding/shards/disabled_shard/path", false, true))
         .to.equal(5);  // value changed
     })
 
@@ -3396,13 +3396,13 @@ describe("DB sharding config", () => {
     })
 
     it("getFunction with isGlobal = true", () => {
-      expect(node.db.getFunction("test/test_sharding/some/path/to", true)).to.equal(null);
+      expect(node.db.getFunction("test/test_sharding/some/path/to", false, true)).to.equal(null);
       assert.deepEqual(
-          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), func);
+          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", false, true), func);
     })
 
     it("getFunction with isGlobal = true and non-existing path", () => {
-      expect(node.db.getFunction("some/non-existing/path", true)).to.equal(null);
+      expect(node.db.getFunction("some/non-existing/path", false, true)).to.equal(null);
     })
 
     it("setFunction with isGlobal = false", () => {
@@ -3418,7 +3418,7 @@ describe("DB sharding config", () => {
           true).code)
               .to.equal(0);
       assert.deepEqual(
-          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", true), newFunc);
+          node.db.getFunction("apps/afan/test/test_sharding/some/path/to", false, true), newFunc);
     })
 
     it("setFunction with isGlobal = true and non-existing path", () => {
@@ -3516,13 +3516,13 @@ describe("DB sharding config", () => {
     })
 
     it("getRule with isGlobal = true", () => {
-      expect(node.db.getRule("test/test_sharding/some/path/to", true)).to.equal(null);
+      expect(node.db.getRule("test/test_sharding/some/path/to", false, true)).to.equal(null);
       assert.deepEqual(
-          node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), rule);
+          node.db.getRule("apps/afan/test/test_sharding/some/path/to", false, true), rule);
     })
 
     it("getRule with isGlobal = true and non-existing path", () => {
-      expect(node.db.getRule("some/non-existing/path", true)).to.equal(null);
+      expect(node.db.getRule("some/non-existing/path", false, true)).to.equal(null);
     })
 
     it("setRule with isGlobal = false", () => {
@@ -3537,7 +3537,7 @@ describe("DB sharding config", () => {
           "apps/afan/test/test_sharding/some/path/to", newRule, { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, true).code)
               .to.equal(0);
       assert.deepEqual(
-          node.db.getRule("apps/afan/test/test_sharding/some/path/to", true), newRule);
+          node.db.getRule("apps/afan/test/test_sharding/some/path/to", false, true), newRule);
     })
 
     it("setRule with isGlobal = true and non-existing path", () => {
@@ -3677,13 +3677,13 @@ describe("DB sharding config", () => {
     })
 
     it("getOwner with isGlobal = true", () => {
-      expect(node.db.getOwner("test/test_sharding/some/path/to", true)).to.equal(null);
+      expect(node.db.getOwner("test/test_sharding/some/path/to", false, true)).to.equal(null);
       assert.deepEqual(
-          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), owner);
+          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", false, true), owner);
     })
 
     it("getOwner with isGlobal = true and non-existing path", () => {
-      expect(node.db.getOwner("some/non-existing/path", true)).to.equal(null);
+      expect(node.db.getOwner("some/non-existing/path", false, true)).to.equal(null);
     })
 
     it("setOwner with isGlobal = false", () => {
@@ -3700,7 +3700,7 @@ describe("DB sharding config", () => {
           { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, true).code)
               .to.equal(0);
       assert.deepEqual(
-          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", true), newOwner);
+          node.db.getOwner("apps/afan/test/test_sharding/some/path/to", false, true), newOwner);
     })
 
     it("setOwner with isGlobal = true and non-existing path", () => {

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -393,6 +393,10 @@ describe("DB operations", () => {
           }
         });
       })
+
+      it("when retrieving existing owner config with is_shallow", () => {
+        assert.deepEqual(node.db.getOwner("test/test_owner", false, true), Object.keys(dbOwners))
+      })
     })
 
     describe("matchFunction()", () => {

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -468,6 +468,35 @@ describe("state-node", () => {
     })
   })
 
+  describe("fromJsObject with version / toJsObjectShallow", () => {
+    it("leaf node", () => {
+      const ver = 'test_version';
+      expect(StateNode.fromJsObject(true, ver).toJsObjectShallow()).to.equal(true);
+      expect(StateNode.fromJsObject(false, ver).toJsObjectShallow()).to.equal(false);
+      expect(StateNode.fromJsObject(10, ver).toJsObjectShallow()).to.equal(10);
+      expect(StateNode.fromJsObject('str', ver).toJsObjectShallow()).to.equal('str');
+      expect(StateNode.fromJsObject(null, ver).toJsObjectShallow()).to.equal(null);
+    })
+
+    it("internal node", () => {
+      const ver = 'test_version';
+      assert.deepEqual(StateNode.fromJsObject({ a: 1, b: 2, c: 3 }, ver).toJsObjectShallow(),
+          {
+            a: true,
+            b: true,
+            c: true,
+          },
+      );
+      assert.deepEqual(StateNode.fromJsObject({ a: { aa: 11 }, b: 2 }, ver).toJsObjectShallow(),
+          {
+            a: true,
+            b: true,
+          },
+      );
+    })
+
+  })
+
   describe("isLeaf", () => {
     it("get / set", () => {
       expect(node.getIsLeaf()).to.equal(true);


### PR DESCRIPTION
## Description
- Now, we can use shallow query in json_rpc & client API
- Supports getValue, getOwner, getRule, getFunction methods
- Add related testcases to db.test.js

![image](https://user-images.githubusercontent.com/74223287/122852143-1a2b8600-d34b-11eb-8857-cbd58b98d771.png)
