### PR TITLE
Add closed type to pull_request

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,6 +11,7 @@ on:
       - 'develop'
       - 'release/*'
       - 'master'
+    types: [opened, synchronize, reopened, closed]
 jobs:
   build_and_test:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}


### PR DESCRIPTION
## Background
- Performance test pipeline need to catch 'closed' event

## Description
- When declaring event types, the default value disappears, so I added `closed` to the default values.
- Refer to [docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request), default event type are 'opened, synchronize, reopened'. 