### PR TITLE
Fix broken tests & receipt, gas related bugs

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -80,7 +80,6 @@ const SNAPSHOTS_N2S_DIR_NAME = 'n2s'; // Number-to-snapshot directory name.
 const SNAPSHOTS_INTERVAL_BLOCK_NUMBER = 1000; // How often the snapshot is generated.
 const MAX_NUM_SNAPSHOTS = 10; // Maximum number of snapshots to be kept.
 const HASH_DELIMITER = '#';
-const JS_REF_SIZE_IN_BYTES = 8;
 const TX_NONCE_ERROR_CODE = 900;
 const TX_TIMESTAMP_ERROR_CODE = 901;
 const MILLI_AIN = 10**-3; // 1,000 milliain = 1 ain
@@ -807,7 +806,6 @@ module.exports = {
   LIGHTWEIGHT,
   SYNC_MODE,
   HASH_DELIMITER,
-  JS_REF_SIZE_IN_BYTES,
   TX_NONCE_ERROR_CODE,
   TX_TIMESTAMP_ERROR_CODE,
   MICRO_AIN,

--- a/db/index.js
+++ b/db/index.js
@@ -1177,10 +1177,11 @@ class DB {
       }
     }
     let balance = this.getBalance(billedTo);
-    if (balance < gasAmountChargedByTransfer) {
+    const gasCost = CommonUtil.getTotalGasCost(gasPrice, gasAmountChargedByTransfer);
+    if (balance < gasCost) {
       Object.assign(executionResult, {
         code: 36,
-        error_message: `Failed to collect gas fee: balance too low (${balance} / ${gasAmountChargedByTransfer})`
+        error_message: `Failed to collect gas fee: balance too low (${balance} / ${gasCost})`
       });
       this.restoreDb(); // Revert changes made by the tx operations
       balance = this.getBalance(billedTo);

--- a/db/index.js
+++ b/db/index.js
@@ -953,13 +953,13 @@ class DB {
       const { nonce, timestamp: accountTimestamp } = this.getAccountNonceAndTimestamp(auth.addr);
       if (tx.tx_body.nonce >= 0 && tx.tx_body.nonce !== nonce) {
         Object.assign(result, CommonUtil.returnTxResult(
-            12, `Invalid nonce (!== ${nonce}) of transaction: ${JSON.stringify(tx)}`, 1));
+            12, `Invalid nonce: ${tx.tx_body.nonce} !== ${nonce}`, 1));
         DB.updateGasAmountTotal(tx, gasAmountTotal, result);
         return result;
       }
       if (tx.tx_body.nonce === -2 && tx.tx_body.timestamp <= accountTimestamp) {
         Object.assign(result, CommonUtil.returnTxResult(
-            13, `Invalid timestamp (<= ${accountTimestamp}) of transaction: ${JSON.stringify(tx)}`, 1));
+            13, `Invalid timestamp: ${tx.tx_body.timestamp} <= ${accountTimestamp}`, 1));
         DB.updateGasAmountTotal(tx, gasAmountTotal, result);
         return result;
       }
@@ -1290,7 +1290,7 @@ class DB {
     }
     if (!tx.tx_body) {
       return CommonUtil.logAndReturnTxResult(
-          logger, 22, `[${LOG_HEADER}] Missing tx_body: ${JSON.stringify(tx, null, 2)}`, 0);
+          logger, 22, `[${LOG_HEADER}] Missing tx_body: ${JSON.stringify(tx)}`, 0);
     }
     const billing = tx.tx_body.billing;
     const op = tx.tx_body.operation;
@@ -1316,7 +1316,7 @@ class DB {
     if (restoreIfFails) {
       if (!this.backupDb()) {
         return CommonUtil.logAndReturnTxResult(
-          logger, 3, `[${LOG_HEADER}] Failed to backup db for tx: ${JSON.stringify(tx, null, 2)}`, 0);
+          logger, 3, `[${LOG_HEADER}] Failed to backup db for tx: ${tx.hash}`, 0);
       }
     }
     // Record when the tx was executed.

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -63,6 +63,8 @@ class StateNode {
         that.treeBytes === this.treeBytes);
   }
 
+  // NOTE(liayoo): Bytes for some data (e.g. parents & children references, version) are excluded
+  //               from this calculation, since their sizes can vary and affect the gas costs and state proof hashes.
   computeNodeBytes() {
     return sizeof(this.isLeaf) +
         sizeof(this.value) +

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -70,8 +70,7 @@ class StateNode {
         sizeof(this.proofHash) +
         sizeof(this.treeHeight) +
         sizeof(this.treeSize) +
-        sizeof(this.treeBytes) +
-        (this.numParents() + this.numChildren()) * JS_REF_SIZE_IN_BYTES;
+        sizeof(this.treeBytes);
   }
 
   static fromJsObject(obj, version) {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -4,7 +4,6 @@ const sizeof = require('object-sizeof');
 const CommonUtil = require('../common/common-util');
 const {
   HASH_DELIMITER,
-  JS_REF_SIZE_IN_BYTES,
   StateInfoProperties,
 } = require('../common/constants');
 

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -883,7 +883,7 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, "some value with numbered nonce");
       })
 
-      it('set_value with failing operation', () => {
+      it('set_value with failing operation', async () => {
         // Check the original value.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=/apps/some/wrong/path')
@@ -912,6 +912,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -946,7 +949,7 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, 10);
       })
 
-      it('inc_value with a failing operation', () => {
+      it('inc_value with a failing operation', async () => {
         // Check the original value.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=/apps/some/wrong/path2')
@@ -975,6 +978,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1009,7 +1015,7 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, -10);
       })
 
-      it('dec_value with a failing operation', () => {
+      it('dec_value with a failing operation', async () => {
         // Check the original value.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=/apps/some/wrong/path3')
@@ -1038,6 +1044,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1103,7 +1112,7 @@ describe('Blockchain Node', () => {
         });
       })
 
-      it('set_function with a failing operation', () => {
+      it('set_function with a failing operation', async () => {
         // Check the original function.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_function?ref=/apps/some/wrong/path')
@@ -1145,6 +1154,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original function is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1194,7 +1206,7 @@ describe('Blockchain Node', () => {
         });
       })
 
-      it('set_rule with a failing operation', () => {
+      it('set_rule with a failing operation', async () => {
         // Check the original rule.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_rule?ref=/apps/some/wrong/path')
@@ -1230,6 +1242,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original rule is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1300,7 +1315,7 @@ describe('Blockchain Node', () => {
         });
       })
 
-      it('set_owner with a failing operation', () => {
+      it('set_owner with a failing operation', async () => {
         // Check the original owner.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_owner?ref=/apps/some/wrong/path')
@@ -1343,6 +1358,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original owner is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1447,7 +1465,7 @@ describe('Blockchain Node', () => {
               "bandwidth_gas_amount": 1
             },
           },
-          "gas_amount_charged": 1680,
+          "gas_amount_charged": 1552,
           "gas_amount_total": {
             "bandwidth": {
               "app": {
@@ -1457,9 +1475,9 @@ describe('Blockchain Node', () => {
             },
             "state": {
               "app": {
-                "test": 3342
+                "test": 3070
               },
-              "service": 1680
+              "service": 1552
             }
           },
           "gas_cost_total": 0
@@ -1477,7 +1495,7 @@ describe('Blockchain Node', () => {
         assert.deepEqual(resultAfter, 'some other100 value');
       })
 
-      it('set with a failing operation', () => {
+      it('set with a failing operation', async () => {
         // Check the original value.
         const resultBefore = parseOrLog(syncRequest(
             'GET', server1 + '/get_value?ref=/apps/test/test_value/some101/path')
@@ -1576,6 +1594,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0
         });
         expect(body.code).to.equal(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         // Confirm that the original value is not altered.
         const resultAfter = parseOrLog(syncRequest(
@@ -1770,7 +1791,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 412
+                    "test": 380
                   },
                   "service": 0
                 }
@@ -1793,7 +1814,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 194
+                    "test": 178
                   },
                   "service": 0
                 }
@@ -1816,7 +1837,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 194
+                    "test": 178
                   },
                   "service": 0
                 }
@@ -1829,7 +1850,7 @@ describe('Blockchain Node', () => {
             "result": {
               "code": 0,
               "bandwidth_gas_amount": 1,
-              "gas_amount_charged": 1680,
+              "gas_amount_charged": 1552,
               "gas_amount_total": {
                 "bandwidth": {
                   "service": 0,
@@ -1838,7 +1859,7 @@ describe('Blockchain Node', () => {
                   }
                 },
                 "state": {
-                  "service": 1680
+                  "service": 1552
                 }
               },
               "gas_cost_total": 0
@@ -1859,7 +1880,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 798
+                    "test": 734
                   },
                   "service": 0
                 }
@@ -1882,7 +1903,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 1744
+                    "test": 1600
                   },
                   "service": 0
                 }
@@ -1919,7 +1940,7 @@ describe('Blockchain Node', () => {
                   "bandwidth_gas_amount": 1
                 }
               },
-              "gas_amount_charged": 1680,
+              "gas_amount_charged": 1552,
               "gas_amount_total": {
                 "bandwidth": {
                   "service": 0,
@@ -1929,9 +1950,9 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 3342
+                    "test": 3070
                   },
-                  "service": 1680
+                  "service": 1552
                 }
               },
               "gas_cost_total": 0
@@ -2145,7 +2166,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 412
+                    "test": 380
                   },
                   "service": 0
                 }
@@ -2168,7 +2189,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 194
+                    "test": 178
                   },
                   "service": 0
                 }
@@ -2191,7 +2212,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 194
+                    "test": 178
                   },
                   "service": 0
                 }
@@ -2225,7 +2246,7 @@ describe('Blockchain Node', () => {
             "result": {
               "code": 0,
               "bandwidth_gas_amount": 1,
-              "gas_amount_charged": 1680,
+              "gas_amount_charged": 1552,
               "gas_amount_total": {
                 "bandwidth": {
                   "service": 0,
@@ -2234,7 +2255,7 @@ describe('Blockchain Node', () => {
                   }
                 },
                 "state": {
-                  "service": 1680
+                  "service": 1552
                 }
               },
               "gas_cost_total": 0
@@ -2255,7 +2276,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 798
+                    "test": 734
                   },
                   "service": 0
                 }
@@ -2278,7 +2299,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 1744
+                    "test": 1600
                   },
                   "service": 0
                 }
@@ -2315,7 +2336,7 @@ describe('Blockchain Node', () => {
                   "bandwidth_gas_amount": 1
                 }
               },
-              "gas_amount_charged": 1680,
+              "gas_amount_charged": 1552,
               "gas_amount_total": {
                 "bandwidth": {
                   "service": 0,
@@ -2325,9 +2346,9 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 3342
+                    "test": 3070
                   },
-                  "service": 1680
+                  "service": 1552
                 }
               },
               "gas_cost_total": 0
@@ -3508,7 +3529,7 @@ describe('Blockchain Node', () => {
           expect(resp).to.not.equal(null);
         });
 
-        it('owner only: set_function with ownerOnly = true (_transfer)', () => {
+        it('owner only: set_function with ownerOnly = true (_transfer)', async () => {
           const body = parseOrLog(syncRequest('POST', server2 + '/set_function', {json: {
             ref: setFunctionWithOwnerOnlyPath,
             value: {
@@ -3540,6 +3561,9 @@ describe('Blockchain Node', () => {
             },
             "gas_cost_total": 0,
           })
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const resp = parseOrLog(syncRequest('GET',
               server2 + `/get_function?ref=${setFunctionWithOwnerOnlyPath}`)
             .body.toString('utf-8')).result
@@ -3549,7 +3573,7 @@ describe('Blockchain Node', () => {
       });
 
       describe('Write rule: auth.fid', () => {
-        it('write rule: auth.fid: without function permission', () => {
+        it('write rule: auth.fid: without function permission', async () => {
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: saveLastTxNotAllowedPath + '/value',
             value: 'some value',
@@ -3590,6 +3614,9 @@ describe('Blockchain Node', () => {
             "gas_cost_total": 0,
           });
           assert.deepEqual(body.code, 1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPath + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -3598,12 +3625,23 @@ describe('Blockchain Node', () => {
         });
 
         it('write rule: auth.fid: with function permission', async () => {
+          const BEFORE = parseOrLog(syncRequest('GET',
+              server2 + `/get_value?ref=/apps/test&include_tree_info=true`)
+            .body.toString('utf-8')).result
+          console.log(`BEFORE: ${JSON.stringify(BEFORE, null, 2)}`);
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: saveLastTxAllowedPath + '/value',
             value: 'some value',
             timestamp: Date.now(),
             nonce: -1,
           }}).body.toString('utf-8'));
+          if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
+          const AFTER = parseOrLog(syncRequest('GET',
+              server2 + `/get_value?ref=/apps/test&include_tree_info=true`)
+            .body.toString('utf-8')).result
+          console.log(`AFTER: ${JSON.stringify(AFTER, null, 2)}`);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {
@@ -3632,7 +3670,7 @@ describe('Blockchain Node', () => {
               },
               "state": {
                 "app": {
-                  "test": 1348
+                  "test": 1252 // 1044
                 },
                 "service": 0
               }
@@ -3640,9 +3678,6 @@ describe('Blockchain Node', () => {
             "gas_cost_total": 0,
           });
           assert.deepEqual(body.code, 0);
-          if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
-            console.error(`Failed to check finalization of tx.`);
-          }
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxAllowedPath + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -3652,7 +3687,7 @@ describe('Blockchain Node', () => {
       });
 
       describe('Write rule: auth.fids', () => {
-        it('write rule: auth.fids: without function permission', () => {
+        it('write rule: auth.fids: without function permission', async () => {
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: saveLastTxNotAllowedPathWithFids + '/value',
             value: 'some value',
@@ -3693,6 +3728,9 @@ describe('Blockchain Node', () => {
             "gas_cost_total": 0,
           });
           assert.deepEqual(body.code, 1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const lastTx = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${saveLastTxNotAllowedPathWithFids + '/.last_tx/value'}`)
             .body.toString('utf-8')).result
@@ -3735,7 +3773,7 @@ describe('Blockchain Node', () => {
               },
               "state": {
                 "app": {
-                  "test": 1126
+                  "test": 1046
                 },
                 "service": 0
               }
@@ -3755,7 +3793,7 @@ describe('Blockchain Node', () => {
       });
 
       describe('Owner rule: auth.fid', () => {
-        it('owner rule: auth.fid: without function permission', () => {
+        it('owner rule: auth.fid: without function permission', async () => {
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: setOwnerConfigNotAllowedPath + '/value',
             value: 'some value',
@@ -3796,6 +3834,9 @@ describe('Blockchain Node', () => {
             "gas_cost_total": 0,
           });
           assert.deepEqual(body.code, 1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const ownerConfig = parseOrLog(syncRequest('GET',
               server2 + `/get_owner?ref=${setOwnerConfigNotAllowedPath + '/value'}`)
             .body.toString('utf-8')).result
@@ -3838,7 +3879,7 @@ describe('Blockchain Node', () => {
               },
               "state": {
                 "app": {
-                  "test": 3072
+                  "test": 2832
                 },
                 "service": 0
               }
@@ -4007,6 +4048,9 @@ describe('Blockchain Node', () => {
             timestamp,
           }}).body.toString('utf-8'));
           assert.deepEqual(body.code, 1);  // Should fail.
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           // Confirm that the value change is undone.
           valueAfter = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${valuePath}`).body.toString('utf-8')).result;
@@ -4164,7 +4208,7 @@ describe('Blockchain Node', () => {
           valueBefore = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${valuePath}`).body.toString('utf-8')).result;
 
-          const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+          const body = parseOrLog(syncRequest('POST', server2 + '/set', {json: {
             op_list: [
               {
                 ref: valuePath,
@@ -4183,6 +4227,9 @@ describe('Blockchain Node', () => {
             timestamp,
           }}).body.toString('utf-8'));
           assert.deepEqual(body.code, 1);  // Should fail.
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           // Confirm that the value change is undone.
           valueAfter = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${valuePath}`).body.toString('utf-8')).result;
@@ -4254,7 +4301,7 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 2591,
+            "gas_amount_charged": 2399,
             "gas_amount_total": {
               "bandwidth": {
                 "app": {
@@ -4263,13 +4310,16 @@ describe('Blockchain Node', () => {
                 "service": 3
               },
               "state": {
-                "service": 2588
+                "service": 2396
               }
             },
             "gas_cost_total": 0
           },
           "tx_hash": "0x4e2a4bc009347bbaa1a14f1ddecb0f2b06d02d46326d33def7c346c613093079"
         });
+        if (!(await waitUntilTxFinalized(serverList, _.get(createAppRes, 'tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
       it("when failed with invalid app name", async () => {
@@ -4314,6 +4364,9 @@ describe('Blockchain Node', () => {
           },
           "tx_hash": "0x60f6a71fedc8bbe457680ff6cf2e24b5c2097718f226c4f40fb4f9849d52f7fa"
         });
+        if (!(await waitUntilTxFinalized(serverList, _.get(createAppRes, 'tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
       it('create a public app', async () => {
@@ -4376,7 +4429,7 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 2987,
+            "gas_amount_charged": 2763,
             "gas_amount_total": {
               "bandwidth": {
                 "app": {
@@ -4385,7 +4438,7 @@ describe('Blockchain Node', () => {
                 "service": 3
               },
               "state": {
-                "service": 2984
+                "service": 2760
               }
             },
             "gas_cost_total": 0
@@ -4439,7 +4492,7 @@ describe('Blockchain Node', () => {
         await setUpApp('test_service_gas_fee', serverList, { admin: { [serviceAdmin]: true } });
       });
 
-      it("native function (_transfer) with individual account registration", () => {
+      it("native function (_transfer) with individual account registration", async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: triggerTransferToIndividualAccountPath1,
           value: 10,
@@ -4478,21 +4531,24 @@ describe('Blockchain Node', () => {
           },
           "code": 0,
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 3004,
+          "gas_amount_charged": 2860,
           "gas_amount_total": {
             "bandwidth": {
               "service": 1004
             },
             "state": {
-              "service": 2000
+              "service": 1856
             }
           },
           "gas_cost_total": 0,
         });
         assert.deepEqual(body.code, 0);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it("native function (_transfer) without individual account registration", () => {
+      it("native function (_transfer) without individual account registration", async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: triggerTransferToIndividualAccountPath2,
           value: 10,
@@ -4531,21 +4587,24 @@ describe('Blockchain Node', () => {
           },
           "code": 0,
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 1286,
+          "gas_amount_charged": 1190,
           "gas_amount_total": {
             "bandwidth": {
               "service": 4
             },
             "state": {
-              "service": 1282
+              "service": 1186
             }
           },
           "gas_cost_total": 0,
         });
         assert.deepEqual(body.code, 0);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it("native function (_transfer) with service account registration", () => {
+      it("native function (_transfer) with service account registration", async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: triggerTransferToServiceAccountPath1,
           value: 10,
@@ -4620,21 +4679,24 @@ describe('Blockchain Node', () => {
           },
           "code": 0,
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 5210,
+          "gas_amount_charged": 4906,
           "gas_amount_total": {
             "bandwidth": {
               "service": 1008
             },
             "state": {
-              "service": 4202
+              "service": 3898
             }
           },
           "gas_cost_total": 0,
         });
         assert.deepEqual(body.code, 0);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it("native function (_transfer) without service account registration", () => {
+      it("native function (_transfer) without service account registration", async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: triggerTransferToServiceAccountPath2,
           value: 10,
@@ -4709,21 +4771,24 @@ describe('Blockchain Node', () => {
           },
           "code": 0,
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 2600,
+          "gas_amount_charged": 2408,
           "gas_amount_total": {
             "bandwidth": {
               "service": 8
             },
             "state": {
-              "service": 2592
+              "service": 2400
             }
           },
           "gas_cost_total": 0,
         });
         assert.deepEqual(body.code, 0);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it("REST function with external RPC call", () => {
+      it("REST function with external RPC call", async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
           ref: triggerRestFunctionPath,
           value: 'some value',
@@ -4747,7 +4812,7 @@ describe('Blockchain Node', () => {
             },
             "state": {
               "app": {
-                "test": 232
+                "test": 216
               },
               "service": 0
             }
@@ -4755,6 +4820,9 @@ describe('Blockchain Node', () => {
           "gas_cost_total": 0,
         });
         assert.deepEqual(body.code, 0);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
     });
 
@@ -4785,7 +4853,7 @@ describe('Blockchain Node', () => {
         expect(resultCode).to.equal(FunctionResultCode.SUCCESS);
       });
 
-      it('transfer: transfer more than account balance', () => {
+      it('transfer: transfer more than account balance', async () => {
         let fromBeforeBalance = parseOrLog(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         let toBeforeBalance = parseOrLog(syncRequest('GET',
@@ -4795,6 +4863,9 @@ describe('Blockchain Node', () => {
           value: fromBeforeBalance + 1
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
         const fromAfterBalance = parseOrLog(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = parseOrLog(syncRequest('GET',
@@ -4803,7 +4874,7 @@ describe('Blockchain Node', () => {
         expect(toAfterBalance).to.equal(toBeforeBalance);
       });
 
-      it('transfer: transfer by another address', () => {
+      it('transfer: transfer by another address', async () => {
         let fromBeforeBalance = parseOrLog(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         let toBeforeBalance = parseOrLog(syncRequest('GET',
@@ -4813,6 +4884,9 @@ describe('Blockchain Node', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
         const fromAfterBalance = parseOrLog(syncRequest('GET',
             server2 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         const toAfterBalance = parseOrLog(syncRequest('GET',
@@ -4821,24 +4895,30 @@ describe('Blockchain Node', () => {
         expect(toAfterBalance).to.equal(toBeforeBalance);
       });
 
-      it('transfer: transfer with a duplicated key', () => {
+      it('transfer: transfer with a duplicated key', async () => {
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: transferPath + '/1/value',
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('transfer: transfer with same addresses', () => {
+      it('transfer: transfer with same addresses', async () => {
         const transferPathSameAddrs = `/transfer/${transferFrom}/${transferFrom}`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: transferPathSameAddrs + '/4/value',
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('transfer: transfer with non-checksum addreess', () => {
+      it('transfer: transfer with non-checksum addreess', async () => {
         const fromLowerCase = _.toLower(transferFrom);
         const transferPathFromLowerCase = `/transfer/${fromLowerCase}/${transferTo}`;
         const bodyFromLowerCase = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
@@ -4846,6 +4926,9 @@ describe('Blockchain Node', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(bodyFromLowerCase.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(bodyFromLowerCase, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         const toLowerCase = _.toLower(transferTo);
         const transferPathToLowerCase = `/transfer/${transferFrom}/${toLowerCase}`;
@@ -4854,6 +4937,9 @@ describe('Blockchain Node', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(bodyToLowerCase.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(bodyToLowerCase, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         const fromUpperCase = _.toLower(transferFrom);
         const transferPathFromUpperCase = `/transfer/${fromUpperCase}/${transferTo}`;
@@ -4862,6 +4948,9 @@ describe('Blockchain Node', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(bodyFromUpperCase.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(bodyFromUpperCase, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
 
         const toUpperCase = _.toLower(transferTo);
         const transferPathToUpperCase = `/transfer/${transferFrom}/${toUpperCase}`;
@@ -4870,6 +4959,9 @@ describe('Blockchain Node', () => {
           value: transferAmount
         }}).body.toString('utf-8'));
         expect(bodyToUpperCase.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(bodyToUpperCase, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
       it('transfer: transfer with valid service account service type', async () => {
@@ -4923,13 +5015,13 @@ describe('Blockchain Node', () => {
                 }
               },
               "bandwidth_gas_amount": 1,
-              "gas_amount_charged": 3254,
+              "gas_amount_charged": 3094,
               "gas_amount_total": {
                 "bandwidth": {
                   "service": 1004
                 },
                 "state": {
-                  "service": 2250
+                  "service": 2090
                 }
               },
               "gas_cost_total": 0
@@ -4984,6 +5076,9 @@ describe('Blockchain Node', () => {
             "tx_hash": "0x6cce46b284beb254c6b67205f5ba00f04c85028d7457410b4fa4b4d8522c14be"
           }
         });
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
         const fromAfterBalance = parseOrLog(syncRequest('GET',
             server1 + `/get_value?ref=${transferFromBalancePath}`).body.toString('utf-8')).result;
         expect(fromAfterBalance).to.equal(fromBeforeBalance);
@@ -5080,13 +5175,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 5206,
+            "gas_amount_charged": 4902,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 1008
               },
               "state": {
-                "service": 4198
+                "service": 3894
               }
             },
             "gas_cost_total": 0,
@@ -5114,7 +5209,7 @@ describe('Blockchain Node', () => {
           expect(stakingAppBalanceTotal).to.equal(stakeAmount + 1);
         });
 
-        it('stake: stake more than account balance', () => {
+        it('stake: stake more than account balance', async () => {
           const beforeBalance = parseOrLog(syncRequest('GET', server2 +
               `/get_value?ref=/accounts/${serviceUser}/balance`).body.toString('utf-8')).result;
           const beforeStakingAccountBalance = parseOrLog(syncRequest('GET',
@@ -5124,6 +5219,9 @@ describe('Blockchain Node', () => {
             value: beforeBalance + 1
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const afterStakingAccountBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${stakingServiceAccountBalancePath}`).body.toString('utf-8')).result;
           const afterBalance = parseOrLog(syncRequest('GET',
@@ -5132,7 +5230,7 @@ describe('Blockchain Node', () => {
           expect(afterBalance).to.equal(beforeBalance);
         });
 
-        it('stake: stake by another address', () => {
+        it('stake: stake by another address', async () => {
           const beforeStakingAccountBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${stakingServiceAccountBalancePath}`).body.toString('utf-8')).result;
           const body = parseOrLog(syncRequest('POST', server3 + '/set_value', {json: {
@@ -5140,6 +5238,9 @@ describe('Blockchain Node', () => {
             value: stakeAmount
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const stakeRequest = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${stakePath}/3`).body.toString('utf-8')).result;
           const afterStakingAccountBalance = parseOrLog(syncRequest('GET',
@@ -5213,15 +5314,18 @@ describe('Blockchain Node', () => {
           });
         });
 
-        it('stake: stake with the same record_id', () => {
+        it('stake: stake with the same record_id', async () => {
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: stakePath + '/1/value',
             value: stakeAmount
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
-        it('stake: stake with non-checksum addreess', () => {
+        it('stake: stake with non-checksum addreess', async () => {
           const addrLowerCase = _.toLower(serviceUser);
           const stakePathLowerCase = `/staking/checksum_addr_test_service/${addrLowerCase}/0/stake`;
           const bodyLowerCase = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
@@ -5229,6 +5333,9 @@ describe('Blockchain Node', () => {
             value: stakeAmount
           }}).body.toString('utf-8'));
           expect(bodyLowerCase.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(bodyLowerCase, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
 
           const addrUpperCase = _.toUpper(serviceUser);
           const stakePathUpperCase = `/staking/checksum_addr_test_service/${addrUpperCase}/0/stake`;
@@ -5237,11 +5344,14 @@ describe('Blockchain Node', () => {
             value: stakeAmount
           }}).body.toString('utf-8'));
           expect(bodyUpperCase.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(bodyUpperCase, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
       });
 
       describe('Unstake', () => {
-        it('unstake: unstake by another address', () => {
+        it('unstake: unstake by another address', async () => {
           let beforeBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=/accounts/${serviceUserBad}/balance`)
               .body.toString('utf-8')).result;
@@ -5252,6 +5362,9 @@ describe('Blockchain Node', () => {
             value: stakeAmount
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const unstakeRequest = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${unstakePath}/1`).body.toString('utf-8')).result;
           const afterStakingAccountBalance = parseOrLog(syncRequest('GET',
@@ -5264,7 +5377,7 @@ describe('Blockchain Node', () => {
           expect(balance).to.equal(beforeBalance);
         });
 
-        it('unstake: unstake more than staked amount', () => {
+        it('unstake: unstake more than staked amount', async () => {
           let beforeBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${serviceUserBalancePath}`).body.toString('utf-8')).result;
           let beforeStakingAccountBalance = parseOrLog(syncRequest('GET',
@@ -5274,6 +5387,9 @@ describe('Blockchain Node', () => {
             value: beforeStakingAccountBalance + 1
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
           const afterStakingAccountBalance = parseOrLog(syncRequest('GET',
               server2 + `/get_value?ref=${stakingServiceAccountBalancePath}`).body.toString('utf-8')).result;
           const balance = parseOrLog(syncRequest('GET',
@@ -5354,13 +5470,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 3367,
+            "gas_amount_charged": 3127,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 7
               },
               "state": {
-                "service": 3360
+                "service": 3120
               }
             },
             "gas_cost_total": 0,
@@ -5422,7 +5538,7 @@ describe('Blockchain Node', () => {
         await setUpApp('test_service_payment', serverList, { admin: { [serviceAdmin]: true } });
       });
 
-      it('payments: non-app admin cannot write pay records', () => {
+      it('payments: non-app admin cannot write pay records', async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
               ref: `/payments/test_service_payment/${serviceUser}/0/pay/key1`,
               value: {
@@ -5430,9 +5546,12 @@ describe('Blockchain Node', () => {
               }
             }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('payments: amount = 0', () => {
+      it('payments: amount = 0', async () => {
         const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: payRef,
@@ -5441,9 +5560,12 @@ describe('Blockchain Node', () => {
           }
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('payments: amount is not a number', () => {
+      it('payments: amount is not a number', async () => {
         const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
         const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
           ref: payRef,
@@ -5452,9 +5574,12 @@ describe('Blockchain Node', () => {
           }
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('payments: payment amount > admin balance', () => {
+      it('payments: payment amount > admin balance', async () => {
         const adminBalance = parseOrLog(syncRequest('GET', server1 +
             `/get_value?ref=/accounts/${serviceAdmin}/balance`).body.toString('utf-8')).result;
         const payRef = `/payments/test_service_payment/${serviceUser}/0/pay/key1`;
@@ -5465,6 +5590,9 @@ describe('Blockchain Node', () => {
           }
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
       it('payments: app admin can write pay records', async () => {
@@ -5534,13 +5662,13 @@ describe('Blockchain Node', () => {
             }
           },
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 5824,
+          "gas_amount_charged": 5472,
           "gas_amount_total": {
             "bandwidth": {
               "service": 1006
             },
             "state": {
-              "service": 4818
+              "service": 4466
             }
           },
           "gas_cost_total": 0,
@@ -5561,7 +5689,7 @@ describe('Blockchain Node', () => {
         assert.deepEqual(serviceAccountBalance, amount);
       });
 
-      it('payments: non-app admin cannot write claim records', () => {
+      it('payments: non-app admin cannot write claim records', async () => {
         const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
               ref: `/payments/test_service_payment/${serviceUser}/0/claim/key1`,
               value: {
@@ -5570,9 +5698,12 @@ describe('Blockchain Node', () => {
               }
             }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('payments: claim amount > payment balance', () => {
+      it('payments: claim amount > payment balance', async () => {
         const paymentBalance = parseOrLog(syncRequest('GET',
             server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
@@ -5585,9 +5716,12 @@ describe('Blockchain Node', () => {
           }
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
-      it('payments: invalid claim target', () => {
+      it('payments: invalid claim target', async () => {
         const paymentBalance = parseOrLog(syncRequest('GET',
             server1 + `/get_value?ref=/service_accounts/payments/test_service_payment/${serviceUser}|0/balance`)
             .body.toString('utf-8')).result;
@@ -5600,6 +5734,9 @@ describe('Blockchain Node', () => {
           }
         }}).body.toString('utf-8'));
         expect(body.code).to.equals(1);
+        if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
       });
 
       it('payments: app admin can claim payments with individual account target', async () => {
@@ -5672,13 +5809,13 @@ describe('Blockchain Node', () => {
             }
           },
           "bandwidth_gas_amount": 1,
-          "gas_amount_charged": 3644,
+          "gas_amount_charged": 3388,
           "gas_amount_total": {
             "bandwidth": {
               "service": 6
             },
             "state": {
-              "service": 3638
+              "service": 3382
             }
           },
           "gas_cost_total": 0,
@@ -5844,13 +5981,13 @@ describe('Blockchain Node', () => {
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 1337,
+            "gas_amount_charged": 1241,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 1
               },
               "state": {
-                "service": 1336
+                "service": 1240
               }
             },
             "gas_cost_total": 0,
@@ -5864,7 +6001,7 @@ describe('Blockchain Node', () => {
           assert.deepEqual(escrowAccountConfig, { admin: { [serviceAdmin]: true } });
         });
 
-        it("escrow: individual -> individual: cannot open escrow if it's already open", () => {
+        it("escrow: individual -> individual: cannot open escrow if it's already open", async () => {
           const configRef = `/escrow/${serviceUser}/${serviceAdmin}/0/config`;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: configRef,
@@ -5875,9 +6012,12 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
-        it("escrow: individual -> individual: non-source account cannot write hold", () => {
+        it("escrow: individual -> individual: non-source account cannot write hold", async () => {
           const key = 1234567890000 + 1;
           const holdRef = `/escrow/${serviceUser}/${serviceAdmin}/0/hold/${key}`;
           const userBalanceBefore = parseOrLog(syncRequest('GET', server1 +
@@ -5889,6 +6029,9 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
         it("escrow: individual -> individual: source account can write hold", async () => {
@@ -5958,13 +6101,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 4730,
+            "gas_amount_charged": 4474,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 1006
               },
               "state": {
-                "service": 3724
+                "service": 3468
               }
             },
             "gas_cost_total": 0,
@@ -5982,7 +6125,7 @@ describe('Blockchain Node', () => {
           expect(escrowServiceAccountBalance).to.equals(userBalanceBefore);
         });
 
-        it("escrow: individual -> individual: non-admin account cannot write release", () => {
+        it("escrow: individual -> individual: non-admin account cannot write release", async () => {
           const key = 1234567890000 + 3;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
@@ -5992,9 +6135,12 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
-        it("escrow: individual -> individual: invalid ratio (ratio = -1)", () => {
+        it("escrow: individual -> individual: invalid ratio (ratio = -1)", async () => {
           const key = 1234567890000 + 4;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
@@ -6004,9 +6150,12 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
-        it("escrow: individual -> individual: invalid ratio (ratio = 1.1)", () => {
+        it("escrow: individual -> individual: invalid ratio (ratio = 1.1)", async () => {
           const key = 1234567890000 + 5;
           const releaseRef = `/escrow/${serviceUser}/${serviceAdmin}/0/release/${key}`;
           const body = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
@@ -6016,6 +6165,9 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
         it("escrow: individual -> individual: admin account can write release (ratio = 0)", async () => {
@@ -6088,13 +6240,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 3446,
+            "gas_amount_charged": 3206,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 6
               },
               "state": {
-                "service": 3440
+                "service": 3200
               }
             },
             "gas_cost_total": 0,
@@ -6158,13 +6310,13 @@ describe('Blockchain Node', () => {
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 1399,
+            "gas_amount_charged": 1303,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 1
               },
               "state": {
-                "service": 1398
+                "service": 1302
               }
             },
             "gas_cost_total": 0,
@@ -6178,7 +6330,7 @@ describe('Blockchain Node', () => {
           assert.deepEqual(escrowAccountConfig, { admin: { [serviceAdmin]: true } });
         });
 
-        it("escrow: service -> individual: non-service admin cannot write hold", () => {
+        it("escrow: service -> individual: non-service admin cannot write hold", async () => {
           const key = 1234567890000 + 102;
           const source = `payments|test_service_escrow|${serviceUser}|0`;
           const target = serviceAdmin;
@@ -6193,6 +6345,9 @@ describe('Blockchain Node', () => {
             }
           }}).body.toString('utf-8'));
           expect(body.code).to.equals(1);
+          if (!(await waitUntilTxFinalized(serverList, _.get(body, 'result.tx_hash')))) {
+            console.error(`Failed to check finalization of tx.`);
+          }
         });
 
         it("escrow: service -> individual: service admin can write hold", async () => {
@@ -6265,13 +6420,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 5176,
+            "gas_amount_charged": 4904,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 1006
               },
               "state": {
-                "service": 4170
+                "service": 3898
               }
             },
             "gas_cost_total": 0,
@@ -6362,13 +6517,13 @@ describe('Blockchain Node', () => {
               }
             },
             "bandwidth_gas_amount": 1,
-            "gas_amount_charged": 3570,
+            "gas_amount_charged": 3330,
             "gas_amount_total": {
               "bandwidth": {
                 "service": 6
               },
               "state": {
-                "service": 3564
+                "service": 3324
               }
             },
             "gas_cost_total": 0,
@@ -6594,8 +6749,8 @@ describe('Blockchain Node', () => {
         }
       }).body.toString('utf-8'));
       expect(txResBody.code).to.equals(1);
-      expect(txResBody.result.result.code, 18);
-      expect(txResBody.result.result.error_message.includes('No write permission on: /gas_fee/collect/billing|test_billing|B'), true);
+      expect(txResBody.result.result.code).to.equals(33);
+      expect(txResBody.result.result.error_message).to.equals("[precheckTxBillingParams] User doesn't have permission to the billing account");
     });
 
     it('app-dependent service tx: billing account', async () => {
@@ -6838,7 +6993,7 @@ describe('Blockchain Node', () => {
           },
           state: {
             app: {
-              test: 204
+              test: 188
             },
             service: 0
           },

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -3662,7 +3662,7 @@ describe('Blockchain Node', () => {
               },
               "state": {
                 "app": {
-                  "test": 1252 // 1044
+                  "test": 1252
                 },
                 "service": 0
               }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -3625,10 +3625,6 @@ describe('Blockchain Node', () => {
         });
 
         it('write rule: auth.fid: with function permission', async () => {
-          const BEFORE = parseOrLog(syncRequest('GET',
-              server2 + `/get_value?ref=/apps/test&include_tree_info=true`)
-            .body.toString('utf-8')).result
-          console.log(`BEFORE: ${JSON.stringify(BEFORE, null, 2)}`);
           const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
             ref: saveLastTxAllowedPath + '/value',
             value: 'some value',
@@ -3638,10 +3634,6 @@ describe('Blockchain Node', () => {
           if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
             console.error(`Failed to check finalization of tx.`);
           }
-          const AFTER = parseOrLog(syncRequest('GET',
-              server2 + `/get_value?ref=/apps/test&include_tree_info=true`)
-            .body.toString('utf-8')).result
-          console.log(`AFTER: ${JSON.stringify(AFTER, null, 2)}`);
           assert.deepEqual(_.get(body, 'result.result'), {
             "code": 0,
             "func_results": {

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -1543,7 +1543,7 @@ describe('Sharding', async () => {
                 "bandwidth_gas_amount": 1
               },
             },
-            "gas_amount_charged": 1676,
+            "gas_amount_charged": 1548,
             "gas_amount_total": {
               "bandwidth": {
                 "app": {
@@ -1553,9 +1553,9 @@ describe('Sharding', async () => {
               },
               "state": {
                 "app": {
-                  "test": 3130
+                  "test": 2874
                 },
-                "service": 1676
+                "service": 1548
               }
             },
             "gas_cost_total": 0
@@ -2107,7 +2107,7 @@ describe('Sharding', async () => {
             },
             "state": {
               "app": {
-                "a_dapp": 766
+                "a_dapp": 710
               },
               "service": 0
             }
@@ -2186,7 +2186,7 @@ describe('Sharding', async () => {
             },
             "state": {
               "app": {
-                "a_dapp": 812
+                "a_dapp": 748
               },
               "service": 0
             }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test_integration_blockchain": "./node_modules/mocha/bin/mocha --timeout 160000 integration/blockchain.test.js",
     "test_integration_consensus": "./node_modules/mocha/bin/mocha --timeout 160000 integration/consensus.test.js",
     "test_integration_dapp": "./node_modules/mocha/bin/mocha --timeout 160000 integration/afan_dapp.test.js",
-    "test_integration_node": "./node_modules/mocha/bin/mocha --timeout 160000 integration/node.test.js",
+    "test_integration_node": "./node_modules/mocha/bin/mocha --timeout 640000 integration/node.test.js",
     "test_integration_sharding": "./node_modules/mocha/bin/mocha --timeout 320000 integration/sharding.test.js",
     "test_unit": "MIN_NUM_VALIDATORS=1 STATE_TREE_BYTES_LIMIT=20000000 ./node_modules/mocha/bin/mocha --timeout 160000 \"unittest/*.test.js\"",
     "test_unit_block_pool": "MIN_NUM_VALIDATORS=1 ./node_modules/mocha/bin/mocha --timeout 160000 unittest/block-pool.test.js",

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -296,7 +296,7 @@ describe("DB operations", () => {
       it('when retrieving value with include_tree_info', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { includeTreeInfo: true }), {
           ".num_parents": 1,
-          ".tree_bytes": 4036,
+          ".tree_bytes": 3708,
           ".tree_height": 4,
           ".tree_size": 21,
           "ai": {
@@ -304,10 +304,10 @@ describe("DB operations", () => {
             ".num_parents:baz": 1,
             ".num_parents:comcom": 1,
             ".num_parents:foo": 1,
-            ".tree_bytes": 740,
-            ".tree_bytes:baz": 174,
-            ".tree_bytes:comcom": 176,
-            ".tree_bytes:foo": 174,
+            ".tree_bytes": 684,
+            ".tree_bytes:baz": 166,
+            ".tree_bytes:comcom": 168,
+            ".tree_bytes:foo": 166,
             ".tree_height": 1,
             ".tree_height:baz": 0,
             ".tree_height:comcom": 0,
@@ -323,8 +323,8 @@ describe("DB operations", () => {
           "decrement": {
             ".num_parents": 1,
             ".num_parents:value": 1,
-            ".tree_bytes": 362,
-            ".tree_bytes:value": 176,
+            ".tree_bytes": 338,
+            ".tree_bytes:value": 168,
             ".tree_height": 1,
             ".tree_height:value": 0,
             ".tree_size": 2,
@@ -334,8 +334,8 @@ describe("DB operations", () => {
           "increment": {
             ".num_parents": 1,
             ".num_parents:value": 1,
-            ".tree_bytes": 362,
-            ".tree_bytes:value": 176,
+            ".tree_bytes": 338,
+            ".tree_bytes:value": 168,
             ".tree_height": 1,
             ".tree_height:value": 0,
             ".tree_size": 2,
@@ -344,14 +344,14 @@ describe("DB operations", () => {
           },
           "nested": {
             ".num_parents": 1,
-            ".tree_bytes": 542,
+            ".tree_bytes": 502,
             ".tree_height": 2,
             ".tree_size": 3,
             "far": {
               ".num_parents": 1,
               ".num_parents:down": 1,
-              ".tree_bytes": 360,
-              ".tree_bytes:down": 176,
+              ".tree_bytes": 336,
+              ".tree_bytes:down": 168,
               ".tree_height": 1,
               ".tree_height:down": 0,
               ".tree_size": 2,
@@ -361,7 +361,7 @@ describe("DB operations", () => {
           },
           "shards": {
             ".num_parents": 1,
-            ".tree_bytes": 1758,
+            ".tree_bytes": 1622,
             ".tree_height": 3,
             ".tree_size": 9,
             "disabled_shard": {
@@ -370,16 +370,16 @@ describe("DB operations", () => {
               ".shard": {
                 ".num_parents": 1,
                 ".num_parents:sharding_enabled": 1,
-                ".tree_bytes": 380,
-                ".tree_bytes:sharding_enabled": 172,
+                ".tree_bytes": 356,
+                ".tree_bytes:sharding_enabled": 164,
                 ".tree_height": 1,
                 ".tree_height:sharding_enabled": 0,
                 ".tree_size": 2,
                 ".tree_size:sharding_enabled": 1,
                 "sharding_enabled": false,
               },
-              ".tree_bytes": 760,
-              ".tree_bytes:path": 176,
+              ".tree_bytes": 704,
+              ".tree_bytes:path": 168,
               ".tree_height": 2,
               ".tree_height:path": 0,
               ".tree_size": 4,
@@ -392,16 +392,16 @@ describe("DB operations", () => {
               ".shard": {
                 ".num_parents": 1,
                 ".num_parents:sharding_enabled": 1,
-                ".tree_bytes": 380,
-                ".tree_bytes:sharding_enabled": 172,
+                ".tree_bytes": 356,
+                ".tree_bytes:sharding_enabled": 164,
                 ".tree_height": 1,
                 ".tree_height:sharding_enabled": 0,
                 ".tree_size": 2,
                 ".tree_size:sharding_enabled": 1,
                 "sharding_enabled": true,
               },
-              ".tree_bytes": 760,
-              ".tree_bytes:path": 176,
+              ".tree_bytes": 704,
+              ".tree_bytes:path": 168,
               ".tree_height": 2,
               ".tree_height:path": 0,
               ".tree_size": 4,
@@ -2569,7 +2569,7 @@ describe("DB operations", () => {
         expect(executableTx.extra.executed_at).to.equal(null);
         assert.deepEqual(node.db.executeTransaction(executableTx, false, true, node.bc.lastBlockNumber() + 1), {
           code: 0,
-          gas_amount_charged: 16,
+          gas_amount_charged: 8,
           bandwidth_gas_amount: 1,
           gas_amount_total: {
             bandwidth: {
@@ -2580,12 +2580,12 @@ describe("DB operations", () => {
             },
             state: {
               app: {
-                test: 918
+                test: 846
               },
-              service: 16
+              service: 8
             }
           },
-          gas_cost_total: 16
+          gas_cost_total: 8
         });
         // extra.executed_at is updated with a non-null value.
         expect(executableTx.extra.executed_at).to.not.equal(null);
@@ -2614,7 +2614,7 @@ describe("DB operations", () => {
         const maxHeightTx = Transaction.fromTxBody(maxHeightTxBody, node.account.private_key);
         assert.deepEqual(node.db.executeTransaction(maxHeightTx, false, true, node.bc.lastBlockNumber() + 1), {
           code: 0,
-          gas_amount_charged: 16,
+          gas_amount_charged: 8,
           bandwidth_gas_amount: 1,
           gas_amount_total: {
             bandwidth: {
@@ -2625,9 +2625,9 @@ describe("DB operations", () => {
             },
             state: {
               app: {
-                test: 3236
+                test: 2956
               },
-              service: 16
+              service: 8
             }
           },
           gas_cost_total: 0,
@@ -2690,11 +2690,11 @@ describe("DB operations", () => {
         
         const expectedGasAmountTotal = {
           bandwidth: {
-            service: 3000,
+            service: 4500,
             app: {},
           },
           state: {
-            service: 2557560
+            service: 3550560
           } 
         };
         const overSizeTxBody = {
@@ -2706,7 +2706,7 @@ describe("DB operations", () => {
           nonce: -1,
           timestamp: 1568798344000,
         };
-        for (let i = 0; i < 1000; i++) {
+        for (let i = 0; i < 1500; i++) {
           overSizeTxBody.operation.op_list.push({
             type: 'SET_VALUE',
             ref: `/manage_app/app_${i}/create/${i}`,
@@ -2717,16 +2717,16 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 25);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (10381522 > 10000000)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (10791482 > 10000000)");
         assert.deepEqual(res.gas_amount_total, expectedGasAmountTotal);
-        assert.deepEqual(res.gas_cost_total, 2.5605599999999997);
+        assert.deepEqual(res.gas_cost_total, 3.5550599999999997);
       });
 
       it("cannot exceed apps state budget", () => {
         const overSizeTree = {};
         for (let i = 0; i < 1000; i++) {
           overSizeTree[i] = {};
-          for (let j = 0; j < 50; j++) {
+          for (let j = 0; j < 100; j++) {
             overSizeTree[i][j] = 'a';
           }
         }
@@ -2743,10 +2743,10 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 26);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for apps (9287388 > 9000000)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for apps (16769332 > 9000000)");
         assert.deepEqual(res.gas_amount_total, {
           bandwidth: { service: 0, app: { test: 1 } },
-          state: { service: 16, app: { test: 9262132 } }
+          state: { service: 8, app: { test: 16746108 } }
         });
         assert.deepEqual(res.gas_cost_total, 0);
       });
@@ -2801,10 +2801,10 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 31);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for app app_0 (1084406 > 818181.8181818182)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for app app_0 (988222 > 818181.8181818182)");
         assert.deepEqual(res.gas_amount_total, {
           bandwidth: { service: 0, app: { app_0: 1 } },
-          state: { service: 16, app: { app_0: 1082132 } }
+          state: { service: 8, app: { app_0: 986108 } }
         });
         assert.deepEqual(res.gas_cost_total, 0);
       });
@@ -2844,10 +2844,10 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 29);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for free tier (1984406 > 1000000)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for free tier (1808222 > 1000000)");
         assert.deepEqual(res.gas_amount_total, {
           bandwidth: { service: 0, app: { app_0: 1 } },
-          state: { service: 16, app: { app_0: 1982132 } }
+          state: { service: 8, app: { app_0: 1806108 } }
         });
         assert.deepEqual(res.gas_cost_total, 0);
       });
@@ -4543,56 +4543,56 @@ describe("State info (getStateInfo)", () => {
       // Existing paths.
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1'), {
         "proof_hash": "0x213304021f1ea1e8f7954c815d49207c0a42ab4bdf09929263369fa5f4d77c8b",
-        "tree_bytes": 994,
+        "tree_bytes": 922,
         "tree_height": 2,
         "tree_size": 5,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label11'), {
         "proof_hash": "0xa8681012b27ff56a45aa80f6f4d95c66c3349046cdd18cdc77028b6a634c9b0b",
-        "tree_bytes": 182,
+        "tree_bytes": 174,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label12'), {
         "proof_hash": "0xbc8b6e1e9e369b5af09e14fea3769c348d66e453b3a2fc6dbec0d00278e094e7",
-        "tree_bytes": 600,
+        "tree_bytes": 560,
         "tree_height": 1,
         "tree_size": 3,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label12/label121'), {
         "proof_hash": "0xfbe04067ec980e5d7364e8b6cf45f4bee9d53be89419211d0233aada9151ad50",
-        "tree_bytes": 192,
+        "tree_bytes": 184,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label12/label122'), {
         "proof_hash": "0x8f17965ac862bad15172d21facff45ff3efb8a55ae50ca085131a3012e001c1f",
-        "tree_bytes": 192,
+        "tree_bytes": 184,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2'), {
         "proof_hash": "0x7b614d2449c2ce477ac040c52b78798e5ff36a20b83115b6af8688f5e88a813f",
-        "tree_bytes": 576,
+        "tree_bytes": 536,
         "tree_height": 1,
         "tree_size": 3,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label21'), {
         "proof_hash": "0xa8681012b27ff56a45aa80f6f4d95c66c3349046cdd18cdc77028b6a634c9b0b",
-        "tree_bytes": 182,
+        "tree_bytes": 174,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label22'), {
         "proof_hash": "0xc0da1458b190e12347891ab14253518f5e43d95473cd2546dbf8852dfb3dc281",
-        "tree_bytes": 182,
+        "tree_bytes": 174,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
@@ -4610,14 +4610,14 @@ describe("State info (getStateInfo)", () => {
 
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1'), {
         "proof_hash": "0x1b8f144f5692c88c242776485c0cafc184d4724942578752d083c615d84a1caa",
-        "tree_bytes": 372,
+        "tree_bytes": 348,
         "tree_height": 1,
         "tree_size": 2,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label11'), {
         "proof_hash": "0xa8681012b27ff56a45aa80f6f4d95c66c3349046cdd18cdc77028b6a634c9b0b",
-        "tree_bytes": 182,
+        "tree_bytes": 174,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
@@ -4625,7 +4625,7 @@ describe("State info (getStateInfo)", () => {
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1/label12'), null);
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2'), {
         "proof_hash": "0x7b614d2449c2ce477ac040c52b78798e5ff36a20b83115b6af8688f5e88a813f",
-        "tree_bytes": 576,
+        "tree_bytes": 536,
         "tree_height": 1,
         "tree_size": 3,
         "version": "NODE:0",
@@ -4643,42 +4643,42 @@ describe("State info (getStateInfo)", () => {
 
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1'), {
         "proof_hash": "0x052b9dbac10fca45626652f264b9896216da0ce6f1b55d10934b7e9cb9141871",
-        "tree_bytes": 978,
+        "tree_bytes": 906,
         "tree_height": 2,
         "tree_size": 5,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2'), {
         "proof_hash": "0x7da207e739139a3fabbcb53c9a2b91f786441b903ffd1de445e69d921f9f30af",
-        "tree_bytes": 978,
+        "tree_bytes": 906,
         "tree_height": 2,
         "tree_size": 5,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label21'), {
         "proof_hash": "0x805586e32d13b938808c5e283c027d0fa7f8b496bdb6fdc8cd5a57d0b12c72af",
-        "tree_bytes": 584,
+        "tree_bytes": 544,
         "tree_height": 1,
         "tree_size": 3,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label21/label211'), {
         "proof_hash": "0xc7b107bdd716d26c8fe34fbcec5b91d738c3f53ee09fdf047678e85181e5f90c",
-        "tree_bytes": 184,
+        "tree_bytes": 176,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label21/label212'), {
         "proof_hash": "0x736c5dded3f67ab5717c8c7c1b15580cb0bbf23562edd4a6898f2c1a6ca63200",
-        "tree_bytes": 184,
+        "tree_bytes": 176,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",
       });
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label2/label22'), {
         "proof_hash": "0xc0da1458b190e12347891ab14253518f5e43d95473cd2546dbf8852dfb3dc281",
-        "tree_bytes": 182,
+        "tree_bytes": 174,
         "tree_height": 0,
         "tree_size": 1,
         "version": "NODE:0",

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -1196,19 +1196,19 @@ describe("state-node", () => {
       // TOTAL: 50 - 6 = 44 bytes (exclude version)
 
       node.setValue(true);  // boolean (4 bytes)
-      expect(node.computeTreeBytes()).to.equal(48);
+      expect(node.computeTreeBytes()).to.equal(40);
       node.setValue(10);  // number (8 bytes)
-      expect(node.computeTreeBytes()).to.equal(52);
+      expect(node.computeTreeBytes()).to.equal(44);
       node.setValue(-200);  // number (8 bytes)
-      expect(node.computeTreeBytes()).to.equal(52);
+      expect(node.computeTreeBytes()).to.equal(44);
       node.setValue('');  // string (0 * 2 = 0 bytes)
-      expect(node.computeTreeBytes()).to.equal(44);
+      expect(node.computeTreeBytes()).to.equal(36);
       node.setValue('str');  // string (3 * 2 = 6 bytes)
-      expect(node.computeTreeBytes()).to.equal(50);
+      expect(node.computeTreeBytes()).to.equal(42);
       node.setValue(null);  // null (0 bytes)
-      expect(node.computeTreeBytes()).to.equal(44);
+      expect(node.computeTreeBytes()).to.equal(36);
       node.setValue(undefined);  // undefined (0 bytes)
-      expect(node.computeTreeBytes()).to.equal(44);
+      expect(node.computeTreeBytes()).to.equal(36);
     });
 
     it("internal node", () => {
@@ -1229,7 +1229,7 @@ describe("state-node", () => {
       child2.setTreeBytes(20);
       child3.setTreeBytes(30);
       // 68 + 6('label1') * 2 + 10 + 6('label2') * 2 + 20 + 6('label3') * 2 + 30 = 164
-      expect(stateTree.computeTreeBytes()).to.equal(164);
+      expect(stateTree.computeTreeBytes()).to.equal(132);
     });
   });
 

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -2247,9 +2247,9 @@ describe("state-util", () => {
         ".tree_size": 3,
         ".tree_size:label1": 1,
         ".tree_size:label2": 1,
-        ".tree_bytes": 560,
-        ".tree_bytes:label1": 180,
-        ".tree_bytes:label2": 180,
+        ".tree_bytes": 528,
+        ".tree_bytes:label1": 172,
+        ".tree_bytes:label2": 172,
         label1: "value1",
         label2: "value2"
       });
@@ -2526,10 +2526,10 @@ describe("state-util", () => {
       expect(anotherNode.getTreeSize()).to.equal(0);
       expect(testNode.getTreeSize()).to.equal(0);
       // Checks tree bytes.
-      expect(fooNode.getTreeBytes()).to.equal(174);
-      expect(bazNode.getTreeBytes()).to.equal(174);
-      expect(level1Node.getTreeBytes()).to.equal(544);
-      expect(level0Node.getTreeBytes()).to.equal(732);
+      expect(fooNode.getTreeBytes()).to.equal(166);
+      expect(bazNode.getTreeBytes()).to.equal(166);
+      expect(level1Node.getTreeBytes()).to.equal(504);
+      expect(level0Node.getTreeBytes()).to.equal(676);
       expect(anotherNode.getTreeBytes()).to.equal(0);
       expect(testNode.getTreeBytes()).to.equal(0);
     });
@@ -2583,9 +2583,9 @@ describe("state-util", () => {
       expect(level0Node.getTreeSize()).to.equal(7);
       expect(rootNode.getTreeSize()).to.equal(8);
       // Checks tree bytes.
-      expect(level1Node.getTreeBytes()).to.equal(338);
-      expect(level0Node.getTreeBytes()).to.equal(660);
-      expect(rootNode.getTreeBytes()).to.equal(840);
+      expect(level1Node.getTreeBytes()).to.equal(322);
+      expect(level0Node.getTreeBytes()).to.equal(620);
+      expect(rootNode.getTreeBytes()).to.equal(792);
     });
 
     it("updates proof hashes for multiple root paths", () => {


### PR DESCRIPTION
- Problem 1. Flaky node integration test cases (related: https://github.com/ainblockchain/ain-blockchain/issues/513)
  - Added `waitUntilTxFinalized` calls for transactions that fail but get included in blocks
- Problem 2. Changing receipts values & state proof hashes
  - Removed the stringified transaction from tx results & receipts for stable results (was getting state proof hash errors)
- Problem 3. Unstable tree byte calculation
  -  Removed num parents & children from tree bytes calculation for stable results
- Problem 4. Bug in balance checking in collectFee()
  - Changed to compare balance with gas cost total, not the gas amount