### PR TITLE
Move entry point labels to PredefinedDbPaths from *Properties

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -119,6 +119,11 @@ const PredefinedDbPaths = {
   RULES_ROOT: 'rules',
   FUNCTIONS_ROOT: 'functions',
   VALUES_ROOT: 'values',
+  // Entry point labels (.*)
+  DOT_RULE: '.rule',
+  DOT_FUNCTION: '.function',
+  DOT_OWNER: '.owner',
+  DOT_SHARD: '.shard',
   // Consensus
   CONSENSUS: 'consensus',
   WHITELIST: 'whitelist',
@@ -235,7 +240,6 @@ const OwnerProperties = {
   ANYONE: '*',
   BRANCH_OWNER: 'branch_owner',
   FID_PREFIX: 'fid:',
-  OWNER: '.owner',
   OWNERS: 'owners',
   WRITE_FUNCTION: 'write_function',
   WRITE_OWNER: 'write_owner',
@@ -248,7 +252,6 @@ const OwnerProperties = {
  * @enum {string}
  */
 const RuleProperties = {
-  RULE: '.rule',
   WRITE: 'write',
 };
 
@@ -259,7 +262,6 @@ const RuleProperties = {
  */
 const FunctionProperties = {
   EVENT_LISTENER: 'event_listener',
-  FUNCTION: '.function',
   FUNCTION_ID: 'function_id',
   FUNCTION_TYPE: 'function_type',
   SERVICE_NAME: 'service_name',
@@ -335,7 +337,6 @@ const ShardingProperties = {
   PROOF_HASH: 'proof_hash',
   PROOF_HASH_MAP: 'proof_hash_map',
   REPORTING_PERIOD: 'reporting_period',
-  SHARD: '.shard',
   SHARD_OWNER: 'shard_owner',
   SHARD_REPORTER: 'shard_reporter',
   SHARDING_ENABLED: 'sharding_enabled',
@@ -680,7 +681,7 @@ function getShardingRule() {
   const ownerAddress =
       CommonUtil.getJsObject(GenesisAccounts, [AccountProperties.OWNER, AccountProperties.ADDRESS]);
   return {
-    [RuleProperties.RULE]: {
+    [PredefinedDbPaths.DOT_RULE]: {
       [RuleProperties.WRITE]: `auth.addr === '${ownerAddress}'`,
     }
   };
@@ -688,7 +689,7 @@ function getShardingRule() {
 
 function getShardingOwner() {
   return {
-    [OwnerProperties.OWNER]: {
+    [PredefinedDbPaths.DOT_OWNER]: {
       [OwnerProperties.OWNERS]: {
         [GenesisAccounts.owner.address]: buildOwnerPermissions(false, true, true, true),
         [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
@@ -699,7 +700,7 @@ function getShardingOwner() {
 
 function getWhitelistOwner() {
   return {
-    [OwnerProperties.OWNER]: {
+    [PredefinedDbPaths.DOT_OWNER]: {
       [OwnerProperties.OWNERS]: {
         [GenesisAccounts.owner.address]: buildOwnerPermissions(false, true, true, true),
         [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
@@ -719,7 +720,7 @@ function buildOwnerPermissions(branchOwner, writeFunction, writeOwner, writeRule
 
 function buildRulePermission(rule) {
   return {
-    [RuleProperties.RULE]: {
+    [PredefinedDbPaths.DOT_RULE]: {
       [RuleProperties.WRITE]: rule
     }
   };

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -1089,7 +1089,7 @@ class Consensus {
         }
         opList.push({
           type: WriteDbOperations.SET_VALUE,
-          ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+          ref: `${shardingPath}/${PredefinedDbPaths.DOT_SHARD}/` +
               `${ShardingProperties.PROOF_HASH_MAP}/${blockNumberToReport}/` +
               `${ShardingProperties.PROOF_HASH}`,
           value: block.state_proof_hash
@@ -1099,7 +1099,7 @@ class Consensus {
           // Remove old reports
           opList.push({
             type: WriteDbOperations.SET_VALUE,
-            ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+            ref: `${shardingPath}/${PredefinedDbPaths.DOT_SHARD}/` +
                 `${ShardingProperties.PROOF_HASH_MAP}/` +
                 `${blockNumberToReport - MAX_SHARD_REPORT}/` +
                 `${ShardingProperties.PROOF_HASH}`,
@@ -1135,7 +1135,7 @@ class Consensus {
         'ain_get',
         {
           type: ReadDbOperations.GET_VALUE,
-          ref: `${shardingPath}/${ShardingProperties.SHARD}/` +
+          ref: `${shardingPath}/${PredefinedDbPaths.DOT_SHARD}/` +
           `${ShardingProperties.PROOF_HASH_MAP}/${ShardingProperties.LATEST}`
         }
     );

--- a/db/functions.js
+++ b/db/functions.js
@@ -300,7 +300,7 @@ class Functions {
 
     for (const key in obj) {
       const childObj = obj[key];
-      if (key === FunctionProperties.FUNCTION) {
+      if (key === PredefinedDbPaths.DOT_FUNCTION) {
         if (CommonUtil.isDict(childObj) && !CommonUtil.isEmpty(childObj)) {
           for (const fid in childObj) {
             const nativeFunction = this.nativeFunctionMap[fid];
@@ -489,7 +489,7 @@ class Functions {
     const parsedValuePath = context.valuePath;
     const auth = context.auth;
     const owner = {
-      [OwnerProperties.OWNER]: {
+      [PredefinedDbPaths.DOT_OWNER]: {
         [OwnerProperties.OWNERS]: {
           [auth.addr]: buildOwnerPermissions(false, true, true, true),
           [OwnerProperties.ANYONE]: buildOwnerPermissions(false, true, true, true),
@@ -561,7 +561,7 @@ class Functions {
       const adminAddrList = Object.keys(adminConfig);
       for (let i = 0; i < adminAddrList.length; i++) {
         const addr = adminAddrList[i];
-        CommonUtil.setJsObject(owner, [OwnerProperties.OWNER, OwnerProperties.OWNERS, addr],
+        CommonUtil.setJsObject(owner, [PredefinedDbPaths.DOT_OWNER, OwnerProperties.OWNERS, addr],
             buildOwnerPermissions(true, true, true, true));
         rule += `auth.addr === '${addr}'` + (i < adminAddrList.length - 1 ? ' || ' : '');
       }

--- a/db/index.js
+++ b/db/index.js
@@ -72,7 +72,7 @@ class DB {
     } else {
       // Initialize DB owners.
       this.writeDatabase([PredefinedDbPaths.OWNERS_ROOT], {
-        [OwnerProperties.OWNER]: {
+        [PredefinedDbPaths.DOT_OWNER]: {
           [OwnerProperties.OWNERS]: {
             [OwnerProperties.ANYONE]: buildOwnerPermissions(true, true, true, true),
           }
@@ -80,7 +80,7 @@ class DB {
       });
       // Initialize DB rules.
       this.writeDatabase([PredefinedDbPaths.RULES_ROOT], {
-        [RuleProperties.RULE]: {
+        [PredefinedDbPaths.DOT_RULE]: {
           [RuleProperties.WRITE]: true
         }
       });

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const validUrl = require('valid-url');
 const CommonUtil = require('../common/common-util');
 const {
+  PredefinedDbPaths,
   FunctionProperties,
   FunctionTypes,
   isNativeFunctionId,
@@ -28,35 +29,35 @@ function getConfig(node, label) {
 }
 
 function hasShardConfig(valueNode) {
-  return hasConfig(valueNode, ShardingProperties.SHARD);
+  return hasConfig(valueNode, PredefinedDbPaths.DOT_SHARD);
 }
 
 function getShardConfig(valueNode) {
-  return getConfig(valueNode, ShardingProperties.SHARD);
+  return getConfig(valueNode, PredefinedDbPaths.DOT_SHARD);
 }
 
 function hasFunctionConfig(funcNode) {
-  return hasConfig(funcNode, FunctionProperties.FUNCTION);
+  return hasConfig(funcNode, PredefinedDbPaths.DOT_FUNCTION);
 }
 
 function getFunctionConfig(funcNode) {
-  return getConfig(funcNode, FunctionProperties.FUNCTION);
+  return getConfig(funcNode, PredefinedDbPaths.DOT_FUNCTION);
 }
 
 function hasRuleConfig(ruleNode) {
-  return hasConfig(ruleNode, RuleProperties.RULE);
+  return hasConfig(ruleNode, PredefinedDbPaths.DOT_RULE);
 }
 
 function getRuleConfig(ruleNode) {
-  return getConfig(ruleNode, RuleProperties.RULE);
+  return getConfig(ruleNode, PredefinedDbPaths.DOT_RULE);
 }
 
 function hasOwnerConfig(ownerNode) {
-  return hasConfig(ownerNode, OwnerProperties.OWNER);
+  return hasConfig(ownerNode, PredefinedDbPaths.DOT_OWNER);
 }
 
 function getOwnerConfig(ownerNode) {
-  return getConfig(ownerNode, OwnerProperties.OWNER);
+  return getConfig(ownerNode, PredefinedDbPaths.DOT_OWNER);
 }
 
 function hasEnabledShardConfig(node) {
@@ -73,7 +74,7 @@ function isWritablePathWithSharding(fullPath, root) {
   const path = [];
   let curNode = root;
   for (const label of fullPath) {
-    if (label !== ShardingProperties.SHARD && hasEnabledShardConfig(curNode)) {
+    if (label !== PredefinedDbPaths.DOT_SHARD && hasEnabledShardConfig(curNode)) {
       isValid = false;
       break;
     }
@@ -364,7 +365,7 @@ function isValidRuleTree(ruleTreeObj) {
     return { isValid: true, invalidPath: '' };
   }
 
-  return isValidConfigTreeRecursive(ruleTreeObj, [], RuleProperties.RULE, isValidRuleConfig);
+  return isValidConfigTreeRecursive(ruleTreeObj, [], PredefinedDbPaths.DOT_RULE, isValidRuleConfig);
 }
 
 /**
@@ -376,7 +377,7 @@ function isValidFunctionTree(functionTreeObj) {
   }
 
   return isValidConfigTreeRecursive(
-      functionTreeObj, [], FunctionProperties.FUNCTION, isValidFunctionConfig);
+      functionTreeObj, [], PredefinedDbPaths.DOT_FUNCTION, isValidFunctionConfig);
 }
 
 /**
@@ -387,7 +388,8 @@ function isValidOwnerTree(ownerTreeObj) {
     return { isValid: true, invalidPath: '' };
   }
 
-  return isValidConfigTreeRecursive(ownerTreeObj, [], OwnerProperties.OWNER, isValidOwnerConfig);
+  return isValidConfigTreeRecursive(
+      ownerTreeObj, [], PredefinedDbPaths.DOT_OWNER, isValidOwnerConfig);
 }
 
 /**
@@ -427,22 +429,22 @@ function hasConfigLabelOnly(stateTreeObj, configLabel) {
 function applyFunctionChange(curFuncTree, functionChange) {
   // NOTE(platfowner): Partial set is applied only when the current function tree has
   // .function property and the function change has .function property as the only property.
-  if (!hasConfigLabel(curFuncTree, FunctionProperties.FUNCTION) ||
-      !hasConfigLabelOnly(functionChange, FunctionProperties.FUNCTION)) {
+  if (!hasConfigLabel(curFuncTree, PredefinedDbPaths.DOT_FUNCTION) ||
+      !hasConfigLabelOnly(functionChange, PredefinedDbPaths.DOT_FUNCTION)) {
     return CommonUtil.isDict(functionChange) ?
         JSON.parse(JSON.stringify(functionChange)) : functionChange;
   }
-  const funcChangeMap = CommonUtil.getJsObject(functionChange, [FunctionProperties.FUNCTION]);
+  const funcChangeMap = CommonUtil.getJsObject(functionChange, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!funcChangeMap || Object.keys(funcChangeMap).length === 0) {
     return curFuncTree;
   }
   const newFuncConfig =
       CommonUtil.isDict(curFuncTree) ? JSON.parse(JSON.stringify(curFuncTree)) : {};
-  let newFuncMap = CommonUtil.getJsObject(newFuncConfig, [FunctionProperties.FUNCTION]);
+  let newFuncMap = CommonUtil.getJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!CommonUtil.isDict(newFuncMap)) {
     // Add a place holder.
-    CommonUtil.setJsObject(newFuncConfig, [FunctionProperties.FUNCTION], {});
-    newFuncMap = CommonUtil.getJsObject(newFuncConfig, [FunctionProperties.FUNCTION]);
+    CommonUtil.setJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION], {});
+    newFuncMap = CommonUtil.getJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
   }
   for (const functionKey in funcChangeMap) {
     const functionInfo = funcChangeMap[functionKey];
@@ -465,12 +467,12 @@ function applyFunctionChange(curFuncTree, functionChange) {
 function applyOwnerChange(curOwnerTree, ownerChange) {
   // NOTE(platfowner): Partial set is applied only when the current owner tree has
   // .owner property and the owner change has .owner property as the only property.
-  if (!hasConfigLabel(curOwnerTree, OwnerProperties.OWNER) ||
-      !hasConfigLabelOnly(ownerChange, OwnerProperties.OWNER)) {
+  if (!hasConfigLabel(curOwnerTree, PredefinedDbPaths.DOT_OWNER) ||
+      !hasConfigLabelOnly(ownerChange, PredefinedDbPaths.DOT_OWNER)) {
     return CommonUtil.isDict(ownerChange) ?
         JSON.parse(JSON.stringify(ownerChange)) : ownerChange;
   }
-  const ownerMapPath = [OwnerProperties.OWNER, OwnerProperties.OWNERS];
+  const ownerMapPath = [PredefinedDbPaths.DOT_OWNER, OwnerProperties.OWNERS];
   const ownerChangeMap = CommonUtil.getJsObject(ownerChange, ownerMapPath);
   if (!ownerChangeMap || Object.keys(ownerChangeMap).length === 0) {
     return curOwnerTree;

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -1960,7 +1960,7 @@ describe('Sharding', async () => {
                 type: WriteDbOperations.SET_RULE,
                 ref: `${sharding_path}/${ShardingProperties.LATEST}`,
                 value: {
-                  [RuleProperties.RULE]: {
+                  [PredefinedDbPaths.DOT_RULE]: {
                     [RuleProperties.WRITE]: `auth.fid === '${NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT}'`
                   }
                 }
@@ -1969,7 +1969,7 @@ describe('Sharding', async () => {
                 type: WriteDbOperations.SET_FUNCTION,
                 ref: `${sharding_path}/$block_number/${ShardingProperties.PROOF_HASH}`,
                 value: {
-                  [FunctionProperties.FUNCTION]: {
+                  [PredefinedDbPaths.DOT_FUNCTION]: {
                     [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: {
                       [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
                       [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT

--- a/node/index.js
+++ b/node/index.js
@@ -264,9 +264,9 @@ class BlockchainNode {
         const shardPath = ainUtil.decode(encodedPath);
         shardingInfo[encodedPath] = {
           [ShardingProperties.SHARDING_ENABLED]: this.db.getValue(CommonUtil.appendPath(
-              shardPath, ShardingProperties.SHARD, ShardingProperties.SHARDING_ENABLED)),
+              shardPath, PredefinedDbPaths.DOT_SHARD, ShardingProperties.SHARDING_ENABLED)),
           [ShardingProperties.LATEST_BLOCK_NUMBER]: this.db.getValue(CommonUtil.appendPath(
-              shardPath, ShardingProperties.SHARD, ShardingProperties.PROOF_HASH_MAP,
+              shardPath, PredefinedDbPaths.DOT_SHARD, ShardingProperties.PROOF_HASH_MAP,
               ShardingProperties.LATEST)),
         };
       }

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -665,10 +665,10 @@ class P2pServer {
     const proofHashRulesLight = `auth.addr === '${shardReporter}'`;
     const proofHashRules = `auth.addr === '${shardReporter}' && ` +
         '((newData === null && ' +
-        `Number($block_number) < (getValue('${shardingPath}/${ShardingProperties.SHARD}/` +
+        `Number($block_number) < (getValue('${shardingPath}/${PredefinedDbPaths.DOT_SHARD}/` +
             `${ShardingProperties.PROOF_HASH_MAP}/latest') || 0)) || ` +
         '(newData !== null && ($block_number === "0" || ' +
-        `$block_number === String((getValue('${shardingPath}/${ShardingProperties.SHARD}/` +
+        `$block_number === String((getValue('${shardingPath}/${PredefinedDbPaths.DOT_SHARD}/` +
             `${ShardingProperties.PROOF_HASH_MAP}/latest') || 0) + 1))))`;
     const latestBlockNumberRules = `auth.fid === '${NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT}'`;
     return {
@@ -679,12 +679,12 @@ class P2pServer {
             type: WriteDbOperations.SET_RULE,
             ref: CommonUtil.appendPath(
                 shardingPath,
-                ShardingProperties.SHARD,
+                PredefinedDbPaths.DOT_SHARD,
                 ShardingProperties.PROOF_HASH_MAP,
                 '$block_number',
                 ShardingProperties.PROOF_HASH),
             value: {
-              [RuleProperties.RULE]: {
+              [PredefinedDbPaths.DOT_RULE]: {
                 [RuleProperties.WRITE]: LIGHTWEIGHT ? proofHashRulesLight : proofHashRules
               }
             }
@@ -693,11 +693,11 @@ class P2pServer {
             type: WriteDbOperations.SET_RULE,
             ref: CommonUtil.appendPath(
                 shardingPath,
-                ShardingProperties.SHARD,
+                PredefinedDbPaths.DOT_SHARD,
                 ShardingProperties.PROOF_HASH_MAP,
                 ShardingProperties.LATEST),
             value: {
-              [RuleProperties.RULE]: {
+              [PredefinedDbPaths.DOT_RULE]: {
                 [RuleProperties.WRITE]: latestBlockNumberRules
               }
             }
@@ -706,12 +706,12 @@ class P2pServer {
             type: WriteDbOperations.SET_FUNCTION,
             ref: CommonUtil.appendPath(
                 shardingPath,
-                ShardingProperties.SHARD,
+                PredefinedDbPaths.DOT_SHARD,
                 ShardingProperties.PROOF_HASH_MAP,
                 '$block_number',
                 ShardingProperties.PROOF_HASH),
             value: {
-              [FunctionProperties.FUNCTION]: {
+              [PredefinedDbPaths.DOT_FUNCTION]: {
                 [NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT]: {
                   [FunctionProperties.FUNCTION_TYPE]: FunctionTypes.NATIVE,
                   [FunctionProperties.FUNCTION_ID]: NativeFunctionIds.UPDATE_LATEST_SHARD_REPORT
@@ -723,7 +723,7 @@ class P2pServer {
             type: WriteDbOperations.SET_VALUE,
             ref: shardingPath,
             value: {
-              [ShardingProperties.SHARD]: {
+              [PredefinedDbPaths.DOT_SHARD]: {
                 [ShardingProperties.SHARDING_ENABLED]: true,
                 [ShardingProperties.PROOF_HASH_MAP]: {
                   [ShardingProperties.LATEST]: -1,


### PR DESCRIPTION
Change summary:
- Move entry point labels to PredefinedDbPaths from *Properties

Rationale:
- They're actually not part of properties but predefined db paths

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/473 