### PR TITLE
Fix sharding setup & scripts.

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -474,7 +474,7 @@ class BlockchainNode {
         baseVersion, `${StateVersions.SEGMENT}:${this.bc.lastBlockNumber()}`,
         this.bc.lastBlockNumber());
     if (!tempDb) {
-      logger.error(`Failed to create a temp database with state version: ${baseVersion}.`);
+      logger.error(`[${LOG_HEADER}] Failed to create a temp database with state version: ${baseVersion}.`);
       return null;
     }
     const validBlocks = this.bc.getValidBlocksInChainSegment(chainSegment);

--- a/start_servers_afan_local.sh
+++ b/start_servers_afan_local.sh
@@ -1,5 +1,5 @@
 # PARENT CHAIN
-CONSOLE_LOG=true node ./tracker-server/index.js &
+CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5
 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 5
@@ -9,10 +9,22 @@ MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=
 sleep 15
 
 # AFAN CHILD CHAIN
-GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9010 P2P_PORT=6000 CONSOLE_LOG=true node ./tracker-server/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9010 P2P_PORT=6000 CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5
 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9011 P2P_PORT=6001 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 5
+
+while :
+do
+    nodeState=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:9011/node_status" | jq -r '.result.state')
+    printf "\nnodeState = ${nodeState}\n"
+    if [[ "$nodeState" = "SERVING" ]]; then
+        printf "\nShard node 0 is now serving!\n"
+        break
+    fi
+    sleep 20
+done
+
 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9012 P2P_PORT=6002 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 5
 GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9013 P2P_PORT=6003 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &

--- a/start_servers_afan_local.sh
+++ b/start_servers_afan_local.sh
@@ -9,14 +9,14 @@ MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=
 sleep 15
 
 # AFAN CHILD CHAIN
-GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9010 P2P_PORT=6000 CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9000 P2P_PORT=6000 CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5
-GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9011 P2P_PORT=6001 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9001 P2P_PORT=6001 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 5
 
 while :
 do
-    nodeState=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:9011/node_status" | jq -r '.result.state')
+    nodeState=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:9001/node_status" | jq -r '.result.state')
     printf "\nnodeState = ${nodeState}\n"
     if [[ "$nodeState" = "SERVING" ]]; then
         printf "\nShard node 0 is now serving!\n"
@@ -25,7 +25,7 @@ do
     sleep 20
 done
 
-GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9012 P2P_PORT=6002 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9002 P2P_PORT=6002 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 5
-GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9013 P2P_PORT=6003 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9003 P2P_PORT=6003 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 15

--- a/start_servers_local.sh
+++ b/start_servers_local.sh
@@ -1,10 +1,10 @@
 # PARENT CHAIN
-node ./tracker-server/index.js &
+BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5
 MIN_NUM_VALIDATORS=5 ACCOUNT_INDEX=0 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
 MIN_NUM_VALIDATORS=5 ACCOUNT_INDEX=1 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
-sleep 1
+sleep 10
 MIN_NUM_VALIDATORS=5 ACCOUNT_INDEX=2 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
 MIN_NUM_VALIDATORS=5 ACCOUNT_INDEX=3 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
@@ -13,21 +13,45 @@ MIN_NUM_VALIDATORS=5 ACCOUNT_INDEX=4 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SE
 sleep 10
 
 # CHILD CHAIN 1
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9010 P2P_PORT=6010 node ./tracker-server/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9000 P2P_PORT=6000 BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9011 P2P_PORT=6011 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9001 P2P_PORT=6001 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9012 P2P_PORT=6012 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+
+while :
+do
+    nodeState=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:9001/node_status" | jq -r '.result.state')
+    printf "\nnodeState = ${nodeState}\n"
+    if [[ "$nodeState" = "SERVING" ]]; then
+        printf "\nShard node 0 is now serving!\n"
+        break
+    fi
+    sleep 20
+done
+
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9002 P2P_PORT=6002 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9013 P2P_PORT=6013 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/afan-shard PORT=9003 P2P_PORT=6003 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
 
 # CHILD CHAIN 2
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9020 P2P_PORT=6020 node ./tracker-server/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9010 P2P_PORT=6010 BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9021 P2P_PORT=6021 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9011 P2P_PORT=6011 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=0 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9022 P2P_PORT=6022 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+
+while :
+do
+    nodeState=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:9011/node_status" | jq -r '.result.state')
+    printf "\nnodeState = ${nodeState}\n"
+    if [[ "$nodeState" = "SERVING" ]]; then
+        printf "\nShard node 0 is now serving!\n"
+        break
+    fi
+    sleep 20
+done
+
+GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9012 P2P_PORT=6012 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=1 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10
-GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9023 P2P_PORT=6023 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 TRACKER_WS_ADDR=ws://localhost:6020 STAKE=250 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
+GENESIS_CONFIGS_DIR=genesis-configs/sim-shard PORT=9013 P2P_PORT=6013 MIN_NUM_VALIDATORS=3 ACCOUNT_INDEX=2 STAKE=100000 CONSOLE_LOG=true ENABLE_DEV_SET_CLIENT_API=true ENABLE_TX_SIG_VERIF_WORKAROUND=true ENABLE_GAS_FEE_WORKAROUND=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./client/index.js &
 sleep 10


### PR DESCRIPTION
- Problem 1: Sharding set up was not finalizing 
  - #482 made it possible to set up sharding apps without staking
- Problem 2: If non-first nodes are started when the first node is alive but is not ready to serve, their initial `CHAIN_SEGMENT_REQUEST`s are ignored and the non-first nodes never request again, thus being unable to sync
  - Updated scripts to wait until the first node is in `SERVING` state
  - Changed to request for blocks when a consensus message was received but the node's state is not `SERVING`
- Problem 3: In `start_servers_local.sh`, two shards were sharing the same sharding config file
  - Changed one of them to use afan-shard and the other to use sim-shard.


Fixes https://github.com/ainblockchain/ain-blockchain/issues/474