### PR TITLE
Add cpu status to tracker server

### DIFF
--- a/monitoring/grafana.json
+++ b/monitoring/grafana.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -24,10 +24,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -54,7 +50,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -117,10 +113,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -147,7 +139,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -210,10 +202,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -240,7 +228,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -303,10 +291,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -333,7 +317,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -396,10 +380,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -426,7 +406,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -490,10 +470,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -520,7 +496,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -578,97 +554,85 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 24
       },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 38,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.5.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
-          "expr": "disk_status:used",
+          "exemplar": true,
+          "expr": "disk_status:usage_percent",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "disk_status:used",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "disk_status:usage_percent",
+      "type": "timeseries"
     },
     {
       "aliasColors": {},
@@ -676,10 +640,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -706,7 +666,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -769,10 +729,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -782,7 +738,7 @@
         "y": 32
       },
       "hiddenSeries": false,
-      "id": 14,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -799,7 +755,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -809,7 +765,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "memory_status:heap_stats:used_heap_size",
+          "exemplar": true,
+          "expr": "disk_status:usage",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -819,7 +776,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "memory_status:heap_stats:used_heap_size",
+      "title": "disk_status:usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -862,10 +819,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -892,7 +845,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -950,97 +903,85 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 40
       },
-      "hiddenSeries": false,
-      "id": 30,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 40,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.5.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
-          "expr": "memory_status:heap_stats:malloced_memory",
+          "exemplar": true,
+          "expr": "memory_status:os:usage_percent",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "memory_status:heap_stats:malloced_memory",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "memory_status:os:usage_percent",
+      "type": "timeseries"
     },
     {
       "aliasColors": {},
@@ -1048,10 +989,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1078,7 +1015,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1141,10 +1078,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1154,7 +1087,7 @@
         "y": 48
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 14,
       "legend": {
         "avg": false,
         "current": false,
@@ -1171,7 +1104,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1181,7 +1114,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_status:state_version_status:num_versions",
+          "expr": "memory_status:heap_stats:used_heap_size",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1191,7 +1124,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "node_status:state_version_status:num_versions",
+      "title": "memory_status:heap_stats:used_heap_size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1234,10 +1167,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1264,7 +1193,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1327,10 +1256,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1340,7 +1265,7 @@
         "y": 56
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 30,
       "legend": {
         "avg": false,
         "current": false,
@@ -1357,7 +1282,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1367,7 +1292,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_status:db_status:state_info:tree_size",
+          "expr": "memory_status:heap_stats:malloced_memory",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1377,7 +1302,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "node_status:db_status:state_info:tree_size",
+      "title": "memory_status:heap_stats:malloced_memory",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1420,10 +1345,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1450,7 +1371,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1513,10 +1434,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1524,6 +1441,184 @@
         "w": 12,
         "x": 12,
         "y": 64
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.0.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_status:state_version_status:num_versions",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "node_status:state_version_status:num_versions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.0.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_status:db_status:state_info:tree_size",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "node_status:db_status:state_info:tree_size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 80
       },
       "hiddenSeries": false,
       "id": 36,
@@ -1543,7 +1638,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.3",
+      "pluginVersion": "8.0.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1603,7 +1698,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 27,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1617,5 +1712,5 @@
   "timezone": "",
   "title": "Blockchain Servers",
   "uid": "M6YpMSyMz",
-  "version": 11
+  "version": 30
 }

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -175,17 +175,6 @@ class P2pServer {
     };
   }
 
-  getDiskUsage() {
-    try {
-      const diskUsage = disk.checkSync(DISK_USAGE_PATH);
-      const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
-      return Object.assign({}, diskUsage, { used });
-    } catch (err) {
-      logger.error(`Error: ${err} ${err.stack}`);
-      return {};
-    }
-  }
-
   getCpuUsage() {
     const cores = os.cpus();
     let free = 0;
@@ -211,15 +200,31 @@ class P2pServer {
     const free = os.freemem();
     const total = os.totalmem();
     const usage = total - free;
+    const usagePercent = total ? usage / total * 100 : 0;
     return {
       os: {
         free,
         usage,
+        usagePercent,
         total,
       },
       heap: process.memoryUsage(),
       heapStats: v8.getHeapStatistics(),
     };
+  }
+
+  getDiskUsage() {
+    try {
+      const diskUsage = disk.checkSync(DISK_USAGE_PATH);
+      const free =  _.get(diskUsage, 'free', 0);
+      const total = _.get(diskUsage, 'total', 0);
+      const usage = total - free;
+      const usagePercent = total ? usage / total * 100 : 0;
+      return Object.assign({}, diskUsage, { usage, usagePercent });
+    } catch (err) {
+      logger.error(`Error: ${err} ${err.stack}`);
+      return {};
+    }
   }
 
   getRuntimeInfo() {

--- a/tracker-server/index.js
+++ b/tracker-server/index.js
@@ -250,6 +250,7 @@ function getStatus() {
     networkStatus: {
       numAliveNodes: getNumAliveNodes(),
     },
+    cpuStatus: getCpuUsage(),
     memoryStatus: getMemoryUsage(),
     diskStatus: getDiskUsage(),
     runtimeInfo: getRuntimeInfo(),
@@ -257,15 +258,25 @@ function getStatus() {
   };
 }
 
-function getDiskUsage() {
-  try {
-    const diskUsage = disk.checkSync(DISK_USAGE_PATH);
-    const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
-    return Object.assign({}, diskUsage, { used });
-  } catch (err) {
-    logger.error(`Error: ${err} ${err.stack}`);
-    return {};
+function getCpuUsage() {
+  const cores = os.cpus();
+  let free = 0;
+  let total = 0;
+  for (const core of cores) {
+    const cpuInfo = _.get(core, 'times');
+    const idle = _.get(cpuInfo, 'idle');
+    const allTimes = Object.values(cpuInfo).reduce((acc, cur) => { return acc + cur }, 0);
+    free += idle;
+    total += allTimes;
   }
+  const usage = total - free;
+  const usagePercent = total ? usage / total * 100 : 0;
+  return {
+    free,
+    usage,
+    usagePercent,
+    total
+  };
 }
 
 function getMemoryUsage() {
@@ -281,6 +292,17 @@ function getMemoryUsage() {
     heap: process.memoryUsage(),
     heapStats: v8.getHeapStatistics(),
   };
+}
+
+function getDiskUsage() {
+  try {
+    const diskUsage = disk.checkSync(DISK_USAGE_PATH);
+    const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
+    return Object.assign({}, diskUsage, { used });
+  } catch (err) {
+    logger.error(`Error: ${err} ${err.stack}`);
+    return {};
+  }
 }
 
 function getRuntimeInfo() {

--- a/tracker-server/index.js
+++ b/tracker-server/index.js
@@ -283,10 +283,12 @@ function getMemoryUsage() {
   const free = os.freemem();
   const total = os.totalmem();
   const usage = total - free;
+  const usagePercent = total ? usage / total * 100 : 0;
   return {
     os: {
       free,
       usage,
+      usagePercent,
       total,
     },
     heap: process.memoryUsage(),
@@ -297,8 +299,11 @@ function getMemoryUsage() {
 function getDiskUsage() {
   try {
     const diskUsage = disk.checkSync(DISK_USAGE_PATH);
-    const used = _.get(diskUsage, 'total', 0) - _.get(diskUsage, 'free', 0);
-    return Object.assign({}, diskUsage, { used });
+    const free =  _.get(diskUsage, 'free', 0);
+    const total = _.get(diskUsage, 'total', 0);
+    const usage = total - free;
+    const usagePercent = total ? usage / total * 100 : 0;
+    return Object.assign({}, diskUsage, { usage, usagePercent });
   } catch (err) {
     logger.error(`Error: ${err} ${err.stack}`);
     return {};

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -150,7 +150,8 @@ describe("p2p", () => {
           available: 113007648768,
           free: 235339354112,
           total: 250685575168,
-          used: 15346221056
+          usage: 15346221056,
+          usagePercent: 10.1
         };
         assert.deepEqual(Object.keys(actual), Object.keys(p2pServer.getDiskUsage()));
       });
@@ -166,7 +167,12 @@ describe("p2p", () => {
     describe("getMemoryUsage", () => {
       it("gets initial memory usage (it depends on the machine)", () => {
         const actual = {
-          os: { free: 211546112, usage: 16968323072, total: 17179869184 },
+          os: {
+            free: 211546112,
+            usage: 16968323072,
+            usagePercent: 30.3,
+            total: 17179869184
+          },
           heap: {
             rss: 80953344,
             heapTotal: 56041472,


### PR DESCRIPTION
Change summary:
- Add cpu status to tracker server
- Add usagePercent for memory and disk
- Rename: used -> usage
- Add more panels (disk usage percent, memory usage percent) to grafana