### PR TITLE
Add shell scripts for restarting servers in GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You can override default port numbering system by setting `PORT` and `P2P_PORT` 
 ```
 gcloud init
 # For one-off deploy
-sh deploy_blockchain_gcp.sh {dev|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
+bash deploy_blockchain_gcp.sh {dev|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
 # For incremental deploy
-sh deploy_blockchain_incremental_gcp.sh {dev|staging|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
+bash deploy_blockchain_incremental_gcp.sh {dev|staging|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
 ```
 - Set up Ubuntu machine (if it's on a new VM)
 ```
-sh setup_blockchain_ubuntu.sh
+bash setup_blockchain_ubuntu.sh
 ```
 - Copy files to a sharable folder & install yarn packages
 ```
@@ -49,7 +49,7 @@ source setup_tracker_gcp.sh
 - Start tracker server job
 ```
 cd ain-blockchain/
-sh start_tracker_genesis_gcp.sh
+bash start_tracker_genesis_gcp.sh
 ```
 
 <!--
@@ -122,13 +122,13 @@ GENESIS_CONFIGS_DIR=genesis-configs/afan-shard MIN_NUM_VALIDATORS=1 ACCOUNT_INDE
 ```
 gcloud init
 # For one-off deploy
-sh deploy_blockchain_gcp.sh {dev|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
+bash deploy_blockchain_gcp.sh {dev|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
 # For incremental deploy
-sh deploy_blockchain_incremental_gcp.sh {dev|staging|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
+bash deploy_blockchain_incremental_gcp.sh {dev|staging|spring|summer} <YOUR_GCP_USER_NAME> <NUMBER_OF_SHARDS> [--setup]
 ```
 - Set up Ubuntu machine (if it's on a new VM)
 ```
-sh setup_blockchain_ubuntu.sh
+bash setup_blockchain_ubuntu.sh
 ```
 - Copy files to a sharable folder & install yarn packages
 ```
@@ -136,7 +136,7 @@ source setup_node_gcp.sh
 ```
 - Start Node server job (set shard index to 0 if you're running a root chain node)
 ```
-sh start_node_genesis_gcp.sh {dev|spring|summer} <SHARD_INDEX> <SERVER_INDEX>
+bash start_node_genesis_gcp.sh {dev|spring|summer} <SHARD_INDEX> <SERVER_INDEX>
 ```
 
 <!--
@@ -303,11 +303,11 @@ POST http://<ip_address>:8080/batch with json_body {"tx_list": [{"operation": {"
 
 Four Node server with a Tracker server can be started all at once using `start_servers.sh` like:
 ```
-sh start_servers.sh
+bash start_servers.sh
 ```
 and can be stopped all at once using `stop_servers.sh` like:
 ```
-sh stop_servers.sh
+bash stop_servers.sh
 ```
 
 ## Versions

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 3 ]]; then
-    echo "Usage: sh deploy_blockchain_genesis_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [--setup]"
-    echo "Example: sh deploy_blockchain_genesis_gcp.sh dev lia 0 --setup"
+    echo "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [--setup]"
+    echo "Example: bash deploy_blockchain_genesis_gcp.sh dev lia 0 --setup"
     exit
 fi
 
@@ -39,8 +39,8 @@ then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
-FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ json_rpc/ genesis-configs/ logger/ node/ tx-pool/ p2p/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh"
+FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ json_rpc/ genesis-configs/ logger/ node/ tx-pool/ p2p/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh"
 
 TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-tracker-taiwan"
 NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-node-0-taiwan"

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 5 ]] || [[ "$#" -gt 6 ]]; then
-    printf "Usage: sh deploy_blockchain_incremental_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [fast|full] [canary|full] [--setup]\n"
-    printf "Example: sh deploy_blockchain_incremental_gcp.sh dev lia 0 fast canary --setup\n"
+    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [fast|full] [canary|full] [--setup]\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev lia 0 fast canary --setup\n"
     exit
 fi
 
@@ -53,8 +53,8 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
-FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ json_rpc/ genesis-configs/ logger/ node/ tx-pool/ p2p/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh"
+FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ json_rpc/ genesis-configs/ logger/ node/ tx-pool/ p2p/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh"
 
 NUM_PARENT_NODES=5
 NUM_SHARD_NODES=3

--- a/deploy_monitoring_gcp.sh
+++ b/deploy_monitoring_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 2 ]]; then
-    echo "Usage: sh deploy_monitoring_gcp.sh [dev|staging|spring|summer] <GCP Username>"
-    echo "Example: sh deploy_monitoring_gcp.sh dev seo"
+    echo "Usage: bash deploy_monitoring_gcp.sh [dev|staging|spring|summer] <GCP Username>"
+    echo "Example: bash deploy_monitoring_gcp.sh dev seo"
     exit
 fi
 

--- a/port_list_macos.sh
+++ b/port_list_macos.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 # Gets a list of the system port numbers in use for MacOS
 sudo lsof -i -P -n | grep LISTEN

--- a/reset_blockchain_gcp.sh
+++ b/reset_blockchain_gcp.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 3 ]]; then
-    echo "Usage: sh reset_blockchain_gcp.sh dev lia 0"
+    echo "Usage: bash reset_blockchain_gcp.sh dev lia 0"
     exit
 fi
 

--- a/restart_node_gcp.sh
+++ b/restart_node_gcp.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+if [[ "$#" -lt 4 ]] || [[ "$#" -gt 4 ]]; then
+    printf "Usage: bash restart_node_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index> [fast|full]\n"
+    printf "Example: bash restart_node_gcp.sh spring 0 0 fast\n"
+    exit
+fi
+
+# 1. Configure env vars (GENESIS_CONFIGS_DIR, TRACKER_WS_ADDR, ACCOUNT_INDEX, ...)
+printf "\n#### [Step 1] Configure env vars ####\n\n"
+
+export GENESIS_CONFIGS_DIR=genesis-configs/testnet
+if [[ "$1" = 'spring' ]]; then
+    export TRACKER_WS_ADDR=ws://35.221.137.80:5000
+elif [[ "$1" = 'summer' ]]; then
+    export TRACKER_WS_ADDR=ws://35.194.172.106:5000
+elif [[ "$1" = 'staging' ]]; then
+    export TRACKER_WS_ADDR=ws://35.221.150.73:5000
+elif [[ "$1" = 'dev' ]]; then
+    if [[ "$2" = 0 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
+    elif [[ "$2" = 1 ]]; then
+        export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
+    elif [[ "$2" = 2 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
+    elif [[ "$2" = 3 ]]; then
+        export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
+    elif [[ "$2" = 4 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
+    elif [[ "$2" = 5 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
+    elif [[ "$2" = 6 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
+    elif [[ "$2" = 7 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
+    elif [[ "$2" = 8 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
+    elif [[ "$2" = 9 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
+    elif [[ "$2" = 10 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
+    elif [[ "$2" = 11 ]]; then
+        export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
+    elif [[ "$2" = 12 ]]; then
+        export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
+    elif [[ "$2" = 13 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
+    elif [[ "$2" = 14 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
+    elif [[ "$2" = 15 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
+    elif [[ "$2" = 16 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
+    elif [[ "$2" = 17 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
+    elif [[ "$2" = 18 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
+    elif [[ "$2" = 19 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
+    elif [[ "$2" = 20 ]]; then
+        export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
+    else
+        printf "Invalid <Shard Index> argument: $2\n"
+        exit
+    fi
+    if [[ "$2" -gt 0 ]]; then
+        # Create a genesis_params.json
+        export GENESIS_CONFIGS_DIR="genesis-configs/shard_$2"
+        mkdir -p "./$GENESIS_CONFIGS_DIR"
+        node > "./$GENESIS_CONFIGS_DIR/genesis_params.json" <<EOF
+        const data = require('./genesis-configs/testnet/genesis_params.json');
+        data.blockchain.TRACKER_WS_ADDR = '$TRACKER_WS_ADDR';
+        data.consensus.MIN_NUM_VALIDATORS = 3;
+        console.log(JSON.stringify(data, null, 2));
+EOF
+    fi
+else
+    printf "Invalid <Project/Season> argument: $1\n"
+    exit
+fi
+
+printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
+printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
+
+if [[ "$3" -lt 0 ]] || [[ "$3" -gt 4 ]]; then
+    printf "Invalid <Node Index> argument: $3\n"
+    exit
+fi
+
+export ACCOUNT_INDEX="$3"
+printf "ACCOUNT_INDEX=$ACCOUNT_INDEX\n"
+
+if [[ "$4" != 'fast' ]] && [[ "$4" != 'full' ]]; then
+    printf "Invalid <Sync Mode> argument: $2\n"
+    exit
+fi
+
+export SYNC_MODE="$4"
+printf "SYNC_MODE=$SYNC_MODE\n"
+
+export DEBUG=false
+export CONSOLE_LOG=false
+export ENABLE_DEV_SET_CLIENT_API=false
+export ENABLE_TX_SIG_VERIF_WORKAROUND=false
+export ENABLE_GAS_FEE_WORKAROUND=true
+export LIGHTWEIGHT=false
+export STAKE=100000
+export BLOCKCHAIN_DATA_DIR="/home/ain_blockchain_data"
+
+# 2. Kill the existing node server 
+printf "\n#### [Step 2] Kill the existing node server ####\n\n"
+
+KILL_CMD="sudo killall node"
+printf "KILL_CMD='$KILL_CMD'\n\n"
+eval $KILL_CMD
+sleep 10
+
+# 3. Restart the node server
+printf "\n#### [Step 3] Restart the node server ####\n\n"
+
+MAX_OLD_SPACE_SIZE_MB=6000
+
+START_CMD="nohup node --async-stack-traces --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB client/index.js >/dev/null 2>error_logs.txt &"
+printf "START_CMD='$START_CMD'\n"
+eval $START_CMD
+
+# 4. Wait until the node server catches up
+printf "\n#### [Step 4] Wait until the node server catches up ####\n\n"
+
+SECONDS=0
+loopCount=0
+
+generate_post_data()
+{
+  cat <<EOF
+  {"method":"$1","params":{"protoVer":"0.8.0"},"jsonrpc":"2.0","id":"1"}
+EOF
+}
+
+while :
+do
+    healthCheck=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:8080/health_check")
+    printf "\nhealthCheck = ${healthCheck}\n"
+    lastBlockNumber=$(curl -m 20 -X POST -H "Content-Type: application/json" --data "$(generate_post_data 'ain_getRecentBlockNumber')" "http://localhost:8080/json-rpc" | jq -r '.result.result')
+    printf "\nlastBlockNumber = ${lastBlockNumber}\n"
+    if [[ "$healthCheck" = "true" ]]; then
+        printf "\nBlockchain Node server is synced & running!\n"
+        printf "\nTime it took to sync in seconds: $SECONDS\n"
+        break
+    fi
+    ((loopCount++))
+    printf "\nLoop count: ${loopCount}\n"
+    sleep 20
+done
+
+printf "\n* << Node server successfully deployed! ***************************************\n\n"

--- a/restart_tracker_gcp.sh
+++ b/restart_tracker_gcp.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [[ "$#" -lt 1 ]] || [[ "$#" -gt 1 ]]; then
+    printf "Usage: bash restart_tracker_gcp.sh <Number of Nodes>\n"
+    printf "Example: bash restart_tracker_gcp.sh 5\n"
+    exit
+fi
+
+# 1. Configure env vars
+printf "\n#### [Step 1] Configure env vars ####\n\n"
+
+NUM_NODES="$1"
+
+# 2. Kill the existing tracker server 
+printf "\n#### [Step 2] Kill the existing tracker server ####\n\n"
+
+KILL_CMD="sudo killall node"
+printf "KILL_CMD='$KILL_CMD'\n\n"
+eval $KILL_CMD
+sleep 10
+
+# 3. Restart the tracker server
+printf "\n#### [Step 3] Restart the tracker server ####\n\n"
+
+export CONSOLE_LOG=false 
+
+START_CMD="nohup node --async-stack-traces tracker-server/index.js >/dev/null 2>error_logs.txt &"
+printf "START_CMD='$START_CMD'\n"
+eval $START_CMD
+
+# 4. Wait until the tracker server catches up
+printf "\n#### [Step 4] Wait until the tracker server catches up ####\n\n"
+
+SECONDS=0
+loopCount=0
+
+while :
+do
+    numAliveNodes=$(curl -m 20 -X GET -H "Content-Type: application/json" "http://localhost:8080/network_status" | jq -r '.numAliveNodes')
+    printf "\nnumAliveNodes = ${numAliveNodes}\n"
+    if [[ "$numAliveNodes" = "$NUM_NODES" ]]; then
+        printf "\nBlockchain Tracker server is running!\n"
+        printf "\nTime it took to sync in seconds: $SECONDS\n"
+        break
+    fi
+    ((loopCount++))
+    printf "\nLoop count: ${loopCount}\n"
+    sleep 20
+done
+
+printf "\n* << Tracker server successfully deployed! ************************************\n\n"

--- a/setup_blockchain_ubuntu.sh
+++ b/setup_blockchain_ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo 'Installing NodeJS..'
 sudo apt update

--- a/setup_monitoring_gcp.sh
+++ b/setup_monitoring_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 1 ]]; then
-    echo "Usage: sh setup_monitoring_gcp.sh [dev|staging|spring|summer]"
-    echo "Example: sh setup_monitoring_gcp.sh dev"
+    echo "Usage: bash setup_monitoring_gcp.sh [dev|staging|spring|summer]"
+    echo "Example: bash setup_monitoring_gcp.sh dev"
     exit
 fi
 

--- a/setup_monitoring_ubuntu.sh
+++ b/setup_monitoring_ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo 'Installing NodeJS..'
 sudo apt update

--- a/start_monitoring_gcp.sh
+++ b/start_monitoring_gcp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo 'Starting up Prometheus..'
 cd prometheus

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 2 ]]; then
-    echo "Usage: sh start_node_genesis_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index>"
-    echo "Example: sh start_node_genesis_gcp.sh spring 0 0"
+    echo "Usage: bash start_node_genesis_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index>"
+    echo "Example: bash start_node_genesis_gcp.sh spring 0 0"
     exit
 fi
 

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 4 ]] || [[ "$#" -gt 4 ]]; then
-    printf "Usage: sh start_node_incremental_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index> [fast|full]\n"
-    printf "Example: sh start_node_incremental_gcp.sh spring 0 0 fast\n"
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index> [fast|full]\n"
+    printf "Example: bash start_node_incremental_gcp.sh spring 0 0 fast\n"
     exit
 fi
 
@@ -142,11 +142,11 @@ printf "\n#### [Step 5] Kill old node server ####\n\n"
 KILL_CMD="sudo killall node"
 printf "KILL_CMD='$KILL_CMD'\n\n"
 eval $KILL_CMD
+sleep 10
 
 # 6. Start a new node server
 printf "\n#### [Step 6] Start new node server ####\n\n"
 
-sleep 10
 MAX_OLD_SPACE_SIZE_MB=6000
 
 START_CMD="nohup node --async-stack-traces --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB client/index.js >/dev/null 2>error_logs.txt &"

--- a/start_servers_afan_local.sh
+++ b/start_servers_afan_local.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # PARENT CHAIN
 CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5

--- a/start_servers_local.sh
+++ b/start_servers_local.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # PARENT CHAIN
 BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5

--- a/start_tracker_genesis_gcp.sh
+++ b/start_tracker_genesis_gcp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo 'Killing jobs..'
 killall node

--- a/start_tracker_incremental_gcp.sh
+++ b/start_tracker_incremental_gcp.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ "$#" -lt 1 ]] || [[ "$#" -gt 1 ]]; then
-    printf "Usage: sh start_tracker_incremental_gcp.sh <Number of Nodes>\n"
-    printf "Example: sh start_tracker_incremental_gcp.sh 5\n"
+    printf "Usage: bash start_tracker_incremental_gcp.sh <Number of Nodes>\n"
+    printf "Example: bash start_tracker_incremental_gcp.sh 5\n"
     exit
 fi
 
@@ -44,11 +44,11 @@ printf "\n#### [Step 5] Kill old tracker server ####\n\n"
 KILL_CMD="sudo killall node"
 printf "KILL_CMD='$KILL_CMD'\n\n"
 eval $KILL_CMD
+sleep 10
 
 # 6. Start new tracker server
 printf "\n#### [Step 6] Start new tracker server ####\n\n"
 
-sleep 10
 export CONSOLE_LOG=false 
 
 START_CMD="nohup node --async-stack-traces tracker-server/index.js >/dev/null 2>error_logs.txt &"

--- a/stop_servers_local.sh
+++ b/stop_servers_local.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 killall -9 node # SIGKILL
 rm -rf ~/ain_blockchain_data/
 BASEDIR=$(dirname "$0")

--- a/unittest/test-util.js
+++ b/unittest/test-util.js
@@ -76,7 +76,7 @@ function addBlock(node, txs, votes, validators) {
 }
 
 async function waitUntilTxFinalized(servers, txHash) {
-  const MAX_ITERATION = 20;
+  const MAX_ITERATION = 40;
   let iterCount = 0;
   const unchecked = new Set(servers);
   while (true) {


### PR DESCRIPTION
Change summary:
- Use bash shell as the default (some scripts have dependency on bash-only syntax)
- Add shell scripts for restarting servers in GCP
- Fix broken integration tests by increasing finalization wait time