### PR TITLE
Update consensus reward distribution logic.

### DIFF
--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -138,8 +138,8 @@ class Block {
       if (!CommonUtil.isCksumAddr(address)) {
         return false;
       }
-      if (!CommonUtil.isDict(info) || !CommonUtil.isNumber(info[PredefinedDbPaths.STAKE]) ||
-          !CommonUtil.isBool(info[PredefinedDbPaths.PROPOSAL_RIGHT])) {
+      if (!CommonUtil.isDict(info) || !CommonUtil.isNumber(info[PredefinedDbPaths.CONSENSUS_STAKE]) ||
+          !CommonUtil.isBool(info[PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT])) {
         return false;
       }
     }
@@ -292,7 +292,7 @@ class Block {
         operation: {
           type: 'SET_VALUE',
           ref: PathUtil.getStakingStakeRecordValuePath(PredefinedDbPaths.CONSENSUS, address, 0, timestamp),
-          value: info[PredefinedDbPaths.STAKE]
+          value: info[PredefinedDbPaths.CONSENSUS_STAKE]
         }
       };
       txs.push(Transaction.fromTxBody(txBody, privateKey));

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -189,7 +189,7 @@ class CommonUtil {
   // NOTE(liayoo): billing is in the form <app name>|<billing id>
   static toBillingAccountName(billing) {
     const { PredefinedDbPaths } = require('../common/constants');
-    return `${PredefinedDbPaths.BILLING}|${billing}`;
+    return `${PredefinedDbPaths.GAS_FEE_BILLING}|${billing}`;
   }
 
   static toEscrowAccountName(source, target, escrowKey) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -154,19 +154,19 @@ const PredefinedDbPaths = {
   DOT_SHARD: '.shard',
   // Consensus
   CONSENSUS: 'consensus',
-  WHITELIST: 'whitelist',
-  NUMBER: 'number',
-  PROPOSE: 'propose',
-  PROPOSER: 'proposer',
-  VALIDATORS: 'validators',
-  TOTAL_AT_STAKE: 'total_at_stake',
-  VOTE: 'vote',
-  BLOCK_HASH: 'block_hash',
-  STAKE: 'stake',
-  PROPOSAL_RIGHT: 'proposal_right',
-  REWARDS: 'rewards',
-  REWARDS_UNCLAIMED: 'unclaimed',
-  REWARDS_CUMULATIVE: 'cumulative',
+  CONSENSUS_BLOCK_HASH: 'block_hash',
+  CONSENSUS_NUMBER: 'number',
+  CONSENSUS_PROPOSAL_RIGHT: 'proposal_right',
+  CONSENSUS_PROPOSE: 'propose',
+  CONSENSUS_PROPOSER: 'proposer',
+  CONSENSUS_REWARDS: 'rewards',
+  CONSENSUS_REWARDS_UNCLAIMED: 'unclaimed',
+  CONSENSUS_REWARDS_CUMULATIVE: 'cumulative',
+  CONSENSUS_STAKE: 'stake',
+  CONSENSUS_TOTAL_AT_STAKE: 'total_at_stake',
+  CONSENSUS_VALIDATORS: 'validators',
+  CONSENSUS_VOTE: 'vote',
+  CONSENSUS_WHITELIST: 'whitelist',
   // Receipts
   RECEIPTS: 'receipts',
   RECEIPTS_ADDRESS: 'address',
@@ -180,10 +180,10 @@ const PredefinedDbPaths = {
   RECEIPTS_EXEC_RESULT_RESULT_LIST: 'result_list',
   // Gas fee
   GAS_FEE: 'gas_fee',
-  CLAIM: 'claim',
-  COLLECT: 'collect',
-  BILLING: 'billing',
   GAS_FEE_AMOUNT: 'amount',
+  GAS_FEE_BILLING: 'billing',
+  GAS_FEE_CLAIM: 'claim',
+  GAS_FEE_COLLECT: 'collect',
   GAS_FEE_UNCLAIMED: 'unclaimed',
   // Token
   TOKEN: 'token',
@@ -570,7 +570,7 @@ function isServiceType(type) {
  * Service types allowed to create service accounts.
  */
 const SERVICE_ACCOUNT_SERVICE_TYPES = [
-  PredefinedDbPaths.BILLING,
+  PredefinedDbPaths.GAS_FEE_BILLING,
   PredefinedDbPaths.ESCROW,
   PredefinedDbPaths.GAS_FEE,
   PredefinedDbPaths.PAYMENTS,
@@ -627,8 +627,8 @@ function overwriteGenesisParams(overwritingParams, type) {
       const addr = GenesisAccounts[AccountProperties.OTHERS][i][AccountProperties.ADDRESS];
       CommonUtil.setJsObject(whitelist, [addr], true);
       CommonUtil.setJsObject(validators, [addr], {
-          [PredefinedDbPaths.STAKE]: GenesisParams.consensus.MIN_STAKE_PER_VALIDATOR,
-          [PredefinedDbPaths.PROPOSAL_RIGHT]: true
+          [PredefinedDbPaths.CONSENSUS_STAKE]: GenesisParams.consensus.MIN_STAKE_PER_VALIDATOR,
+          [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true
         });
     }
     GenesisParams.consensus.GENESIS_WHITELIST = whitelist;
@@ -735,7 +735,7 @@ function getGenesisValues() {
   CommonUtil.setJsObject(
       values, [PredefinedDbPaths.SHARDING, PredefinedDbPaths.SHARDING_CONFIG], GenesisSharding);
   CommonUtil.setJsObject(
-      values, [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST], GenesisParams.consensus.GENESIS_WHITELIST);
+      values, [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_WHITELIST], GenesisParams.consensus.GENESIS_WHITELIST);
   return values;
 }
 
@@ -754,7 +754,7 @@ function getGenesisRules() {
 }
 
 function getGenesisOwners() {
-  let owners = getGenesisConfig('genesis_owners.json', process.env.ADDITIONAL_OWNERS);
+  const owners = getGenesisConfig('genesis_owners.json', process.env.ADDITIONAL_OWNERS);
   CommonUtil.setJsObject(owners, [], getRootOwner());
   if (GenesisSharding[ShardingProperties.SHARDING_PROTOCOL] !== ShardingProtocols.NONE) {
     CommonUtil.setJsObject(
@@ -762,7 +762,7 @@ function getGenesisOwners() {
         getShardingOwner());
   }
   CommonUtil.setJsObject(
-      owners, [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST], getWhitelistOwner());
+      owners, [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_WHITELIST], getWhitelistOwner());
   return owners;
 }
 

--- a/common/constants.js
+++ b/common/constants.js
@@ -164,6 +164,9 @@ const PredefinedDbPaths = {
   BLOCK_HASH: 'block_hash',
   STAKE: 'stake',
   PROPOSAL_RIGHT: 'proposal_right',
+  REWARDS: 'rewards',
+  REWARDS_UNCLAIMED: 'unclaimed',
+  REWARDS_CUMULATIVE: 'cumulative',
   // Receipts
   RECEIPTS: 'receipts',
   RECEIPTS_ADDRESS: 'address',
@@ -174,11 +177,14 @@ const PredefinedDbPaths = {
   RECEIPTS_EXEC_RESULT_ERROR_MESSAGE: 'error_message',
   RECEIPTS_EXEC_RESULT_GAS_AMOUNT_CHARGED: 'gas_amount_charged',
   RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL: 'gas_cost_total',
+  RECEIPTS_EXEC_RESULT_RESULT_LIST: 'result_list',
   // Gas fee
   GAS_FEE: 'gas_fee',
+  CLAIM: 'claim',
   COLLECT: 'collect',
   BILLING: 'billing',
   GAS_FEE_AMOUNT: 'amount',
+  GAS_FEE_UNCLAIMED: 'unclaimed',
   // Token
   TOKEN: 'token',
   TOKEN_BRIDGE: 'bridge',
@@ -371,6 +377,7 @@ const StateInfoProperties = {
  */
 const NativeFunctionIds = {
   CLAIM: '_claim',
+  CLAIM_REWARD: '_claimReward',
   CLOSE_CHECKIN: '_closeCheckin',
   CLOSE_CHECKOUT: '_closeCheckout',
   COLLECT_FEE: '_collectFee',
@@ -489,6 +496,8 @@ const FunctionResultCode = {
   INVALID_CHECKOUT_AMOUNT: 401,
   INVALID_RECIPIENT: 402,
   INVALID_TOKEN_BRIDGE_CONFIG: 403,
+  // Claim reward
+  INVALID_AMOUNT: 500,
 };
 
 /**

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -240,11 +240,11 @@ class PathUtil {
   }
 
   static getConsensusWhitelistPath() {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_WHITELIST]);
   }
 
   static getConsensusWhitelistAddrPath(address) {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST, address]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_WHITELIST, address]);
   }
 
   static getConsensusStakingAccountPath(address) {
@@ -257,39 +257,39 @@ class PathUtil {
   }
 
   static getConsensusRewardsPath(address) {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_REWARDS, address]);
   }
 
   static getConsensusRewardsUnclaimedPath(address) {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address, PredefinedDbPaths.REWARDS_UNCLAIMED]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_REWARDS, address, PredefinedDbPaths.CONSENSUS_REWARDS_UNCLAIMED]);
   }
 
   static getConsensusRewardsCumulativePath(address) {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address, PredefinedDbPaths.REWARDS_CUMULATIVE]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_REWARDS, address, PredefinedDbPaths.CONSENSUS_REWARDS_CUMULATIVE]);
   }
 
   static getConsensusNumberPath(blockNumber) {
-    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber]);
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_NUMBER, blockNumber]);
   }
 
   static getConsensusProposePath(blockNumber) {
     return CommonUtil.formatPath([
-        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);
+        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_NUMBER, blockNumber, PredefinedDbPaths.CONSENSUS_PROPOSE]);
   }
 
   static getConsensusVotePath(blockNumber, address) {
     return CommonUtil.formatPath([
-        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.VOTE, address]);
+        PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_NUMBER, blockNumber, PredefinedDbPaths.CONSENSUS_VOTE, address]);
   }
 
   static getGasFeeClaimPath(userAddr, recordId) {
     return CommonUtil.formatPath([
-        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.CLAIM, userAddr, recordId]);
+        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE_CLAIM, userAddr, recordId]);
   }
 
   static getGasFeeCollectPath(blockNumber, userAddr, txHash) {
     return CommonUtil.formatPath([
-        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.COLLECT, blockNumber, userAddr, txHash]);
+        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE_COLLECT, blockNumber, userAddr, txHash]);
   }
 
   static getReceiptPath(txHash) {

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -71,6 +71,10 @@ class PathUtil {
     return CommonUtil.formatPath([PredefinedDbPaths.MANAGE_APP, appName, PredefinedDbPaths.MANAGE_APP_CONFIG]);
   }
 
+  static getManageAppConfigAdminPath(appName) {
+    return `${PathUtil.getManageAppConfigPath(appName)}/${PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN}`;
+  }
+
   static getManageAppBillingUsersPath(appName, billingId) {
     return `${PathUtil.getManageAppConfigPath(appName)}/${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING}/` +
         `${billingId}/${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING_USERS}`;

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -256,6 +256,22 @@ class PathUtil {
     return CommonUtil.appendPath(accountPath, PredefinedDbPaths.BALANCE)
   }
 
+  static getConsensusRewardsPath(address) {
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address]);
+  }
+
+  static getConsensusRewardsUnclaimedPath(address) {
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address, PredefinedDbPaths.REWARDS_UNCLAIMED]);
+  }
+
+  static getConsensusRewardsCumulativePath(address) {
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.REWARDS, address, PredefinedDbPaths.REWARDS_CUMULATIVE]);
+  }
+
+  static getConsensusNumberPath(blockNumber) {
+    return CommonUtil.formatPath([PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber]);
+  }
+
   static getConsensusProposePath(blockNumber) {
     return CommonUtil.formatPath([
         PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.PROPOSE]);
@@ -266,9 +282,14 @@ class PathUtil {
         PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.NUMBER, blockNumber, PredefinedDbPaths.VOTE, address]);
   }
 
-  static getGasFeeCollectPath(userAddr, blockNumber, txHash) {
+  static getGasFeeClaimPath(userAddr, recordId) {
     return CommonUtil.formatPath([
-        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.COLLECT, userAddr, blockNumber, txHash]);
+        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.CLAIM, userAddr, recordId]);
+  }
+
+  static getGasFeeCollectPath(blockNumber, userAddr, txHash) {
+    return CommonUtil.formatPath([
+        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.COLLECT, blockNumber, userAddr, txHash]);
   }
 
   static getReceiptPath(txHash) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -637,6 +637,10 @@ class Functions {
 
   _distributeFee(value, context) {
     const blockNumber = context.params.number;
+    // NOTE(liayoo): Because we need to have the votes to determine which validators to give the
+    //               rewards to, we're distributing the rewards from the (N-1)th block when a
+    //               proposal for the Nth block is written. Genesis block doesn't have rewards,
+    //               so we can start from block number 2 (= processing block number 1) and so on.
     if (blockNumber <= 1) {
       return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
     }

--- a/db/functions.js
+++ b/db/functions.js
@@ -50,6 +50,8 @@ class Functions {
     this.nativeFunctionMap = {
       [NativeFunctionIds.CLAIM]: {
         func: this._claim.bind(this), ownerOnly: true, extraGasAmount: 0 },
+      [NativeFunctionIds.CLAIM_REWARD]: {
+        func: this._claimReward.bind(this), ownerOnly: true, extraGasAmount: 0 },
       [NativeFunctionIds.CLOSE_CHECKIN]: {
         func: this._closeCheckin.bind(this), ownerOnly: true, extraGasAmount: 10 },
       [NativeFunctionIds.CLOSE_CHECKOUT]: {
@@ -612,9 +614,8 @@ class Functions {
 
   _collectFee(value, context) {
     const from = context.params.from;
-    const blockNumber = context.params.block_number;
     const gasFeeServiceAccountName = CommonUtil.toServiceAccountName(
-        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE, blockNumber);
+        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE_UNCLAIMED);
     const result =
         this.setServiceAccountTransferOrLog(from, gasFeeServiceAccountName, value.amount, context);
     if (!CommonUtil.isFailedTx(result)) {
@@ -625,23 +626,59 @@ class Functions {
     }
   }
 
+  incrementConsensusRewards(address, amount, context) {
+    const rewardsPath = PathUtil.getConsensusRewardsPath(address);
+    const prevRewards = this.db.getValue(rewardsPath) || {};
+    return this.setValueOrLog(rewardsPath, {
+      [PredefinedDbPaths.REWARDS_UNCLAIMED]: (prevRewards[PredefinedDbPaths.REWARDS_UNCLAIMED] || 0) + amount,
+      [PredefinedDbPaths.REWARDS_CUMULATIVE]: (prevRewards[PredefinedDbPaths.REWARDS_CUMULATIVE] || 0) + amount
+    }, context);
+  }
+
   _distributeFee(value, context) {
     const blockNumber = context.params.number;
-    const gasCostTotal = value.gas_cost_total;
-    const proposer = value.proposer;
+    if (blockNumber <= 1) {
+      return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
+    }
+    const lastConsensusRound = this.db.getValue(PathUtil.getConsensusNumberPath(blockNumber - 1));
+    const gasCostTotal = lastConsensusRound.propose.gas_cost_total;
     if (gasCostTotal <= 0) {
       return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
     }
+    const proposer = lastConsensusRound.propose.proposer;
+    const totalAtStake = Object.values(lastConsensusRound.vote).reduce((acc, cur) => acc + cur.stake, 0);
+    const validators = Object.keys(lastConsensusRound.vote);
+    const proposerReward = gasCostTotal / 2;
+    const validatorRewardTotal = gasCostTotal - proposerReward;
+    this.incrementConsensusRewards(proposer, proposerReward, context);
+    for (const validator of validators) {
+      const validatorStake = lastConsensusRound.vote[validator].stake;
+      this.incrementConsensusRewards(
+          validator, validatorRewardTotal * (validatorStake / totalAtStake), context);
+    }
+    return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
+  }
+
+  _claimReward(value, context) {
+    const addr = context.params.user_addr;
+    const unclaimedRewardsPath = PathUtil.getConsensusRewardsUnclaimedPath(addr);
+    const unclaimedRewards = this.db.getValue(unclaimedRewardsPath) || 0;
+    if (unclaimedRewards < value.amount) {
+      return this.returnFuncResult(context, FunctionResultCode.INVALID_AMOUNT);
+    }
     const gasFeeServiceAccountName = CommonUtil.toServiceAccountName(
-        PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE, blockNumber);
-    const result = this.setServiceAccountTransferOrLog(
-        gasFeeServiceAccountName, proposer, gasCostTotal, context);
-    if (!CommonUtil.isFailedTx(result)) {
-      return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
-    } else {
-      logger.error(`  ===> _distributeFee failed: ${JSON.stringify(result)}`);
+      PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE, PredefinedDbPaths.GAS_FEE_UNCLAIMED);
+    const transferRes = this.setServiceAccountTransferOrLog(gasFeeServiceAccountName, addr, value.amount, context);
+    if (CommonUtil.isFailedTx(transferRes)) {
+      logger.error(`  ===> _claimReward failed: ${JSON.stringify(transferRes)}`);
       return this.returnFuncResult(context, FunctionResultCode.FAILURE);
     }
+    const updateUnclaimedRes = this.setValueOrLog(unclaimedRewardsPath, unclaimedRewards - value.amount, context);
+    if (CommonUtil.isFailedTx(updateUnclaimedRes)) {
+      logger.error(`  ===> _claimReward failed: ${JSON.stringify(updateUnclaimedRes)}`);
+      return this.returnFuncResult(context, FunctionResultCode.INTERNAL_ERROR);
+    }
+    return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
   }
 
   _stake(value, context) {

--- a/db/functions.js
+++ b/db/functions.js
@@ -630,8 +630,8 @@ class Functions {
     const rewardsPath = PathUtil.getConsensusRewardsPath(address);
     const prevRewards = this.db.getValue(rewardsPath) || {};
     return this.setValueOrLog(rewardsPath, {
-      [PredefinedDbPaths.REWARDS_UNCLAIMED]: (prevRewards[PredefinedDbPaths.REWARDS_UNCLAIMED] || 0) + amount,
-      [PredefinedDbPaths.REWARDS_CUMULATIVE]: (prevRewards[PredefinedDbPaths.REWARDS_CUMULATIVE] || 0) + amount
+      [PredefinedDbPaths.CONSENSUS_REWARDS_UNCLAIMED]: (prevRewards[PredefinedDbPaths.CONSENSUS_REWARDS_UNCLAIMED] || 0) + amount,
+      [PredefinedDbPaths.CONSENSUS_REWARDS_CUMULATIVE]: (prevRewards[PredefinedDbPaths.CONSENSUS_REWARDS_CUMULATIVE] || 0) + amount
     }, context);
   }
 

--- a/db/functions.js
+++ b/db/functions.js
@@ -651,11 +651,18 @@ class Functions {
     const proposerReward = gasCostTotal / 2;
     const validatorRewardTotal = gasCostTotal - proposerReward;
     this.incrementConsensusRewards(proposer, proposerReward, context);
-    for (const validator of validators) {
+    let rewardSum = 0;
+    validators.forEach((validator, index) => {
       const validatorStake = lastConsensusRound.vote[validator].stake;
-      this.incrementConsensusRewards(
-          validator, validatorRewardTotal * (validatorStake / totalAtStake), context);
-    }
+      let validatorReward = 0;
+      if (index === validators.length - 1) {
+        validatorReward = validatorRewardTotal - rewardSum;
+      } else {
+        validatorReward = validatorRewardTotal * (validatorStake / totalAtStake);
+        rewardSum += validatorReward;
+      }
+      this.incrementConsensusRewards(validator, validatorReward, context);
+    });
     return this.returnFuncResult(context, FunctionResultCode.SUCCESS);
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -1193,12 +1193,22 @@ class DB {
   }
 
   static trimExecutionResult(executionResult) {
-    return _.pick(executionResult, [
+    const trimmed = _.pick(executionResult, [
       PredefinedDbPaths.RECEIPTS_EXEC_RESULT_CODE,
       PredefinedDbPaths.RECEIPTS_EXEC_RESULT_ERROR_MESSAGE,
       PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_AMOUNT_CHARGED,
       PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL,
     ]);
+    if (executionResult[PredefinedDbPaths.RECEIPTS_EXEC_RESULT_RESULT_LIST]) {
+      trimmed[PredefinedDbPaths.RECEIPTS_EXEC_RESULT_RESULT_LIST] = {};
+      for (const [key, val] of Object.entries(executionResult[PredefinedDbPaths.RECEIPTS_EXEC_RESULT_RESULT_LIST])) {
+        trimmed[PredefinedDbPaths.RECEIPTS_EXEC_RESULT_RESULT_LIST][key] = _.pick(val, [
+          PredefinedDbPaths.RECEIPTS_EXEC_RESULT_CODE,
+          PredefinedDbPaths.RECEIPTS_EXEC_RESULT_ERROR_MESSAGE,
+        ]);
+      }
+    }
+    return trimmed;
   }
 
   recordReceipt(auth, tx, blockNumber, executionResult) {

--- a/db/index.js
+++ b/db/index.js
@@ -1181,7 +1181,7 @@ class DB {
     executionResult.gas_amount_charged = gasAmountChargedByTransfer;
     executionResult.gas_cost_total = CommonUtil.getTotalGasCost(gasPrice, executionResult.gas_amount_charged);
     if (executionResult.gas_cost_total <= 0) return;
-    const gasFeeCollectPath = PathUtil.getGasFeeCollectPath(billedTo, blockNumber, tx.hash);
+    const gasFeeCollectPath = PathUtil.getGasFeeCollectPath(blockNumber, billedTo, tx.hash);
     const gasFeeCollectRes = this.setValue(
         gasFeeCollectPath, { amount: executionResult.gas_cost_total }, auth, timestamp, tx);
     if (CommonUtil.isFailedTx(gasFeeCollectRes)) { // Should not happend

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -155,9 +155,8 @@ class RuleUtil {
   }
 
   isAppAdmin(appName, address, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
-    return getValue(`/${PredefinedDbPaths.MANAGE_APP}/${appName}/${PredefinedDbPaths.MANAGE_APP_CONFIG}/` +
-        `${PredefinedDbPaths.MANAGE_APP_CONFIG_ADMIN}/${address}`) === true;
+    const PathUtil = require('../common/path-util');
+    return getValue(`${PathUtil.getManageAppConfigAdminPath(appName)}/${address}`) === true;
   }
 
   isAppAdminFromServAcntName(accountName, address, getValue) {
@@ -166,12 +165,12 @@ class RuleUtil {
   }
 
   getBalancePath(addrOrServAcnt) {
-    const { PredefinedDbPaths } = require('../common/constants');
+    const PathUtil = require('../common/path-util');
     if (this.isServAcntName(addrOrServAcnt)) {
       const parsed = this.parseServAcntName(addrOrServAcnt);
-      return `/${PredefinedDbPaths.SERVICE_ACCOUNTS}/${parsed[0]}/${parsed[1]}/${parsed[2]}/${PredefinedDbPaths.BALANCE}`;
+      return PathUtil.getServiceAccountBalancePath(parsed[0], parsed[1], parsed[2]);
     } else {
-      return `/${PredefinedDbPaths.ACCOUNTS}/${addrOrServAcnt}/${PredefinedDbPaths.BALANCE}`;
+      return PathUtil.getAccountBalancePath(addrOrServAcnt);
     }
   }
 
@@ -180,37 +179,16 @@ class RuleUtil {
   }
 
   isBillingUser(billingServAcntName, userAddr, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
+    const PathUtil = require('../common/path-util');
     const parsed = this.parseServAcntName(billingServAcntName);
     const appName = parsed[1];
     const billingId = parsed[2];
-    return getValue(
-        `/${PredefinedDbPaths.MANAGE_APP}/${appName}/${PredefinedDbPaths.MANAGE_APP_CONFIG}/` +
-        `${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING}/${billingId}/` +
-        `${PredefinedDbPaths.MANAGE_APP_CONFIG_BILLING_USERS}/${userAddr}`) === true;
-  }
-
-  isGasFeeCollected(address, newData, txHash, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
-    const blockNumber = newData[PredefinedDbPaths.RECEIPTS_BLOCK_NUMBER];
-    const gasCost = _.get(newData, `${PredefinedDbPaths.RECEIPTS_EXEC_RESULT}.` +
-        `${PredefinedDbPaths.RECEIPTS_EXEC_RESULT_GAS_COST_TOTAL}`);
-    if (gasCost === undefined) {
-      return false;
-    }
-    const billing = _.get(newData, `${PredefinedDbPaths.RECEIPTS_BILLING}`);
-    const collectedFrom = billing ? `${PredefinedDbPaths.GAS_FEE_BILLING}|${billing}` : address;
-    const feeCollected = getValue(
-        `/${PredefinedDbPaths.GAS_FEE}/${PredefinedDbPaths.GAS_FEE_COLLECT}/${collectedFrom}` +
-        `/${blockNumber}/${txHash}/${PredefinedDbPaths.GAS_FEE_AMOUNT}`) || 0;
-    return feeCollected === gasCost;
+    return getValue(`${PathUtil.getManageAppBillingUsersPath(appName, billingId)}/${userAddr}`) === true;
   }
 
   getConsensusStakeBalance(address, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
-    return getValue(
-        `/${PredefinedDbPaths.SERVICE_ACCOUNTS}/${PredefinedDbPaths.STAKING}/` +
-        `${PredefinedDbPaths.CONSENSUS}/${address}|0/${PredefinedDbPaths.BALANCE}`) || 0;
+    const PathUtil = require('../common/path-util');
+    return getValue(PathUtil.getConsensusStakingAccountBalancePath(address)) || 0;
   }
 
   getOwnerAddr() {
@@ -234,15 +212,13 @@ class RuleUtil {
   }
 
   getTokenBridgeConfig(type, tokenId, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
-    return getValue(`/${PredefinedDbPaths.TOKEN}/${PredefinedDbPaths.TOKEN_BRIDGE}/${type}/${tokenId}`);
+    const PathUtil = require('../common/path-util');
+    return getValue(PathUtil.getTokenBridgeConfigPath(type, tokenId));
   }
 
   getTokenPoolAddr(type, tokenId, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
-    return getValue(
-        `/${PredefinedDbPaths.TOKEN}/${PredefinedDbPaths.TOKEN_BRIDGE}/${type}/${tokenId}/` +
-        `${PredefinedDbPaths.TOKEN_BRIDGE_TOKEN_POOL}`);
+    const PathUtil = require('../common/path-util');
+    return getValue(PathUtil.getTokenBridgeTokenPoolPath(type, tokenId));
   }
 
   getTokenPoolAddrFromHistoryData(userAddr, checkoutId, getValue) {
@@ -276,12 +252,11 @@ class RuleUtil {
   }
 
   validateClaimRewardData(userAddr, data, getValue) {
-    const { PredefinedDbPaths } = require('../common/constants');
+    const PathUtil = require('../common/path-util');
     if (!this.isDict(data) || !this.isNumber(data.amount) || data.amount <= 0) {
       return false;
     }
-    const unclaimed = getValue(`/${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.CONSENSUS_REWARDS}/` +
-        `${userAddr}/${PredefinedDbPaths.CONSENSUS_REWARDS_UNCLAIMED}`) || 0;
+    const unclaimed = getValue(PathUtil.getConsensusRewardsUnclaimedPath(userAddr)) || 0;
     return data.amount <= unclaimed;
   }
 

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -274,6 +274,21 @@ class RuleUtil {
         (data.response.status === FunctionResultCode.SUCCESS ||
         data.response.status === FunctionResultCode.FAILURE);
   }
+
+  validateClaimRewardData(userAddr, data, getValue) {
+    const { PredefinedDbPaths } = require('../common/constants');
+    if (!this.isDict(data) || !this.isNumber(data.amount) || data.amount <= 0) {
+      return false;
+    }
+    const unclaimed = getValue(`/${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.REWARDS}/` +
+        `${userAddr}/${PredefinedDbPaths.REWARDS_UNCLAIMED}`) || 0;
+    return data.amount <= unclaimed;
+  }
+
+  validateCollectFeeData(data, newData, from, getValue) {
+    return data === null && this.isDict(newData) && this.isNumber(newData.amount) &&
+        newData.amount <= this.getBalance(from, getValue);
+  }
 }
 
 module.exports = RuleUtil;

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -199,9 +199,9 @@ class RuleUtil {
       return false;
     }
     const billing = _.get(newData, `${PredefinedDbPaths.RECEIPTS_BILLING}`);
-    const collectedFrom = billing ? `${PredefinedDbPaths.BILLING}|${billing}` : address;
+    const collectedFrom = billing ? `${PredefinedDbPaths.GAS_FEE_BILLING}|${billing}` : address;
     const feeCollected = getValue(
-        `/${PredefinedDbPaths.GAS_FEE}/${PredefinedDbPaths.COLLECT}/${collectedFrom}` +
+        `/${PredefinedDbPaths.GAS_FEE}/${PredefinedDbPaths.GAS_FEE_COLLECT}/${collectedFrom}` +
         `/${blockNumber}/${txHash}/${PredefinedDbPaths.GAS_FEE_AMOUNT}`) || 0;
     return feeCollected === gasCost;
   }
@@ -280,8 +280,8 @@ class RuleUtil {
     if (!this.isDict(data) || !this.isNumber(data.amount) || data.amount <= 0) {
       return false;
     }
-    const unclaimed = getValue(`/${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.REWARDS}/` +
-        `${userAddr}/${PredefinedDbPaths.REWARDS_UNCLAIMED}`) || 0;
+    const unclaimed = getValue(`/${PredefinedDbPaths.CONSENSUS}/${PredefinedDbPaths.CONSENSUS_REWARDS}/` +
+        `${userAddr}/${PredefinedDbPaths.CONSENSUS_REWARDS_UNCLAIMED}`) || 0;
     return data.amount <= unclaimed;
   }
 

--- a/genesis-configs/base/genesis_functions.json
+++ b/genesis-configs/base/genesis_functions.json
@@ -94,9 +94,21 @@
     }
   },
   "gas_fee": {
+    "claim": {
+      "$user_addr": {
+        "$record_id": {
+          ".function": {
+            "_claimReward": {
+              "function_type": "NATIVE",
+              "function_id": "_claimReward"
+            }
+          }
+        }
+      }
+    },
     "collect": {
-      "$from": {
-        "$block_number": {
+      "$block_number": {
+        "$from": {
           "$tx_hash": {
             ".function": {
               "_collectFee": {

--- a/genesis-configs/base/genesis_rules.json
+++ b/genesis-configs/base/genesis_rules.json
@@ -69,7 +69,7 @@
         },
         "propose": {
           ".rule": {
-            "write": "util.isDict(newData) && newData.proposer === auth.addr && Number($number) === newData.number && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || (getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') >= util.getMinStakeAmount() && getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') <= util.getMaxStakeAmount())) && util.isNumber(newData.gas_cost_total) && (newData.gas_cost_total === 0 || newData.gas_cost_total === getValue('/service_accounts/gas_fee/gas_fee/' + $number + '/balance'))"
+            "write": "util.isDict(newData) && newData.proposer === auth.addr && Number($number) === newData.number && getValue('/consensus/whitelist/' + auth.addr) === true && (lastBlockNumber < 1 || (getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') >= util.getMinStakeAmount() && getValue('/service_accounts/staking/consensus/' + auth.addr + '|0/balance') <= util.getMaxStakeAmount())) && util.isNumber(newData.gas_cost_total)"
           }
         },
         "vote": {
@@ -78,6 +78,13 @@
               "write": "auth.addr === $user_addr && util.isDict(newData) && util.isString(newData.block_hash) && util.isNumber(newData.stake) && (lastBlockNumber < 1 || util.getConsensusStakeBalance(auth.addr, getValue) === newData.stake)"
             }
           }
+        }
+      }
+    },
+    "rewards": {
+      "$user_addr": {
+        ".rule": {
+          "write": "auth.fid === '_distributeFee' || auth.fid === '_claimReward'"
         }
       }
     },
@@ -127,12 +134,21 @@
     }
   },
   "gas_fee": {
+    "claim": {
+      "$user_addr": {
+        "$record_id": {
+          ".rule": {
+            "write": "auth.addr === $user_addr && util.validateClaimRewardData(auth.addr, newData, getValue) === true"
+          }
+        }
+      }
+    },
     "collect": {
-      "$from": {
-        "$block_number": {
+      "$block_number": {
+        "$from": {
           "$tx_hash": {
             ".rule": {
-              "write": "(auth.addr === $from || (util.isServAcntName($from) && util.isBillingUser($from, auth.addr, getValue) === true)) && data === null && util.isDict(newData) && util.isNumber(newData.amount) && newData.amount <= util.getBalance($from, getValue)"
+              "write": "(auth.addr === $from || (util.isServAcntName($from) && util.isBillingUser($from, auth.addr, getValue) === true)) && util.validateCollectFeeData(data, newData, $from, getValue)"
             }
           }
         }
@@ -269,7 +285,7 @@
         "$key": {
           "value": {
             ".rule": {
-              "write": "(auth.addr === $from || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release' || auth.fid === '_collectFee' || auth.fid === '_distributeFee' || auth.fid === '_openCheckout' || auth.fid === '_closeCheckout') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && util.getBalance($from, getValue) >= newData"
+              "write": "(auth.addr === $from || auth.fid === '_stake' || auth.fid === '_unstake' || auth.fid === '_pay' || auth.fid === '_claim' || auth.fid === '_hold' || auth.fid === '_release' || auth.fid === '_collectFee' || auth.fid === '_claimReward' || auth.fid === '_openCheckout' || auth.fid === '_closeCheckout') && !getValue('transfer/' + $from + '/' + $to + '/' + $key) && (util.isServAcntName($from) || util.isCksumAddr($from)) && (util.isServAcntName($to) || util.isCksumAddr($to)) && $from !== $to && util.isNumber(newData) && util.getBalance($from, getValue) >= newData"
             }
           },
           "result": {

--- a/integration/consensus.test.js
+++ b/integration/consensus.test.js
@@ -20,6 +20,7 @@ const {
   waitForNewBlocks,
   parseOrLog,
   getLastBlock,
+  getBlockByNumber,
 } = require('../unittest/test-util');
 
 const MAX_NUM_VALIDATORS = 4;
@@ -286,5 +287,153 @@ describe('Consensus', () => {
       assert.deepEqual(votes[server4Addr], undefined);
       assert.deepEqual(votes[server5Addr][PredefinedDbPaths.STAKE], 100020);
     });
-  })
+  });
+
+  describe('Rewards', () => {
+    it('consensus rewards are updated', async () => {
+      const rewardsBefore = parseOrLog(syncRequest('GET',
+          server2 + `/get_value?ref=/consensus/rewards`).body.toString('utf-8')).result || {};
+      const txWithGasFee = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+        ref: `/transfer/${server1Addr}/${server2Addr}/0/value`,
+        value: 1,
+        gas_price: 1000000
+      }}).body.toString('utf-8')).result;
+      if (!(await waitUntilTxFinalized(serverList, txWithGasFee.tx_hash))) {
+        console.error(`Failed to check finalization of tx.`);
+      }
+      await waitForNewBlocks(server2); // Make sure 1 more block is finalized
+      const rewardsAfter = parseOrLog(syncRequest('GET',
+          server2 + `/get_value?ref=/consensus/rewards`).body.toString('utf-8')).result;
+      const txInfo = parseOrLog(syncRequest('GET',
+          server2 + `/get_transaction?hash=${txWithGasFee.tx_hash}`).body.toString('utf-8')).result;
+      const blockNumber = txInfo.number;
+      const consensusRound = parseOrLog(syncRequest('GET',
+          server2 + `/get_value?ref=/consensus/number/${blockNumber}`).body.toString('utf-8')).result;
+      const proposer = consensusRound.propose.proposer;
+      const validators = Object.keys(consensusRound.vote);
+      const gasCostTotal = consensusRound.propose.gas_cost_total;
+      const proposerReward = gasCostTotal / 2;
+      const validatorRewardTotal = gasCostTotal - proposerReward;
+      const totalAtStake = Object.values(consensusRound.vote).reduce((acc, cur) => acc + cur.stake, 0);
+      for (const validator of validators) {
+        const validatorStake = consensusRound.vote[validator].stake;
+        const validatorReward = validatorRewardTotal * (validatorStake / totalAtStake) +
+            (validator === proposer ? proposerReward : 0);
+        assert.deepEqual(_.get(rewardsBefore, `${validator}.unclaimed`, 0) + validatorReward,
+            rewardsAfter[validator].unclaimed);
+        assert.deepEqual(_.get(rewardsBefore, `${validator}.cumulative`, 0) + validatorReward,
+            rewardsAfter[validator].cumulative);
+      }
+      assert.deepEqual(txWithGasFee.result.gas_cost_total, consensusRound.propose.gas_cost_total);
+    });
+
+    it('cannot claim more than unclaimed rewards', async () => {
+      const unclaimed = parseOrLog(syncRequest('GET',
+          server2 + `/get_value?ref=/consensus/rewards/${server1Addr}/unclaimed`).body.toString('utf-8')).result;
+      const claimTx = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+        ref: `/gas_fee/claim/${server1Addr}/0`,
+        value: {
+          amount: unclaimed + 1
+        }
+      }}).body.toString('utf-8')).result;
+      if (!(await waitUntilTxFinalized(serverList, claimTx.tx_hash))) {
+        console.error(`Failed to check finalization of tx.`);
+      }
+      assert.deepEqual(claimTx.result, {
+        "gas_amount_total":{
+          "bandwidth":{
+            "service":1
+          },
+          "state":{
+            "service":0
+          }
+        },
+        "gas_cost_total":0,
+        "error_message":"No write permission on: /gas_fee/claim/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/0",
+        "code":103,
+        "bandwidth_gas_amount":1,
+        "gas_amount_charged":1
+      });
+    });
+
+    it('can claim unclaimed rewards', async () => {
+      const unclaimed = parseOrLog(syncRequest('GET',
+          server2 + `/get_value?ref=/consensus/rewards/${server1Addr}/unclaimed`).body.toString('utf-8')).result;
+      const claimTx = parseOrLog(syncRequest('POST', server1 + '/set_value', {json: {
+        ref: `/gas_fee/claim/${server1Addr}/1`,
+        value: {
+          amount: unclaimed
+        },
+        timestamp: 1629377509815
+      }}).body.toString('utf-8')).result;
+      if (!(await waitUntilTxFinalized(serverList, claimTx.tx_hash))) {
+        console.error(`Failed to check finalization of tx.`);
+      }
+      assert.deepEqual(claimTx.result, {
+        "gas_amount_total": {
+          "bandwidth": {
+            "service": 6
+          },
+          "state": {
+            "service": 2414
+          }
+        },
+        "gas_cost_total": 0,
+        "func_results": {
+          "_claimReward": {
+            "op_results": {
+              "0": {
+                "path": "/transfer/gas_fee|gas_fee|unclaimed/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1629377509815/value",
+                "result": {
+                  "func_results": {
+                    "_transfer": {
+                      "op_results": {
+                        "0": {
+                          "path": "/service_accounts/gas_fee/gas_fee/unclaimed/balance",
+                          "result": {
+                            "code": 0,
+                            "bandwidth_gas_amount": 1
+                          }
+                        },
+                        "1": {
+                          "path": "/accounts/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/balance",
+                          "result": {
+                            "code": 0,
+                            "bandwidth_gas_amount": 1
+                          }
+                        },
+                        "2": {
+                          "path": "/transfer/gas_fee|gas_fee|unclaimed/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/1629377509815/result",
+                          "result": {
+                            "code": 0,
+                            "bandwidth_gas_amount": 1
+                          }
+                        }
+                      },
+                      "code": 0,
+                      "bandwidth_gas_amount": 0
+                    }
+                  },
+                  "code": 0,
+                  "bandwidth_gas_amount": 1
+                }
+              },
+              "1": {
+                "path": "/consensus/rewards/0x00ADEc28B6a845a085e03591bE7550dd68673C1C/unclaimed",
+                "result": {
+                  "code": 0,
+                  "bandwidth_gas_amount": 1
+                }
+              }
+            },
+            "code": 0,
+            "bandwidth_gas_amount": 0
+          }
+        },
+        "code": 0,
+        "bandwidth_gas_amount": 1,
+        "gas_amount_charged": 2420
+      });
+    });
+  });
 });

--- a/integration/consensus.test.js
+++ b/integration/consensus.test.js
@@ -189,13 +189,13 @@ describe('Consensus', () => {
         iterCount++;
         await CommonUtil.sleep(200);
       }
-      assert.deepEqual(lastBlock.validators[server4Addr][PredefinedDbPaths.PROPOSAL_RIGHT], false);
+      assert.deepEqual(lastBlock.validators[server4Addr][PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT], false);
       await waitForNewBlocks(server1, 1);
       const server4Voted = parseOrLog(syncRequest(
         'GET',
         `${server1}/get_value?ref=/consensus/number/${lastBlock.number}/vote/${server4Addr}`
       ).body.toString('utf-8')).result;
-      assert.deepEqual(server4Voted[PredefinedDbPaths.STAKE], 100000);
+      assert.deepEqual(server4Voted[PredefinedDbPaths.CONSENSUS_STAKE], 100000);
       // 3. server5 stakes 100000
       const server5StakeRes = parseOrLog(syncRequest('POST', server5 + '/set_value', {json: {
         ref: `/staking/consensus/${server5Addr}/0/stake/${Date.now()}/value`,
@@ -218,14 +218,14 @@ describe('Consensus', () => {
         iterCount++;
         await CommonUtil.sleep(200);
       }
-      assert.deepEqual(lastBlock.validators[server5Addr][PredefinedDbPaths.PROPOSAL_RIGHT], false);
+      assert.deepEqual(lastBlock.validators[server5Addr][PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT], false);
       await waitForNewBlocks(server1, 1);
       const votes = parseOrLog(syncRequest(
         'GET',
         `${server1}/get_value?ref=/consensus/number/${lastBlock.number}/vote`
       ).body.toString('utf-8')).result;
       assert.deepEqual(votes[server4Addr], undefined);
-      assert.deepEqual(votes[server5Addr][PredefinedDbPaths.STAKE], 100000);
+      assert.deepEqual(votes[server5Addr][PredefinedDbPaths.CONSENSUS_STAKE], 100000);
     });
 
     it('When more than MAX_NUM_VALIDATORS validators exist, validatators with bigger stakes get prioritized', async () => {
@@ -256,7 +256,7 @@ describe('Consensus', () => {
         `${server1}/get_value?ref=/consensus/number/${lastBlock.number}/vote`
       ).body.toString('utf-8')).result;
       assert.deepEqual(votes[server5Addr], undefined);
-      assert.deepEqual(votes[server4Addr][PredefinedDbPaths.STAKE], 100010);
+      assert.deepEqual(votes[server4Addr][PredefinedDbPaths.CONSENSUS_STAKE], 100010);
       // 3. server5 stakes 20 more AIN
       const server5StakeRes = parseOrLog(syncRequest('POST', server5 + '/set_value', {json: {
         ref: `/staking/consensus/${server5Addr}/0/stake/${Date.now()}/value`,
@@ -285,7 +285,7 @@ describe('Consensus', () => {
         `${server1}/get_value?ref=/consensus/number/${lastBlock.number}/vote`
       ).body.toString('utf-8')).result;
       assert.deepEqual(votes[server4Addr], undefined);
-      assert.deepEqual(votes[server5Addr][PredefinedDbPaths.STAKE], 100020);
+      assert.deepEqual(votes[server5Addr][PredefinedDbPaths.CONSENSUS_STAKE], 100020);
     });
   });
 

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -7106,6 +7106,9 @@ describe('Blockchain Node', () => {
           signature,
           protoVer: CURRENT_PROTOCOL_VERSION
         });
+        if (!(await waitUntilTxFinalized(serverList, _.get(res, 'result.result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
         assert.deepEqual(_.get(res, 'result.result.result'), {
           "gas_amount_total": {
             "bandwidth": {
@@ -7352,7 +7355,7 @@ describe('Blockchain Node', () => {
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',
-        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+        `${server2}/get_value?ref=/gas_fee/collect/${tx.number}/${billingUserA}/${txRes.tx_hash}/amount`
       ).body.toString('utf-8')).result;
       assert.deepEqual(
         gasFeeCollected,
@@ -7430,7 +7433,7 @@ describe('Blockchain Node', () => {
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',
-        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+        `${server2}/get_value?ref=/gas_fee/collect/${tx.number}/${billingUserA}/${txRes.tx_hash}/amount`
       ).body.toString('utf-8')).result;
       assert.deepEqual(
         gasFeeCollected,
@@ -7490,7 +7493,7 @@ describe('Blockchain Node', () => {
       const tx = parseOrLog(syncRequest('GET', server2 + `/get_transaction?hash=${txRes.tx_hash}`).body.toString('utf-8')).result;
       const gasFeeCollected = parseOrLog(syncRequest(
         'GET',
-        `${server2}/get_value?ref=/gas_fee/collect/${billingUserA}/${tx.number}/${txRes.tx_hash}/amount`
+        `${server2}/get_value?ref=/gas_fee/collect/${tx.number}/${billingUserA}/${txRes.tx_hash}/amount`
       ).body.toString('utf-8')).result;
       assert.deepEqual(
         gasFeeCollected,
@@ -7681,7 +7684,7 @@ describe('Blockchain Node', () => {
       // Failed tx's gas fees have been collected
       const blockNumber = receipt.block_number;
       const gasFeeCollected = parseOrLog(syncRequest(
-        'GET', server2 + `/get_value?ref=/gas_fee/collect/${server1Address}/${blockNumber}/${txHash}/amount`
+        'GET', server2 + `/get_value?ref=/gas_fee/collect/${blockNumber}/${server1Address}/${txHash}/amount`
       ).body.toString('utf-8')).result;
       assert.deepEqual(gasFeeCollected, body.result.result.gas_cost_total);
 

--- a/unittest/block-pool.test.js
+++ b/unittest/block-pool.test.js
@@ -25,7 +25,7 @@ describe("BlockPool", () => {
   function createAndAddBlock(node, blockPool, lastBlock, number, epoch) {
     const block = Block.create(
         lastBlock.hash, [], [], number, epoch, '', node.account.address,
-        {[node.account.address]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true } }, 0, 0);
+        {[node.account.address]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true } }, 0, 0);
     const proposal = getTransaction(node, {
         operation: {
           type: 'SET_VALUE',
@@ -33,7 +33,7 @@ describe("BlockPool", () => {
           value: {
             number: block.number,
             epoch: block.epoch,
-            validators: { [node.account.address]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true } },
+            validators: { [node.account.address]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true } },
             total_at_stake: 100000,
             proposer: node.account.address,
             block_hash: block.hash
@@ -66,7 +66,7 @@ describe("BlockPool", () => {
     const addr = node1.account.address;
     const block = Block.create(
         lastBlock.hash, [], [], lastBlock.number + 1, lastBlock.epoch + 1, '', addr,
-        {[addr]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true }}, 0, 0);
+        {[addr]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true }}, 0, 0);
     const proposalTx = getTransaction(node1, {
         operation: {
           type: 'SET_VALUE',
@@ -74,7 +74,7 @@ describe("BlockPool", () => {
           value: {
             number: block.number,
             epoch: block.epoch,
-            validators: {[addr]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true } },
+            validators: {[addr]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true } },
             total_at_stake: 100000,
             proposer: addr,
             block_hash: block.hash
@@ -95,7 +95,7 @@ describe("BlockPool", () => {
     const lastBlock = node1.bc.lastBlock();
     const block = Block.create(
         lastBlock.hash, [], [], lastBlock.number + 1, lastBlock.epoch + 1, '', addr,
-        {[addr]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true }}, 0, 0);
+        {[addr]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true }}, 0, 0);
     const proposalTx = getTransaction(node1, {
         operation: {
           type: 'SET_VALUE',
@@ -103,7 +103,7 @@ describe("BlockPool", () => {
           value: {
             number: block.number,
             epoch: block.epoch,
-            validators: {[addr]: { [PredefinedDbPaths.STAKE]: 100000, [PredefinedDbPaths.PROPOSAL_RIGHT]: true } },
+            validators: {[addr]: { [PredefinedDbPaths.CONSENSUS_STAKE]: 100000, [PredefinedDbPaths.CONSENSUS_PROPOSAL_RIGHT]: true } },
             total_at_stake: 100000,
             proposer: addr,
             block_hash: block.hash

--- a/unittest/consensus.test.js
+++ b/unittest/consensus.test.js
@@ -116,7 +116,7 @@ describe("Consensus", () => {
     // Bypass whitelist rule check (need owner's private key)
     const tempDb = node1.createTempDb(node1.db.stateVersion, 'CONSENSUS_UNIT_TEST', lastBlock.number);
     tempDb.writeDatabase(
-        [PredefinedDbPaths.VALUES_ROOT, PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.WHITELIST, addr],
+        [PredefinedDbPaths.VALUES_ROOT, PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_WHITELIST, addr],
         true);
     node1.cloneAndFinalizeVersion(tempDb.stateVersion, -1); // Bypass already existing final state version
     

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -2717,7 +2717,7 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 25);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (10753622 > 10000000)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (10756390 > 10000000)");
         assert.deepEqual(res.gas_amount_total, expectedGasAmountTotal);
         assert.deepEqual(res.gas_cost_total, 3.5460599999999998);
       });


### PR DESCRIPTION
- Now tx fees are split across the proposer and the validators
- New consensus path has been introduced to keep track of unclaimed & cumulative rewards (`/consensus/rewards/${address}: { unclaimed, cumulative }`)
- Added _claimReward native function
  - Triggered by setting a value at `/gas_fee/claim/${address}/${key}: { amount }`
- DB structure updated: `/gas_fee/collect/${address}/${blockNumber}/${txHash}` => `/gas_fee/collect/${blockNumber}/${address}/${txHash}`
- Fixed trimExecutionResult() for multi-set txs