### PR TITLE
Add blockchain owner as the root owner in genesis

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -243,8 +243,8 @@ class CommonUtil {
    * Sets a value to the given path of an object. If the given path is empty, it tries to copy
    * the first-level properties of the value to the object.
    * 
-   * @param {*} obj target object
-   * @param {*} path target path
+   * @param {object} obj target object
+   * @param {array} path target path
    * @param {*} value value to set
    * @returns true if any changes are done, otherwise false
    */

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -239,6 +239,15 @@ class CommonUtil {
     return ref === undefined ? null : ref;
   }
 
+  /**
+   * Sets a value to the given path of an object. If the given path is empty, it tries to copy
+   * the first-level properties of the value to the object.
+   * 
+   * @param {*} obj target object
+   * @param {*} path target path
+   * @param {*} value value to set
+   * @returns true if any changes are done, otherwise false
+   */
   static setJsObject(obj, path, value) {
     if (!CommonUtil.isArray(path)) {
       return false;
@@ -247,7 +256,15 @@ class CommonUtil {
       return false;
     }
     if (path.length === 0) {
-      return false;
+      if (!CommonUtil.isDict(value)) {
+        return false;
+      }
+      for (const key in value) {
+        if (value.hasOwnProperty(key)) {
+          obj[key] = value[key];
+        }
+      }
+      return true;
     }
     let ref = obj;
     for (let i = 0; i < path.length - 1; i++) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -686,7 +686,8 @@ function getGenesisRules() {
 }
 
 function getGenesisOwners() {
-  const owners = getGenesisConfig('genesis_owners.json', process.env.ADDITIONAL_OWNERS);
+  let owners = getGenesisConfig('genesis_owners.json', process.env.ADDITIONAL_OWNERS);
+  CommonUtil.setJsObject(owners, [], getRootOwner());
   if (GenesisSharding[ShardingProperties.SHARDING_PROTOCOL] !== ShardingProtocols.NONE) {
     CommonUtil.setJsObject(
         owners, [PredefinedDbPaths.SHARDING, PredefinedDbPaths.SHARDING_CONFIG],
@@ -703,6 +704,17 @@ function getShardingRule() {
   return {
     [PredefinedDbPaths.DOT_RULE]: {
       [RuleProperties.WRITE]: `auth.addr === '${ownerAddress}'`,
+    }
+  };
+}
+
+function getRootOwner() {
+  return {
+    [PredefinedDbPaths.DOT_OWNER]: {
+      [OwnerProperties.OWNERS]: {
+        [GenesisAccounts.owner.address]: buildOwnerPermissions(true, true, true, true),
+        [OwnerProperties.ANYONE]: buildOwnerPermissions(false, false, false, false),
+      }
     }
   };
 }

--- a/unittest/common-util.test.js
+++ b/unittest/common-util.test.js
@@ -247,9 +247,25 @@ describe("CommonUtil", () => {
       assert.deepEqual(obj.b.ba.baz, value);
     })
 
-    it("when empty path", () => {
-      expect(CommonUtil.setJsObject(obj, [], value)).to.equal(false);
+    it("when empty path with primitive value", () => {
+      expect(CommonUtil.setJsObject(obj, [], 'some value')).to.equal(false);
       assert.deepEqual(obj, org);  // No change.
+    })
+
+    it("when empty path with object value", () => {
+      expect(CommonUtil.setJsObject(obj, [], value)).to.equal(true);
+      for (const key in value) {
+        if (value.hasOwnProperty(key)) {
+          expect(obj.hasOwnProperty(key)).to.equal(true);
+          assert.deepEqual(obj[key], value[key]);
+        }
+      }
+      for (const key in org) {
+        if (org.hasOwnProperty(key)) {
+          expect(obj.hasOwnProperty(key)).to.equal(true);
+          assert.deepEqual(obj[key], org[key]);
+        }
+      }
     })
 
     it("when existing path", () => {

--- a/unittest/common-util.test.js
+++ b/unittest/common-util.test.js
@@ -205,7 +205,8 @@ describe("CommonUtil", () => {
       }
     };
     const value = {
-      some: 'value'
+      some: 'value',
+      b: 'other b value'
     };
     let obj;
 
@@ -261,7 +262,7 @@ describe("CommonUtil", () => {
         }
       }
       for (const key in org) {
-        if (org.hasOwnProperty(key)) {
+        if (org.hasOwnProperty(key) && !value.hasOwnProperty(key)) {
           expect(obj.hasOwnProperty(key)).to.equal(true);
           assert.deepEqual(obj[key], org[key]);
         }

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -2457,7 +2457,7 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         assert.deepEqual(node.db.executeTransaction(overSizeTx, node.bc.lastBlockNumber() + 1), {
           "code": 25,
-          "error_message": "Exceeded state budget limit for services (10379080 > 10000000)",
+          "error_message": "Exceeded state budget limit for services (10381522 > 10000000)",
           "bandwidth_gas_amount": 0
         });
       });


### PR DESCRIPTION
Change summary:
- Add blockchain owner as the root owner in genesis
- Extend setJsObject() for empty paths

Related issues: https://github.com/ainblockchain/ain-blockchain/issues/490 