### PR TITLE
Clean up state-related terms

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -390,7 +390,7 @@ app.get('/tx_pool_size_util', (req, res) => {
 app.get('/get_transaction', (req, res, next) => {
   const transactionInfo = node.tp.transactionTracker[req.query.hash];
   if (transactionInfo) {
-    if (transactionInfo.status === TransactionStates.IN_BLOCK) {
+    if (transactionInfo.state === TransactionStates.IN_BLOCK) {
       const block = node.bc.getBlockByNumber(transactionInfo.number);
       const index = transactionInfo.index;
       if (!block) {
@@ -400,7 +400,7 @@ app.get('/get_transaction', (req, res, next) => {
       } else {
         transactionInfo.transaction = _.find(block.last_votes, (tx) => tx.hash === req.query.hash);
       }
-    } else if (transactionInfo.status === TransactionStates.IN_POOL) {
+    } else if (transactionInfo.state === TransactionStates.IN_POOL) {
       const address = transactionInfo.address;
       transactionInfo.transaction = _.find(node.tp.transactions[address], (tx) => tx.hash === req.query.hash);
     }

--- a/client/index.js
+++ b/client/index.js
@@ -15,7 +15,7 @@ const {
   PORT,
   BlockchainNodeStates,
   WriteDbOperations,
-  TransactionStatus,
+  TransactionStates,
 } = require('../common/constants');
 const { ConsensusStates } = require('../consensus/constants');
 
@@ -390,7 +390,7 @@ app.get('/tx_pool_size_util', (req, res) => {
 app.get('/get_transaction', (req, res, next) => {
   const transactionInfo = node.tp.transactionTracker[req.query.hash];
   if (transactionInfo) {
-    if (transactionInfo.status === TransactionStatus.BLOCK_STATUS) {
+    if (transactionInfo.status === TransactionStates.IN_BLOCK) {
       const block = node.bc.getBlockByNumber(transactionInfo.number);
       const index = transactionInfo.index;
       if (!block) {
@@ -400,7 +400,7 @@ app.get('/get_transaction', (req, res, next) => {
       } else {
         transactionInfo.transaction = _.find(block.last_votes, (tx) => tx.hash === req.query.hash);
       }
-    } else if (transactionInfo.status === TransactionStatus.POOL_STATUS) {
+    } else if (transactionInfo.status === TransactionStates.IN_POOL) {
       const address = transactionInfo.address;
       transactionInfo.transaction = _.find(node.tp.transactions[address], (tx) => tx.hash === req.query.hash);
     }

--- a/client/index.js
+++ b/client/index.js
@@ -17,7 +17,7 @@ const {
   WriteDbOperations,
   TransactionStatus,
 } = require('../common/constants');
-const { ConsensusStatus } = require('../consensus/constants');
+const { ConsensusStates } = require('../consensus/constants');
 
 const MAX_BLOCKS = 20;
 
@@ -59,7 +59,7 @@ app.get('/health_check', (req, res, next) => {
   const nodeStatus = p2pServer.getNodeStatus();
   const consensusState = p2pServer.consensus.getState();
   const result = nodeStatus.state === BlockchainNodeStates.SERVING &&
-      consensusState.state === ConsensusStatus.RUNNING &&
+      consensusState.state === ConsensusStates.RUNNING &&
       consensusState.health === true;
   res.status(200)
     .set('Content-Type', 'text/plain')

--- a/client/index.js
+++ b/client/index.js
@@ -57,10 +57,10 @@ app.get('/', (req, res, next) => {
 
 app.get('/health_check', (req, res, next) => {
   const nodeStatus = p2pServer.getNodeStatus();
-  const consensusState = p2pServer.consensus.getState();
+  const consensusStatus = p2pServer.consensus.getStatus();
   const result = nodeStatus.state === BlockchainNodeStates.SERVING &&
-      consensusState.state === ConsensusStates.RUNNING &&
-      consensusState.health === true;
+      consensusStatus.state === ConsensusStates.RUNNING &&
+      consensusStatus.health === true;
   res.status(200)
     .set('Content-Type', 'text/plain')
     .send(result)
@@ -435,16 +435,16 @@ app.get('/get_sharding', (req, res, next) => {
     .end();
 });
 
-app.get('/get_raw_consensus_state', (req, res) => {
-  const result = p2pServer.consensus.getRawState();
+app.get('/get_raw_consensus_status', (req, res) => {
+  const result = p2pServer.consensus.getRawStatus();
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})
     .end();
 });
 
-app.get('/get_consensus_state', (req, res) => {
-  const result = p2pServer.consensus.getState();
+app.get('/get_consensus_status', (req, res) => {
+  const result = p2pServer.consensus.getStatus();
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({code: 0, result})

--- a/common/constants.js
+++ b/common/constants.js
@@ -412,15 +412,15 @@ const FunctionResultCode = {
 };
 
 /**
- * Constant values for transactionTracker.
+ * Transaction states.
  *
  * @enum {string}
  */
-const TransactionStatus = {
-  BLOCK_STATUS: 'BLOCK',
-  POOL_STATUS: 'POOL',
-  TIMEOUT_STATUS: 'TIMEOUT',
-  FAIL_STATUS: 'FAIL'
+const TransactionStates = {
+  IN_BLOCK: 'IN_BLOCK',
+  IN_POOL: 'IN_POOL',
+  TIMED_OUT: 'TIMED_OUT',
+  FAILED: 'FAILED'
 };
 
 /**
@@ -764,7 +764,7 @@ module.exports = {
   TokenExchangeSchemes,
   ReadDbOperations,
   WriteDbOperations,
-  TransactionStatus,
+  TransactionStates,
   StateVersions,
   GenesisToken,
   GenesisAccounts,

--- a/consensus/constants.js
+++ b/consensus/constants.js
@@ -10,7 +10,7 @@ const ConsensusMessageTypes = {
   VOTE: 'vote'
 };
 
-const ConsensusStatus = {
+const ConsensusStates = {
   STARTING: 'STARTING',
   RUNNING: 'RUNNING',
   STOPPED: 'STOPPED',
@@ -19,5 +19,5 @@ const ConsensusStatus = {
 module.exports = {
   ConsensusMessageTypes,
   ConsensusConsts,
-  ConsensusStatus,
+  ConsensusStates,
 }

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -1137,7 +1137,7 @@ class Consensus {
    *   }
    * }
    */
-  getRawState() {
+  getRawStatus() {
     const result = {};
     result.consensus =
         Object.assign({}, { epoch: this.epoch, proposer: this.proposer }, { state: this.state });
@@ -1165,7 +1165,7 @@ class Consensus {
    *   epoch
    * }
    */
-  getState() {
+  getStatus() {
     const lastFinalizedBlock = this.node.bc.lastBlock();
     let health;
     if (!lastFinalizedBlock) {

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -50,7 +50,6 @@ class Consensus {
     this.node = node;
     this.state = null;
     this.stateChangedBlockNumber = null;
-    this.setter = '';
     this.setState(ConsensusStates.STARTING);
     this.consensusProtocolVersion = CONSENSUS_PROTOCOL_VERSION;
     this.majorConsensusProtocolVersion = VersionUtil.toMajorVersion(CONSENSUS_PROTOCOL_VERSION);
@@ -94,13 +93,13 @@ class Consensus {
         this.server.executeAndBroadcastTransaction(stakeTx);
       }
       this.blockPool = new BlockPool(this.node, lastBlockWithoutProposal);
-      this.setState(ConsensusStates.RUNNING, 'init');
+      this.setState(ConsensusStates.RUNNING);
       this.startEpochTransition();
       logger.info(`[${LOG_HEADER}] Initialized to number ${finalizedNumber} and ` +
           `epoch ${this.proposerStatus.epoch}`);
     } catch (err) {
       logger.error(`[${LOG_HEADER}] Init error: ${err} ${err.stack}`);
-      this.setState(ConsensusStates.STARTING, 'init');
+      this.setState(ConsensusStates.STARTING);
     }
   }
 
@@ -160,7 +159,7 @@ class Consensus {
 
   stop() {
     logger.info(`Stop epochInterval.`);
-    this.setState(ConsensusStates.STOPPED, 'stop');
+    this.setState(ConsensusStates.STOPPED);
     if (this.epochInterval) {
       clearInterval(this.epochInterval);
       this.epochInterval = null;
@@ -1122,13 +1121,11 @@ class Consensus {
     return this.state === ConsensusStates.RUNNING;
   }
 
-  setState(status, setter = '') {
+  setState(state) {
     const LOG_HEADER = 'setState';
-    logger.info(`[${LOG_HEADER}] setting consensus status from ${this.state} to ` +
-        `${status} (setter = ${setter})`);
-    this.state = status;
+    logger.info(`[${LOG_HEADER}] Setting consensus state from ${this.state} to ${state}`);
+    this.state = state;
     this.stateChangedBlockNumber = this.node.bc.lastBlockNumber();
-    this.setter = setter;
   }
 
   /**

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -214,7 +214,7 @@ class Consensus {
       return;
     }
     if (this.state !== ConsensusStates.RUNNING) {
-      logger.debug(`[${LOG_HEADER}] Consensus status (${this.state}) is not RUNNING ` +
+      logger.debug(`[${LOG_HEADER}] Consensus state (${this.state}) is not RUNNING ` +
           `(${ConsensusStates.RUNNING})`);
       return;
     }

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -17,16 +17,14 @@ const {
   CHAINS_DIR,
   PredefinedDbPaths,
   WriteDbOperations,
-  OwnerProperties,
   RuleProperties,
   ShardingProperties,
   FunctionProperties,
   FunctionTypes,
   NativeFunctionIds,
-  buildOwnerPermissions
 } = require('../common/constants');
 const {
-  ConsensusStatus
+  ConsensusStates
 } = require('../consensus/constants');
 const ChainUtil = require('../common/chain-util');
 const {
@@ -112,7 +110,7 @@ async function waitUntilShardReporterStarts() {
   while (true) {
     consensusState = parseOrLog(syncRequest('GET', server1 + '/get_consensus_state')
         .body.toString('utf-8')).result;
-    if (consensusState && consensusState.state === ConsensusStatus.RUNNING) return;
+    if (consensusState && consensusState.state === ConsensusStates.RUNNING) return;
     await ChainUtil.sleep(1000);
   }
 }

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -106,11 +106,11 @@ function startServer(application, serverName, envVars, stdioInherit = false) {
 // Needed to make sure the shard initialization is finished
 // before other shard nodes start
 async function waitUntilShardReporterStarts() {
-  let consensusState;
+  let consensusStatus;
   while (true) {
-    consensusState = parseOrLog(syncRequest('GET', server1 + '/get_consensus_state')
+    consensusStatus = parseOrLog(syncRequest('GET', server1 + '/get_consensus_status')
         .body.toString('utf-8')).result;
-    if (consensusState && consensusState.state === ConsensusStates.RUNNING) return;
+    if (consensusStatus && consensusStatus.state === ConsensusStates.RUNNING) return;
     await ChainUtil.sleep(1000);
   }
 }

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -398,13 +398,13 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
       done(null, addProtocolVersion({result: NETWORK_ID}));
     },
 
-    net_consensusState: function(args, done) {
-      const result = p2pServer.consensus.getState();
+    net_consensusStatus: function(args, done) {
+      const result = p2pServer.consensus.getStatus();
       done(null, addProtocolVersion({result}));
     },
 
-    net_rawConsensusState: function(args, done) {
-      const result = p2pServer.consensus.getRawState();
+    net_rawConsensusStatus: function(args, done) {
+      const result = p2pServer.consensus.getRawStatus();
       done(null, addProtocolVersion({result}));
     }
   };

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -218,7 +218,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     ain_getTransactionByHash: function(args, done) {
       const transactionInfo = node.tp.transactionTracker[args.hash];
       if (transactionInfo) {
-        if (transactionInfo.status === TransactionStates.IN_BLOCK) {
+        if (transactionInfo.state === TransactionStates.IN_BLOCK) {
           const block = node.bc.getBlockByNumber(transactionInfo.number);
           const index = transactionInfo.index;
           if (!block) {
@@ -228,7 +228,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
           } else {
             transactionInfo.transaction = _.find(block.last_votes, (tx) => tx.hash === args.hash);
           }
-        } else if (transactionInfo.status === TransactionStates.IN_POOL) {
+        } else if (transactionInfo.state === TransactionStates.IN_POOL) {
           const address = transactionInfo.address;
           transactionInfo.transaction = _.find(node.tp.transactions[address], (tx) => tx.hash === args.hash);
         }

--- a/json_rpc/index.js
+++ b/json_rpc/index.js
@@ -7,7 +7,7 @@ const {
   CURRENT_PROTOCOL_VERSION,
   BlockchainNodeStates,
   ReadDbOperations,
-  TransactionStatus,
+  TransactionStates,
   TX_BYTES_LIMIT,
   BATCH_TX_LIST_SIZE_LIMIT,
   NETWORK_ID,
@@ -218,7 +218,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
     ain_getTransactionByHash: function(args, done) {
       const transactionInfo = node.tp.transactionTracker[args.hash];
       if (transactionInfo) {
-        if (transactionInfo.status === TransactionStatus.BLOCK_STATUS) {
+        if (transactionInfo.status === TransactionStates.IN_BLOCK) {
           const block = node.bc.getBlockByNumber(transactionInfo.number);
           const index = transactionInfo.index;
           if (!block) {
@@ -228,7 +228,7 @@ module.exports = function getMethods(node, p2pServer, minProtocolVersion, maxPro
           } else {
             transactionInfo.transaction = _.find(block.last_votes, (tx) => tx.hash === args.hash);
           }
-        } else if (transactionInfo.status === TransactionStatus.POOL_STATUS) {
+        } else if (transactionInfo.status === TransactionStates.IN_POOL) {
           const address = transactionInfo.address;
           transactionInfo.transaction = _.find(node.tp.transactions[address], (tx) => tx.hash === args.hash);
         }

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const P2pServer = require('./server');
 const Websocket = require('ws');
 const logger = require('../logger')('P2P_CLIENT');
-const { ConsensusStatus } = require('../consensus/constants');
+const { ConsensusStates } = require('../consensus/constants');
 const VersionUtil = require('../common/version-util');
 const {
   PORT,
@@ -333,7 +333,7 @@ class P2pClient {
               `${JSON.stringify(chainSegment, null, 2)}`);
           // Check catchup info is behind or equal to me
           if (number <= this.server.node.bc.lastBlockNumber()) {
-            if (this.server.consensus.status === ConsensusStatus.STARTING) {
+            if (this.server.consensus.state === ConsensusStates.STARTING) {
               if ((!chainSegment && !catchUpInfo) ||
                   number === this.server.node.bc.lastBlockNumber()) {
                 // Regard this situation as if you're synced.
@@ -359,7 +359,7 @@ class P2pClient {
                 logger.info(`[${LOG_HEADER}] Blockchain Node is now synced!`);
                 this.server.node.state = BlockchainNodeStates.SERVING;
               }
-              if (this.server.consensus.status === ConsensusStatus.STARTING) {
+              if (this.server.consensus.state === ConsensusStates.STARTING) {
                 this.server.consensus.init();
               }
             } else {
@@ -384,7 +384,7 @@ class P2pClient {
             if (number <= this.server.node.bc.lastBlockNumber()) {
               logger.info(`[${LOG_HEADER}] I am ahead ` +
                   `(${number} > ${this.server.node.bc.lastBlockNumber()}).`);
-              if (this.server.consensus.status === ConsensusStatus.STARTING) {
+              if (this.server.consensus.state === ConsensusStates.STARTING) {
                 this.server.consensus.init();
                 if (this.server.consensus.isRunning()) {
                   this.server.consensus.catchUp(catchUpInfo);

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -141,7 +141,7 @@ class P2pServer {
   getConsensusStatus() {
     return Object.assign(
       {},
-      this.consensus.getState(),
+      this.consensus.getStatus(),
       {
         longestNotarizedChainTipsSize: this.consensus.blockPool ?
             this.consensus.blockPool.longestNotarizedChainTips.length : 0

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -138,11 +138,11 @@ EOF
 
 while :
 do
-    consensusState=$(curl -X POST -H "Content-Type: application/json" --data "$(generate_post_data 'net_consensusState')" "http://localhost:8080/json-rpc" | jq -r '.result.result.state')
+    consensusStatus=$(curl -X POST -H "Content-Type: application/json" --data "$(generate_post_data 'net_consensusStatus')" "http://localhost:8080/json-rpc" | jq -r '.result.result.state')
     lastBlockNumber=$(curl -X POST -H "Content-Type: application/json" --data "$(generate_post_data 'ain_getRecentBlockNumber')" "http://localhost:8080/json-rpc" | jq -r '.result.result')
-    printf "\nconsensusState = ${consensusState}"
+    printf "\nconsensusStatus = ${consensusStatus}"
     printf "\nlastBlockNumber = ${lastBlockNumber}"
-    if [ "$consensusState" == "RUNNING" ]; then
+    if [ "$consensusStatus" == "RUNNING" ]; then
         printf "\nNode is synced & running!"
         printf "Time it took to sync in seconds: $SECONDS\n\n"
         break

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -60,7 +60,7 @@ class TransactionPool {
     }
     this.transactions[tx.address].push(tx);
     this.transactionTracker[tx.hash] = {
-      status: TransactionStates.IN_POOL,
+      state: TransactionStates.IN_POOL,
       address: tx.address,
       index: this.transactions[tx.address].length - 1,
       timestamp: tx.tx_body.timestamp,
@@ -388,8 +388,8 @@ class TransactionPool {
       }
       addrToTxSet[address].add(hash);
       const tracked = this.transactionTracker[hash];
-      if (tracked && tracked.status !== TransactionStates.IN_BLOCK) {
-        this.transactionTracker[hash].status = TransactionStates.FAILED;
+      if (tracked && tracked.state !== TransactionStates.IN_BLOCK) {
+        this.transactionTracker[hash].state = TransactionStates.FAILED;
       }
     });
     for (const address in addrToTxSet) {
@@ -414,7 +414,7 @@ class TransactionPool {
       const txTimestamp = voteTx.tx_body.timestamp;
       // voting txs with ordered nonces.
       this.transactionTracker[voteTx.hash] = {
-        status: TransactionStates.IN_BLOCK,
+        state: TransactionStates.IN_BLOCK,
         number: block.number,
         index: -1,
         address: voteTx.address,
@@ -431,7 +431,7 @@ class TransactionPool {
       const txTimestamp = tx.tx_body.timestamp;
       // Update transaction tracker.
       this.transactionTracker[tx.hash] = {
-        status: TransactionStates.IN_BLOCK,
+        state: TransactionStates.IN_BLOCK,
         number: block.number,
         index: i,
         address: tx.address,
@@ -517,8 +517,8 @@ class TransactionPool {
             `  =>> Checked remote transaction: ${JSON.stringify(trackingInfo, null, 2)} ` +
             `with result: ${JSON.stringify(result, null, 2)}`);
         if (result && (result.is_finalized ||
-            result.status === TransactionStates.FAILED ||
-            result.status === TransactionStates.TIMED_OUT)) {
+            result.state === TransactionStates.FAILED ||
+            result.state === TransactionStates.TIMED_OUT)) {
           this.doAction(trackingInfo.action, result.is_finalized);
           delete this.remoteTransactionTracker[txHash];
         }

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -96,7 +96,7 @@ describe("p2p", () => {
     });
 
     describe("getConsensusStatus", () => {
-      it("gets initial consensus status", () => {
+      it("gets initial consensus state", () => {
         const actual = {
           health: false,
           state: 'STARTING',


### PR DESCRIPTION
Change summary:
- Rename consensus state terms:
  - ConsensusStatus -> ConsensusStates
  - Consensus.status -> Consensus.state
  - Consensus.state -> Consensus.proposerStatus
  - Remove Consensus.setter 
- Rename transaction state terms:
  - TransactionStatue -> TransactionState
  - BLOCK -> IN_BLOCK, POOL -> IN_POOL, TIMEOUT -> TIMED_OUT, FAIL -> FAILED
- Rename client API:
  - /get_raw_consensus_state -> /get_raw_consensus_status
  - /get_consensus_state -> /get_consensus_status
- Rename JSON RPC API:
  - net_consensusState() -> net_consensusStatus()
  - net_rawConsensusState() -> net_rawConsensusStatus()

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/452 