### PR TITLE
Trim down execution result in receipt values.

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -172,7 +172,10 @@ const PredefinedDbPaths = {
   RECEIPTS_BILLING: 'billing',
   RECEIPTS_BLOCK_NUMBER: 'block_number',
   RECEIPTS_EXEC_RESULT: 'exec_result',
-  RECEIPTS_GAS_COST_TOTAL: 'gas_cost_total',
+  RECEIPTS_EXEC_RESULT_CODE: 'code',
+  RECEIPTS_EXEC_RESULT_ERROR_MESSAGE: 'error_message',
+  RECEIPTS_EXEC_RESULT_GAS_AMOUNT_CHARGED: 'gas_amount_charged',
+  RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL: 'gas_cost_total',
   // Gas fee
   GAS_FEE: 'gas_fee',
   COLLECT: 'collect',

--- a/db/index.js
+++ b/db/index.js
@@ -1192,12 +1192,21 @@ class DB {
     }
   }
 
+  static trimExecutionResult(executionResult) {
+    return _.pick(executionResult, [
+      PredefinedDbPaths.RECEIPTS_EXEC_RESULT_CODE,
+      PredefinedDbPaths.RECEIPTS_EXEC_RESULT_ERROR_MESSAGE,
+      PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_AMOUNT_CHARGED,
+      PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL,
+    ]);
+  }
+
   recordReceipt(auth, tx, blockNumber, executionResult) {
     const receiptPath = PathUtil.getReceiptPath(tx.hash);
     const receipt = {
       [PredefinedDbPaths.RECEIPTS_ADDRESS]: auth.addr,
       [PredefinedDbPaths.RECEIPTS_BLOCK_NUMBER]: blockNumber,
-      [PredefinedDbPaths.RECEIPTS_EXEC_RESULT]: executionResult
+      [PredefinedDbPaths.RECEIPTS_EXEC_RESULT]: DB.trimExecutionResult(executionResult)
     };
     if (tx.tx_body.billing) {
       receipt[PredefinedDbPaths.RECEIPTS_BILLING] = tx.tx_body.billing;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -189,7 +189,8 @@ class RuleUtil {
   isGasFeeCollected(address, newData, txHash, getValue) {
     const { PredefinedDbPaths } = require('../common/constants');
     const blockNumber = newData[PredefinedDbPaths.RECEIPTS_BLOCK_NUMBER];
-    const gasCost = _.get(newData, `${PredefinedDbPaths.RECEIPTS_EXEC_RESULT}.${PredefinedDbPaths.RECEIPTS_GAS_COST_TOTAL}`);
+    const gasCost = _.get(newData, `${PredefinedDbPaths.RECEIPTS_EXEC_RESULT}.` +
+        `${PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL}`);
     if (gasCost === undefined) {
       return false;
     }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -32,6 +32,7 @@ const {
   waitForNewBlocks,
   getBlockByNumber,
 } = require('../unittest/test-util');
+const DB = require('../db');
 
 const ENV_VARIABLES = [
   {
@@ -7615,23 +7616,8 @@ describe('Blockchain Node', () => {
           .body.toString('utf-8')).result;
       assert.deepEqual(receipt.address, txSignerAddress);
       assert.deepEqual(receipt.exec_result, {
-        "bandwidth_gas_amount": 1,
         "code": 0,
         "gas_amount_charged": 0,
-        "gas_amount_total": {
-          "bandwidth": {
-            "app": {
-              "test": 1
-            },
-            "service": 0
-          },
-          "state": {
-            "app": {
-              "test": 536
-            },
-            "service": 0
-          },
-        },
         "gas_cost_total": 0
       });
     });
@@ -7690,7 +7676,7 @@ describe('Blockchain Node', () => {
       const receipt = parseOrLog(syncRequest(
         'GET', server2 + `/get_value?ref=${PathUtil.getReceiptPath(txHash)}`).body.toString('utf-8')).result;
       expect(receipt).to.not.equal(null);
-      assert.deepEqual(receipt.exec_result, body.result.result);
+      assert.deepEqual(receipt.exec_result, DB.trimExecutionResult(body.result.result));
 
       // Failed tx's gas fees have been collected
       const blockNumber = receipt.block_number;


### PR DESCRIPTION
As discussed offline, receipt's exec_result now only contains the result code, error_message, gas_amount_charged, and gas_cost_total to prevent txs from exceeding the state tree limits.