### PR TITLE
Add set / update / verify proof hash APIs

### DIFF
--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -1,5 +1,7 @@
 const logger = require('../logger')('RADIX_NODE');
 
+const StateNode = require('./state-node');
+
 /**
  * Implements a radix node, which is used as a component of RadixTree.
  */
@@ -10,6 +12,7 @@ class RadixNode {
     this.labelSuffix = '';
     this.parent = null;
     this.radixChildMap = new Map();
+    this.proofHash = null;
   }
 
   getStateNode() {
@@ -17,7 +20,15 @@ class RadixNode {
   }
 
   setStateNode(stateNode) {
+    const LOG_HEADER = 'setStateNode';
+    if (!(stateNode instanceof StateNode)) {
+      logger.error(
+          `[${LOG_HEADER}] Setting with a non-StateNode instance.`);
+      // Does nothing.
+      return false;
+    }
     this.stateNode = stateNode;
+    return true;
   }
 
   hasStateNode() {
@@ -25,7 +36,7 @@ class RadixNode {
   }
 
   resetStateNode() {
-    this.setStateNode(null);
+    this.stateNode = null;
   }
 
   getLabelRadix() {

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -173,6 +173,8 @@ class RadixNode {
     if (this.hasStateNode()) {
       preimage = this.getStateNode().getProofHash();
     }
+    // NOTE(platfowner): Put delimiter twice to distinguish the state node proof hash and
+    // the radix child proof hash.
     preimage += `${HASH_DELIMITER}${HASH_DELIMITER}`;
     preimage += this.getChildNodes().map((child) => {
       return `${child.getLabel()}${HASH_DELIMITER}${child.getProofHash()}`;

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -185,6 +185,42 @@ class RadixNode {
     this.setProofHash(this._buildProofHash());
   }
 
+  setProofHashForRadixTree() {
+    let numAffectedNodes = 0;
+    for (const child of this.getChildNodes()) {
+      numAffectedNodes += child.setProofHashForRadixTree();
+    }
+    this.updateProofHash();
+    numAffectedNodes++;
+
+    return numAffectedNodes;
+  }
+
+  updateProofHashForRootPath() {
+    let numAffectedNodes = 0;
+    let curNode = this;
+    curNode.updateProofHash();
+    numAffectedNodes++;
+    while (curNode.hasParent()) {
+      curNode = curNode.getParent();
+      curNode.updateProofHash();
+      numAffectedNodes++;
+    }
+    return numAffectedNodes;
+  }
+
+  verifyProofHashForRadixTree() {
+    if (!this.verifyProofHash()) {
+      return false;
+    }
+    for (const child of this.getChildNodes()) {
+      if (!child.verifyProofHashForRadixTree()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Converts the subtree to a js object.
    * This is for testing / debugging purpose.

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -176,7 +176,7 @@ class RadixNode {
     preimage += `${HASH_DELIMITER}${HASH_DELIMITER}`;
     preimage += this.getChildNodes().map((child) => {
       return `${child.getLabel()}${HASH_DELIMITER}${child.getProofHash()}`;
-    }, '').join(HASH_DELIMITER);
+    }).join(HASH_DELIMITER);
     return CommonUtil.hashString(preimage);
   }
 

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -75,6 +75,10 @@ class RadixNode {
     this.setLabelSuffix('');
   }
 
+  getLabel() {
+    return this.getLabelRadix() + this.getLabelSuffix();
+  }
+
   getParent() {
     return this.parent;
   }
@@ -171,8 +175,7 @@ class RadixNode {
     }
     preimage += `${HASH_DELIMITER}${HASH_DELIMITER}`;
     preimage += this.getChildNodes().map((child) => {
-      const childLabel = `${child.getLabelRadix()}${child.getLabelSuffix()}`;
-      return `${childLabel}${HASH_DELIMITER}${child.getProofHash()}`;
+      return `${child.getLabel()}${HASH_DELIMITER}${child.getProofHash()}`;
     }, '').join(HASH_DELIMITER);
     return CommonUtil.hashString(preimage);
   }

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -7,7 +7,6 @@ const RadixNode = require('./radix-node');
  * A database for (label, stateNode) pairs. For efficient update and retrieval of proof hashes,
  * it uses a radix tree internally.
  */
-// TODO(platfowner): Add access methods for proof hashes.
 class RadixTree {
   constructor() {
     this.root = new RadixNode();
@@ -242,6 +241,34 @@ class RadixTree {
 
   size() {
     return this.stateNodeMap.size;
+  }
+
+  getRootProofHash() {
+    return this.root.getProofHash();
+  }
+
+  hasRootProofHash() {
+    return this.root.hasProofHash();
+  }
+
+  setProofHashForRadixTree() {
+    return this.root.setProofHashForRadixTree();
+  }
+
+  updateProofHashForRootPath(label) {
+    const hexLabel = RadixTree._toHexLabel(label);
+    const node = this._getRadixNodeForReading(hexLabel);
+    if (node === null) {
+      logger.error(
+          `[${LOG_HEADER}] Updating proof hash for non-existing child with label: ${label}.`);
+      // Does nothing.
+      return 0;
+    }
+    return node.updateProofHashForRootPath();
+  }
+
+  verifyProofHashForRadixTree() {
+    return this.root.verifyProofHashForRadixTree();
   }
 
   /**

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -128,7 +128,7 @@ class RadixTree {
   _setInTree(label, stateNode) {
     const hexLabel = RadixTree._toHexLabel(label);
     const node = this._getRadixNodeForWriting(hexLabel);
-    node.setStateNode(stateNode);
+    return node.setStateNode(stateNode);
   }
 
   _setInMap(label, stateNode) {
@@ -137,9 +137,12 @@ class RadixTree {
 
   set(label, stateNode) {
     // 1. Set in the radix tree.
-    this._setInTree(label, stateNode);
+    if (!this._setInTree(label, stateNode)) {
+      return false;
+    }
     // 2. Set in the hash map.
     this._setInMap(label, stateNode);
+    return true;
   }
 
   _hasInTree(label) {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -297,7 +297,7 @@ class StateNode {
     } else {
       preimage = this.getChildLabels().map((label) => {
         return `${label}${HASH_DELIMITER}${this.getChild(label).getProofHash()}`;
-      }, '').join(HASH_DELIMITER);
+      }).join(HASH_DELIMITER);
     }
     return CommonUtil.hashString(CommonUtil.toString(preimage));
   }

--- a/unittest/radix-node.test.js
+++ b/unittest/radix-node.test.js
@@ -77,6 +77,22 @@ describe("radix-node", () => {
     });
   });
 
+  describe("label", () => {
+    it("get", () => {
+      const labelRadix = '0';
+      const labelSuffix = 'ffff';
+      expect(node.getLabel()).to.equal('');
+      node.setLabelRadix(labelRadix);
+      expect(node.getLabel()).to.equal(labelRadix);
+      node.setLabelSuffix(labelSuffix);
+      expect(node.getLabel()).to.equal(labelRadix + labelSuffix);
+      node.resetLabelSuffix();
+      expect(node.getLabel()).to.equal(labelRadix);
+      node.resetLabelRadix();
+      expect(node.getLabel()).to.equal('');
+    });
+  });
+
   describe("parent", () => {
     it("get / set / has / reset", () => {
       const parent = new RadixNode();

--- a/unittest/radix-node.test.js
+++ b/unittest/radix-node.test.js
@@ -274,65 +274,317 @@ describe("radix-node", () => {
   });
 
   describe("proofHash", () => {
-    const labelRadix1 = '0';
-    const labelSuffix1 = '0000';
-    const child1 = new RadixNode();
-    const childPH1 = 'childPH1';
+    const labelRadix1 = '1';
+    const labelSuffix1 = '100';
+    let child1;
 
-    const labelRadix2 = '1';
-    const labelSuffix2 = '1111';
-    const child2 = new RadixNode();
-    const childPH2 = 'childPH2';
+    const labelRadix2 = '2';
+    const labelSuffix2 = '200';
+    let child2;
 
-    const stateNode = new StateNode();
+    const labelRadix11 = '1';
+    const labelSuffix11 = '110';
+    let child11;
+
+    const labelRadix12 = '2';
+    const labelSuffix12 = '120';
+    let child12;
+
+    const labelRadix21 = '1';
+    const labelSuffix21 = '210';
+    let child21;
+
+    const labelRadix22 = '2';
+    const labelSuffix22 = '220';
+    let child22;
+
+    let stateNode;
     const stateNodePH = 'stateNodePH';
+
+    let childStateNode1;
+    const childStateNodePH1 = 'childStateNodePH1';
+
+    let childStateNode2;
+    const childStateNodePH2 = 'childStateNodePH2';
+
+    let childStateNode11;
+    const childStateNodePH11 = 'childStateNodePH11';
+
+    let childStateNode12;
+    const childStateNodePH12 = 'childStateNodePH12';
+
+    let childStateNode21;
+    const childStateNodePH21 = 'childStateNodePH21';
+
+    let childStateNode22;
+    const childStateNodePH22 = 'childStateNodePH22';
+
+    beforeEach(() => {
+      child1 = new RadixNode();
+      child2 = new RadixNode();
+      child11 = new RadixNode();
+      child12 = new RadixNode();
+      child21 = new RadixNode();
+      child22 = new RadixNode();
+
+      stateNode = new StateNode();
+      stateNode.setProofHash(stateNodePH);
+      node.setStateNode(stateNode);
+
+      childStateNode1 = new StateNode();
+      childStateNode1.setProofHash(childStateNodePH1);
+      child1.setStateNode(childStateNode1);
+
+      childStateNode2 = new StateNode();
+      childStateNode2.setProofHash(childStateNodePH2);
+      child2.setStateNode(childStateNode2);
+
+      childStateNode11 = new StateNode();
+      childStateNode11.setProofHash(childStateNodePH11);
+      child11.setStateNode(childStateNode11);
+
+      childStateNode12 = new StateNode();
+      childStateNode12.setProofHash(childStateNodePH12);
+      child12.setStateNode(childStateNode12);
+
+      childStateNode21 = new StateNode();
+      childStateNode21.setProofHash(childStateNodePH21);
+      child21.setStateNode(childStateNode21);
+
+      childStateNode22 = new StateNode();
+      childStateNode22.setProofHash(childStateNodePH22);
+      child22.setStateNode(childStateNode22);
+    })
 
     it("get / set / has / reset", () => {
       const proofHash = 'proofHash';
-      expect(node.getProofHash()).to.equal(null);
+
       expect(node.hasProofHash()).to.equal(false);
+      expect(node.getProofHash()).to.equal(null);
       node.setProofHash(proofHash);
-      expect(node.getProofHash()).to.equal(proofHash);
       expect(node.hasProofHash()).to.equal(true);
+      expect(node.getProofHash()).to.equal(proofHash);
       node.resetProofHash();
-      expect(node.getProofHash()).to.equal(null);
       expect(node.hasProofHash()).to.equal(false);
+      expect(node.getProofHash()).to.equal(null);
     });
 
     it("build", () => {
+      const childPH1 = 'childPH1';
+      const childPH2 = 'childPH2';
+
       child1.setProofHash(childPH1);
       child2.setProofHash(childPH2);
-      stateNode.setProofHash(stateNodePH);
 
       node.setChild(labelRadix1, labelSuffix1, child1);
       node.setChild(labelRadix2, labelSuffix2, child2);
 
-      // Without stateNode
-      const preimage1 = `${HASH_DELIMITER}${HASH_DELIMITER}${labelRadix1}${labelSuffix1}${HASH_DELIMITER}${childPH1}${HASH_DELIMITER}${labelRadix2}${labelSuffix2}${HASH_DELIMITER}${childPH2}`;
-      const proofHash1 = CommonUtil.hashString(preimage1);
-      expect(node._buildProofHash()).to.equal(proofHash1)
+      assert.deepEqual(node.toJsObject(), {
+        "1:100": {
+          "->": true
+        },
+        "2:200": {
+          "->": true
+        }
+      });
 
       // With stateNode
       node.setStateNode(stateNode);
-      const preimage2 = `${stateNodePH}${HASH_DELIMITER}${HASH_DELIMITER}${labelRadix1}${labelSuffix1}${HASH_DELIMITER}${childPH1}${HASH_DELIMITER}${labelRadix2}${labelSuffix2}${HASH_DELIMITER}${childPH2}`;
+      const preimage2 = `${stateNodePH}${HASH_DELIMITER}${HASH_DELIMITER}` +
+          `${labelRadix1}${labelSuffix1}${HASH_DELIMITER}${childPH1}` +
+          `${HASH_DELIMITER}${labelRadix2}${labelSuffix2}${HASH_DELIMITER}${childPH2}`;
       const proofHash2 = CommonUtil.hashString(preimage2);
       expect(node._buildProofHash()).to.equal(proofHash2)
+
+      // Without stateNode
+      node.resetStateNode();
+      const preimage1 = `${HASH_DELIMITER}${HASH_DELIMITER}` +
+          `${labelRadix1}${labelSuffix1}${HASH_DELIMITER}${childPH1}` +
+          `${HASH_DELIMITER}${labelRadix2}${labelSuffix2}${HASH_DELIMITER}${childPH2}`;
+      const proofHash1 = CommonUtil.hashString(preimage1);
+      expect(node._buildProofHash()).to.equal(proofHash1)
     });
 
     it("update / verify", () => {
+      const childPH1 = 'childPH1';
+      const childPH2 = 'childPH2';
+
       child1.setProofHash(childPH1);
       child2.setProofHash(childPH2);
-      stateNode.setProofHash(stateNodePH);
 
       node.setChild(labelRadix1, labelSuffix1, child1);
       node.setChild(labelRadix2, labelSuffix2, child2);
-      node.setStateNode(stateNode);
+
+      assert.deepEqual(node.toJsObject(), {
+        "1:100": {
+          "->": true
+        },
+        "2:200": {
+          "->": true
+        }
+      });
 
       node.resetProofHash();
       expect(node.verifyProofHash()).to.equal(false);
       node.updateProofHash();
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getProofHash()).to.equal(node._buildProofHash());
+    });
+
+    it("setProofHashForRadixTree", () => {
+      node.setStateNode(stateNode);
+      node.setChild(labelRadix1, labelSuffix1, child1);
+      node.setChild(labelRadix2, labelSuffix2, child2);
+      child1.setChild(labelRadix11, labelSuffix11, child11);
+      child1.setChild(labelRadix12, labelSuffix12, child12);
+      child2.setChild(labelRadix21, labelSuffix21, child21);
+      child2.setChild(labelRadix22, labelSuffix22, child22);
+
+      assert.deepEqual(node.toJsObject(), {
+        "1:100": {
+          "->": true,
+          "1:110": {
+            "->": true
+          },
+          "2:120": {
+            "->": true
+          }
+        },
+        "2:200": {
+          "->": true,
+          "1:210": {
+            "->": true
+          },
+          "2:220": {
+            "->": true
+          }
+        }
+      });
+
+      // initial status
+      expect(node.verifyProofHash()).to.equal(false);
+      expect(child1.verifyProofHash()).to.equal(false);
+      expect(child2.verifyProofHash()).to.equal(false);
+      expect(child11.verifyProofHash()).to.equal(false);
+      expect(child12.verifyProofHash()).to.equal(false);
+      expect(child21.verifyProofHash()).to.equal(false);
+      expect(child22.verifyProofHash()).to.equal(false);
+
+      // set
+      expect(node.setProofHashForRadixTree()).to.equal(7);
+      expect(node.verifyProofHash()).to.equal(true);
+      expect(child1.verifyProofHash()).to.equal(true);
+      expect(child2.verifyProofHash()).to.equal(true);
+      expect(child11.verifyProofHash()).to.equal(true);
+      expect(child12.verifyProofHash()).to.equal(true);
+      expect(child21.verifyProofHash()).to.equal(true);
+      expect(child22.verifyProofHash()).to.equal(true);
+
+      // change of a state node's proof hash
+      childStateNode12.setProofHash('another PH');
+      expect(node.verifyProofHash()).to.equal(true);
+      expect(child1.verifyProofHash()).to.equal(true);
+      expect(child2.verifyProofHash()).to.equal(true);
+      expect(child11.verifyProofHash()).to.equal(true);
+      expect(child12.verifyProofHash()).to.equal(false);
+      expect(child21.verifyProofHash()).to.equal(true);
+      expect(child22.verifyProofHash()).to.equal(true);
+    });
+
+    it("updateProofHashForRootPath", () => {
+      node.setStateNode(stateNode);
+      node.setChild(labelRadix1, labelSuffix1, child1);
+      node.setChild(labelRadix2, labelSuffix2, child2);
+      child1.setChild(labelRadix11, labelSuffix11, child11);
+      child1.setChild(labelRadix12, labelSuffix12, child12);
+      child2.setChild(labelRadix21, labelSuffix21, child21);
+      child2.setChild(labelRadix22, labelSuffix22, child22);
+
+      assert.deepEqual(node.toJsObject(), {
+        "1:100": {
+          "->": true,
+          "1:110": {
+            "->": true
+          },
+          "2:120": {
+            "->": true
+          }
+        },
+        "2:200": {
+          "->": true,
+          "1:210": {
+            "->": true
+          },
+          "2:220": {
+            "->": true
+          }
+        }
+      });
+
+      // initial status
+      expect(node.verifyProofHash()).to.equal(false);
+      expect(child1.verifyProofHash()).to.equal(false);
+      expect(child2.verifyProofHash()).to.equal(false);
+      expect(child11.verifyProofHash()).to.equal(false);
+      expect(child12.verifyProofHash()).to.equal(false);
+      expect(child21.verifyProofHash()).to.equal(false);
+      expect(child22.verifyProofHash()).to.equal(false);
+
+      // update
+      expect(child21.updateProofHashForRootPath()).to.equal(3);
+      expect(node.verifyProofHash()).to.equal(true);
+      expect(child1.verifyProofHash()).to.equal(false);
+      expect(child2.verifyProofHash()).to.equal(true);
+      expect(child11.verifyProofHash()).to.equal(false);
+      expect(child12.verifyProofHash()).to.equal(false);
+      expect(child21.verifyProofHash()).to.equal(true);
+      expect(child22.verifyProofHash()).to.equal(false);
+    });
+
+    it("verifyProofHashForRadixTree", () => {
+      node.setStateNode(stateNode);
+      node.setChild(labelRadix1, labelSuffix1, child1);
+      node.setChild(labelRadix2, labelSuffix2, child2);
+      child1.setChild(labelRadix11, labelSuffix11, child11);
+      child1.setChild(labelRadix12, labelSuffix12, child12);
+      child2.setChild(labelRadix21, labelSuffix21, child21);
+      child2.setChild(labelRadix22, labelSuffix22, child22);
+
+      assert.deepEqual(node.toJsObject(), {
+        "1:100": {
+          "->": true,
+          "1:110": {
+            "->": true
+          },
+          "2:120": {
+            "->": true
+          }
+        },
+        "2:200": {
+          "->": true,
+          "1:210": {
+            "->": true
+          },
+          "2:220": {
+            "->": true
+          }
+        }
+      });
+
+      // initial status
+      expect(node.verifyProofHashForRadixTree()).to.equal(false);
+
+      // set
+      expect(node.setProofHashForRadixTree()).to.equal(7);
+      expect(node.verifyProofHashForRadixTree()).to.equal(true);
+
+      // change of a state node's proof hash
+      childStateNode21.setProofHash('another PH');
+      expect(node.verifyProofHashForRadixTree()).to.equal(false);
+
+      // update
+      expect(child21.updateProofHashForRootPath()).to.equal(3);
+      expect(node.verifyProofHashForRadixTree()).to.equal(true);
     });
   });
 

--- a/unittest/radix-node.test.js
+++ b/unittest/radix-node.test.js
@@ -26,12 +26,21 @@ describe("radix-node", () => {
       const stateNode = new StateNode();
       expect(node.getStateNode()).to.equal(null);
       expect(node.hasStateNode()).to.equal(false);
-      node.setStateNode(stateNode);
+      expect(node.setStateNode(stateNode)).to.equal(true);
       expect(node.getStateNode()).to.equal(stateNode);
       expect(node.hasStateNode()).to.equal(true);
       node.resetStateNode();
       expect(node.getStateNode()).to.equal(null);
       expect(node.hasStateNode()).to.equal(false);
+    });
+
+    it("set with invalid state node", () => {
+      const invalidStateNode = new RadixNode();
+      expect(node.setStateNode(invalidStateNode)).to.equal(false);
+      expect(node.setStateNode('')).to.equal(false);
+      expect(node.setStateNode(true)).to.equal(false);
+      expect(node.setStateNode(null)).to.equal(false);
+      expect(node.setStateNode(undefined)).to.equal(false);
     });
   });
 
@@ -266,7 +275,7 @@ describe("radix-node", () => {
       const grandChild21 = new RadixNode();
       const grandChild22 = new RadixNode();
       const stateNode1 = new StateNode();
-      const stateNode22 = new RadixNode();
+      const stateNode22 = new StateNode();
       node.setChild('0', '001', child1);
       node.setChild('1', '002', child2);
       child2.setChild('2', '021', grandChild21);

--- a/unittest/radix-tree.test.js
+++ b/unittest/radix-tree.test.js
@@ -779,6 +779,94 @@ describe("radix-tree", () => {
           }
         });
       });
+
+      it("get / has / set / update / verify proof hash", () => {
+        const label1 = '0x000aaa';
+        const stateNode1 = new StateNode();
+        const stateNodePH1 = 'childStateNodePH1';
+        stateNode1.setProofHash(stateNodePH1);
+
+        const label11 = '0x000aaa111';
+        const stateNodePH11 = 'childStateNodePH11';
+        const stateNode11 = new StateNode();
+        stateNode11.setProofHash(stateNodePH11);
+
+        const label12 = '0x000aaa212';
+        const stateNodePH12 = 'childStateNodePH12';
+        const stateNode12 = new StateNode();
+        stateNode12.setProofHash(stateNodePH12);
+
+        const label21 = '0x000bbb121';
+        const stateNodePH21 = 'childStateNodePH21';
+        const stateNode21 = new StateNode();
+        stateNode21.setProofHash(stateNodePH21);
+
+        const label22 = '0x000bbb222';
+        const stateNodePH22 = 'childStateNodePH22';
+        const stateNode22 = new StateNode();
+        stateNode22.setProofHash(stateNodePH22);
+
+        const label3 = '0x111ccc';
+        const stateNode3 = new StateNode();
+        const stateNodePH3 = 'childStateNodePH3';
+        stateNode3.setProofHash(stateNodePH3);
+
+        tree.set(label1, stateNode1);
+        tree.set(label11, stateNode11);
+        tree.set(label12, stateNode12);
+        tree.set(label21, stateNode21);
+        tree.set(label22, stateNode22);
+        tree.set(label3, stateNode3);
+
+        assert.deepEqual(tree.toJsObject(), {
+          "0:00": {
+            "->": false,
+            "a:aa": {
+              "->": true,
+              "1:11": {
+                "->": true
+              },
+              "2:12": {
+                "->": true
+              }
+            },
+            "b:bb": {
+              "->": false,
+              "1:21": {
+                "->": true
+              },
+              "2:22": {
+                "->": true
+              }
+            }
+          },
+          "1:11ccc": {
+            "->": true
+          }
+        });
+
+        // initial status
+        expect(tree.hasRootProofHash()).to.equal(false);
+        expect(tree.getRootProofHash()).to.equal(null);
+        expect(tree.verifyProofHashForRadixTree()).to.equal(false);
+
+        // set
+        expect(tree.setProofHashForRadixTree()).to.equal(9);
+        expect(tree.hasRootProofHash()).to.equal(true);
+        expect(tree.getRootProofHash()).to.equal(
+            '0xbc310c6c1b9d339951756d3c0f90bb25e70be0c0a261e04564917ce6c57016d5');
+        expect(tree.verifyProofHashForRadixTree()).to.equal(true);
+
+        // change of a state node's proof hash
+        stateNode21.setProofHash('another PH');
+        expect(tree.verifyProofHashForRadixTree()).to.equal(false);
+
+        // update
+        expect(tree.updateProofHashForRootPath(label21)).to.equal(4);
+        expect(tree.getRootProofHash()).to.equal(
+            '0x20520d0c668099565300affd3c4b288fb59dc37b9fbf31702e99a37b564d12d5');
+        expect(tree.verifyProofHashForRadixTree()).to.equal(true);
+      });
     });
   });
 });

--- a/unittest/radix-tree.test.js
+++ b/unittest/radix-tree.test.js
@@ -142,6 +142,17 @@ describe("radix-tree", () => {
       const stateNode21 = new StateNode();
       const stateNode22 = new StateNode();
 
+      it("set with invalid state node", () => {
+        const invalidStateNode = new RadixNode();
+        const label = '0x000aaa';
+
+        expect(tree._setInTree(label, invalidStateNode)).to.equal(false);
+        expect(tree._setInTree(label, '')).to.equal(false);
+        expect(tree._setInTree(label, true)).to.equal(false);
+        expect(tree._setInTree(label, null)).to.equal(false);
+        expect(tree._setInTree(label, undefined)).to.equal(false);
+      });
+
       it("set / delete without common label prefix", () => {
         const label1 = '0xa';
         const label2 = '0xb';
@@ -428,6 +439,17 @@ describe("radix-tree", () => {
       const stateNode2 = new StateNode();
       const stateNode21 = new StateNode();
       const stateNode22 = new StateNode();
+
+      it("set with invalid state node", () => {
+        const invalidStateNode = new RadixNode();
+        const label = '0x000aaa';
+
+        expect(tree.set(label, invalidStateNode)).to.equal(false);
+        expect(tree.set(label, '')).to.equal(false);
+        expect(tree.set(label, true)).to.equal(false);
+        expect(tree.set(label, null)).to.equal(false);
+        expect(tree.set(label, undefined)).to.equal(false);
+      });
 
       it("set / delete without common label prefix", () => {
         const label1 = '0xa';


### PR DESCRIPTION
Change summary:
- Add set / update / verify proof hash APIs for radix tree
- Handle invalid state node input

Related issues: 
https://github.com/ainblockchain/ain-blockchain/issues/519
https://github.com/ainblockchain/ain-blockchain/issues/517