### PR TITLE
Use a cache for hex labels

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -31,6 +31,8 @@ const FeatureFlags = {
   enableReceiptPathPrefixLayers: false,  // Some test cases assume this value false.
   // Enables radix layers.
   enableRadixTreeLayers: true,  // Some test cases assume this value true.
+  // Enables hex label map.
+  enableHexLabelMap: true,
   // Enables array radix child map.
   enableArrayRadixChildMap: true,
 };

--- a/common/constants.js
+++ b/common/constants.js
@@ -31,8 +31,8 @@ const FeatureFlags = {
   enableReceiptPathPrefixLayers: false,  // Some test cases assume this value false.
   // Enables radix layers.
   enableRadixTreeLayers: true,  // Some test cases assume this value true.
-  // Enables hex label map.
-  enableHexLabelMap: true,
+  // Enables hex label cache.
+  enableHexLabelCache: true,
   // Enables array radix child map.
   enableArrayRadixChildMap: true,
 };

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -14,21 +14,21 @@ class RadixTree {
   constructor() {
     this.root = new RadixNode();
     this.stateNodeMap = new Map();
-    if (FeatureFlags.enableHexLabelMap) {
-      this.hexLabelMap = new Map();
+    if (FeatureFlags.enableHexLabelCache) {
+      this.hexLabelCache = new Map();
     }
   }
 
   _toHexLabel(stateLabel) {
-    if (FeatureFlags.enableHexLabelMap) {
-      if (this.hexLabelMap.has(stateLabel)) {
-        return this.hexLabelMap.get(stateLabel);
+    if (FeatureFlags.enableHexLabelCache) {
+      if (this.hexLabelCache.has(stateLabel)) {
+        return this.hexLabelCache.get(stateLabel);
       }
     }
     const hexLabelWithPrefix = CommonUtil.toHexString(stateLabel);
     const hexLabel = hexLabelWithPrefix.length >= 2 ? hexLabelWithPrefix.slice(2) : '';
-    if (FeatureFlags.enableHexLabelMap) {
-      this.hexLabelMap.set(stateLabel, hexLabel);
+    if (FeatureFlags.enableHexLabelCache) {
+      this.hexLabelCache.set(stateLabel, hexLabel);
     }
     return hexLabel;
   }
@@ -239,8 +239,8 @@ class RadixTree {
         return this._mergeToChild(parent);
       }
     }
-    if (FeatureFlags.enableHexLabelMap) {
-      this.hexLabelMap.delete(stateLabel);
+    if (FeatureFlags.enableHexLabelCache) {
+      this.hexLabelCache.delete(stateLabel);
     }
     return true;
   }

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -1,6 +1,9 @@
 const logger = require('../logger')('RADIX_TREE');
 
 const CommonUtil = require('../common/common-util');
+const {
+  FeatureFlags,
+} = require('../common/constants');
 const RadixNode = require('./radix-node');
 
 /**
@@ -11,14 +14,23 @@ class RadixTree {
   constructor() {
     this.root = new RadixNode();
     this.stateNodeMap = new Map();
+    if (FeatureFlags.enableHexLabelMap) {
+      this.hexLabelMap = new Map();
+    }
   }
 
-  static _toHexLabel(stateLabel) {
-    const hexLabel = CommonUtil.toHexString(stateLabel);
-    if (hexLabel.length < 2) {
-      return hexLabel;
+  _toHexLabel(stateLabel) {
+    if (FeatureFlags.enableHexLabelMap) {
+      if (this.hexLabelMap.has(stateLabel)) {
+        return this.hexLabelMap.get(stateLabel);
+      }
     }
-    return hexLabel.slice(2);
+    const hexLabelWithPrefix = CommonUtil.toHexString(stateLabel);
+    const hexLabel = hexLabelWithPrefix.length >= 2 ? hexLabelWithPrefix.slice(2) : '';
+    if (FeatureFlags.enableHexLabelMap) {
+      this.hexLabelMap.set(stateLabel, hexLabel);
+    }
+    return hexLabel;
   }
 
   static _matchLabelSuffix(radixNode, hexLabel, index) {
@@ -105,7 +117,7 @@ class RadixTree {
   }
 
   _getFromTree(stateLabel) {
-    const hexLabel = RadixTree._toHexLabel(stateLabel);
+    const hexLabel = this._toHexLabel(stateLabel);
     const node = this._getRadixNodeForReading(hexLabel);
     if (node === null) {
       return null;
@@ -127,7 +139,7 @@ class RadixTree {
   }
 
   _setInTree(stateLabel, stateNode) {
-    const hexLabel = RadixTree._toHexLabel(stateLabel);
+    const hexLabel = this._toHexLabel(stateLabel);
     const node = this._getRadixNodeForWriting(hexLabel);
     return node.setStateNode(stateNode);
   }
@@ -147,7 +159,7 @@ class RadixTree {
   }
 
   _hasInTree(stateLabel) {
-    const hexLabel = RadixTree._toHexLabel(stateLabel);
+    const hexLabel = this._toHexLabel(stateLabel);
     const node = this._getRadixNodeForReading(hexLabel);
     return node !== null;
   }
@@ -194,7 +206,7 @@ class RadixTree {
   _deleteFromTree(stateLabel) {
     const LOG_HEADER = '_deleteFromTree';
 
-    const hexLabel = RadixTree._toHexLabel(stateLabel);
+    const hexLabel = this._toHexLabel(stateLabel);
     const node = this._getRadixNodeForReading(hexLabel);
     if (node === null || !node.hasStateNode()) {
       logger.error(
@@ -226,6 +238,9 @@ class RadixTree {
       if (parent.numChildren() === 1 && !parent.hasStateNode() && parent.hasParent()) {
         return this._mergeToChild(parent);
       }
+    }
+    if (FeatureFlags.enableHexLabelMap) {
+      this.hexLabelMap.delete(stateLabel);
     }
     return true;
   }
@@ -264,7 +279,7 @@ class RadixTree {
   updateProofHashForRadixPath(updatedNodeLabel) {
     const LOG_HEADER = 'updateProofHashForRadixPath';
 
-    const hexLabel = RadixTree._toHexLabel(updatedNodeLabel);
+    const hexLabel = this._toHexLabel(updatedNodeLabel);
     const node = this._getRadixNodeForReading(hexLabel);
     if (node === null) {
       logger.error(
@@ -281,7 +296,7 @@ class RadixTree {
   }
 
   getProofOfState(stateLabel, stateProof) {
-    const hexLabel = RadixTree._toHexLabel(stateLabel);
+    const hexLabel = this._toHexLabel(stateLabel);
     let curNode = this._getRadixNodeForReading(hexLabel);
     if (curNode === null || !curNode.hasStateNode()) {
       return null;

--- a/unittest/radix-tree.test.js
+++ b/unittest/radix-tree.test.js
@@ -6,10 +6,11 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 describe("radix-tree", () => {
-  describe("Static utils", () => {
+  describe("Utils", () => {
     it("_toHexLabel", () => {
-      expect(RadixTree._toHexLabel('0x1234567890abcdef')).to.equal('1234567890abcdef');
-      expect(RadixTree._toHexLabel('aAzZ')).to.equal('61417a5a');
+      const tree = new RadixTree();
+      expect(tree._toHexLabel('0x1234567890abcdef')).to.equal('1234567890abcdef');
+      expect(tree._toHexLabel('aAzZ')).to.equal('61417a5a');
     });
 
     it("_matchLabelSuffix with empty label suffix", () => {


### PR DESCRIPTION
Change summary:
- Use a cache for hex labels

Related issue: https://github.com/ainblockchain/ain-blockchain/issues/519