### PR TITLE
Apply recursive empty node removal for all parent paths

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -45,9 +45,8 @@ const {
   isValidOwnerTree,
   applyFunctionChange,
   applyOwnerChange,
-  removeEmptyNodesForAllRootPaths,
-  updateStateInfoForStateTree,
   updateStateInfoForAllRootPaths,
+  updateStateInfoForStateTree,
   getProofOfStatePath,
 } = require('./state-util');
 const Functions = require('./functions');
@@ -387,6 +386,9 @@ class DB {
 
   static writeToStateRoot(stateRoot, stateVersion, fullPath, stateObj) {
     const tree = StateNode.fromJsObject(stateObj, stateVersion);
+    if (!LIGHTWEIGHT) {
+      updateStateInfoForStateTree(tree);
+    }
     if (fullPath.length === 0) {
       stateRoot = tree;
     } else {
@@ -395,14 +397,7 @@ class DB {
       const parent = DB.getRefForWritingToStateRoot(stateRoot, pathToParent);
       parent.setChild(treeLabel, tree);
     }
-    if (isEmptyNode(tree)) {
-      removeEmptyNodesForAllRootPaths(fullPath, stateRoot);
-    } else if (!LIGHTWEIGHT) {
-      updateStateInfoForStateTree(tree);
-    }
-    if (!LIGHTWEIGHT) {
-      updateStateInfoForAllRootPaths(fullPath, stateRoot);
-    }
+    updateStateInfoForAllRootPaths(fullPath, stateRoot);
     return stateRoot;
   }
 

--- a/db/index.js
+++ b/db/index.js
@@ -46,6 +46,7 @@ const {
   isValidOwnerTree,
   applyFunctionChange,
   applyOwnerChange,
+  removeEmptyNodesFromStateRoot,
   updateProofHashForStateTree,
   updateProofHashForAllRootPaths,
   getProofOfStatePath,
@@ -396,7 +397,7 @@ class DB {
       parent.setChild(treeLabel, tree);
     }
     if (isEmptyNode(tree)) {
-      DB.removeEmptyNodesFromStateRoot(stateRoot, fullPath);
+      removeEmptyNodesFromStateRoot(stateRoot, fullPath);
     } else if (!LIGHTWEIGHT) {
       updateProofHashForStateTree(tree);
     }
@@ -408,27 +409,6 @@ class DB {
 
   writeDatabase(fullPath, stateObj) {
     this.stateRoot = DB.writeToStateRoot(this.stateRoot, this.stateVersion, fullPath, stateObj);
-  }
-
-  static removeEmptyNodesRecursive(fullPath, depth, curDbNode) {
-    if (depth < fullPath.length - 1) {
-      const nextDbNode = curDbNode.getChild(fullPath[depth]);
-      if (nextDbNode === null) {
-        logger.error(`Unavailable path in the database: ${CommonUtil.formatPath(fullPath)}`);
-      } else {
-        DB.removeEmptyNodesRecursive(fullPath, depth + 1, nextDbNode);
-      }
-    }
-    for (const label of curDbNode.getChildLabels()) {
-      const childNode = curDbNode.getChild(label);
-      if (isEmptyNode(childNode)) {
-        curDbNode.deleteChild(label);
-      }
-    }
-  }
-
-  static removeEmptyNodesFromStateRoot(stateRoot, fullPath) {
-    return DB.removeEmptyNodesRecursive(fullPath, 0, stateRoot);
   }
 
   static readFromStateRoot(stateRoot, rootLabel, refPath, options, shardingPath) {

--- a/db/index.js
+++ b/db/index.js
@@ -7,7 +7,6 @@ const {
   PredefinedDbPaths,
   OwnerProperties,
   RuleProperties,
-  ProofProperties,
   StateInfoProperties,
   ShardingProperties,
   GenesisAccounts,
@@ -46,7 +45,7 @@ const {
   isValidOwnerTree,
   applyFunctionChange,
   applyOwnerChange,
-  removeEmptyNodesFromStateRoot,
+  removeEmptyNodesForAllRootPaths,
   updateProofHashForStateTree,
   updateProofHashForAllRootPaths,
   getProofOfStatePath,
@@ -397,7 +396,7 @@ class DB {
       parent.setChild(treeLabel, tree);
     }
     if (isEmptyNode(tree)) {
-      removeEmptyNodesFromStateRoot(stateRoot, fullPath);
+      removeEmptyNodesForAllRootPaths(fullPath, stateRoot);
     } else if (!LIGHTWEIGHT) {
       updateProofHashForStateTree(tree);
     }

--- a/db/index.js
+++ b/db/index.js
@@ -46,8 +46,8 @@ const {
   applyFunctionChange,
   applyOwnerChange,
   removeEmptyNodesForAllRootPaths,
-  updateProofHashForStateTree,
-  updateProofHashForAllRootPaths,
+  updateStateInfoForStateTree,
+  updateStateInfoForAllRootPaths,
   getProofOfStatePath,
 } = require('./state-util');
 const Functions = require('./functions');
@@ -398,10 +398,10 @@ class DB {
     if (isEmptyNode(tree)) {
       removeEmptyNodesForAllRootPaths(fullPath, stateRoot);
     } else if (!LIGHTWEIGHT) {
-      updateProofHashForStateTree(tree);
+      updateStateInfoForStateTree(tree);
     }
     if (!LIGHTWEIGHT) {
-      updateProofHashForAllRootPaths(fullPath, stateRoot);
+      updateStateInfoForAllRootPaths(fullPath, stateRoot);
     }
     return stateRoot;
   }

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -7,6 +7,7 @@ const {
   HASH_DELIMITER,
   StateInfoProperties,
   ProofProperties,
+  LIGHTWEIGHT,
 } = require('../common/constants');
 const RadixTree = require('./radix-tree');
 
@@ -452,7 +453,9 @@ class StateNode {
   }
 
   updateStateInfo(updatedChildLabel = null) {
-    this.setProofHash(this.buildProofHash(updatedChildLabel));
+    if (!LIGHTWEIGHT) {
+      this.setProofHash(this.buildProofHash(updatedChildLabel));
+    }
     this.setTreeHeight(this.computeTreeHeight());
     this.setTreeSize(this.computeTreeSize());
     this.setTreeBytes(this.computeTreeBytes());

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -454,7 +454,7 @@ class StateNode {
     }
   }
 
-  updateProofHashAndStateInfo(updatedChildLabel = null) {
+  updateStateInfo(updatedChildLabel = null) {
     this.setProofHash(this.buildProofHash(updatedChildLabel));
     this.setTreeHeight(this.computeTreeHeight());
     this.setTreeSize(this.computeTreeSize());

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -294,9 +294,6 @@ class StateNode {
     } else {
       this.childMap.delete(label);
     }
-    if (child.numParents() === 0) {
-      child._resetLabel();
-    }
     if (this.numChildren() === 0) {
       this.setIsLeaf(true);
     }

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -653,31 +653,31 @@ function removeEmptyNodesForAllRootPaths(fullPath, root) {
   return removeEmptyNodesForAllRootPathsRecursive(curNode);
 }
 
-function updateProofHashForStateTree(stateTree) {
+function updateStateInfoForStateTree(stateTree) {
   let numAffectedNodes = 0;
   if (!stateTree.getIsLeaf()) {
     for (const node of stateTree.getChildNodes()) {
-      numAffectedNodes += updateProofHashForStateTree(node);
+      numAffectedNodes += updateStateInfoForStateTree(node);
     }
   }
-  stateTree.updateProofHashAndStateInfo();
+  stateTree.updateStateInfo();
   numAffectedNodes++;
 
   return numAffectedNodes;
 }
 
-function updateProofHashForAllRootPathsRecursive(parent, updatedChildLabel) {
+function updateStateInfoForAllRootPathsRecursive(parent, updatedChildLabel) {
   let numAffectedNodes = 0;
-  parent.updateProofHashAndStateInfo(updatedChildLabel);
+  parent.updateStateInfo(updatedChildLabel);
   numAffectedNodes++;
   for (const grandParent of parent.getParentNodes()) {
-    numAffectedNodes += updateProofHashForAllRootPathsRecursive(grandParent, parent.getLabel());
+    numAffectedNodes += updateStateInfoForAllRootPathsRecursive(grandParent, parent.getLabel());
   }
   return numAffectedNodes;
 }
 
-function updateProofHashForAllRootPaths(fullPath, root) {
-  const LOG_HEADER = 'updateProofHashForAllRootPaths';
+function updateStateInfoForAllRootPaths(fullPath, root) {
+  const LOG_HEADER = 'updateStateInfoForAllRootPaths';
 
   if (fullPath.length === 0) {
     // No parents to update.
@@ -702,7 +702,7 @@ function updateProofHashForAllRootPaths(fullPath, root) {
     }
     parent = child;
   }
-  return updateProofHashForAllRootPathsRecursive(parent, updatedChildLabel);
+  return updateStateInfoForAllRootPathsRecursive(parent, updatedChildLabel);
 }
 
 function verifyProofHashForStateTree(stateTree) {
@@ -772,8 +772,8 @@ module.exports = {
   makeCopyOfStateTree,
   equalStateTrees,
   removeEmptyNodesForAllRootPaths,
-  updateProofHashForStateTree,
-  updateProofHashForAllRootPaths,
+  updateStateInfoForStateTree,
+  updateStateInfoForAllRootPaths,
   verifyProofHashForStateTree,
   getProofOfStatePath,
 };

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -616,7 +616,8 @@ function updateStateInfoForAllRootPathsRecursive(
   let numAffectedNodes = 0;
   const curLabel = curNode.getLabel();
   const parentNodes = curNode.getParentNodes();
-  if (isEmptyNode(curNode)) {
+  const isEmpty = isEmptyNode(curNode);
+  if (isEmpty) {
     for (const parent of parentNodes) {
       parent.deleteChild(curLabel);
       numAffectedNodes++;
@@ -626,7 +627,8 @@ function updateStateInfoForAllRootPathsRecursive(
     numAffectedNodes++;
   }
   for (const parent of parentNodes) {
-    numAffectedNodes += updateStateInfoForAllRootPathsRecursive(parent, true, curLabel);
+    numAffectedNodes +=
+        updateStateInfoForAllRootPathsRecursive(parent, true, isEmpty ? null : curLabel);
   }
   return numAffectedNodes;
 }

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -611,6 +611,29 @@ function equalStateTrees(node1, node2) {
   return true;
 }
 
+function removeEmptyNodesRecursive(fullPath, depth, curNode) {
+  let childOnPath = null;
+  let childRemoved = false;
+  if (depth < fullPath.length - 1) {
+    childOnPath = curNode.getChild(fullPath[depth]);
+    if (childOnPath === null) {
+      logger.error(`Unavailable path in the database: ${CommonUtil.formatPath(fullPath)}`);
+    } else {
+      childRemoved = DB.removeEmptyNodesRecursive(fullPath, depth + 1, childOnPath);
+    }
+  }
+  for (const label of curNode.getChildLabels()) {
+    const child = curNode.getChild(label);
+    if (isEmptyNode(child)) {
+      curNode.deleteChild(label);
+    }
+  }
+}
+
+function removeEmptyNodesFromStateRoot(stateRoot, fullPath) {
+  return removeEmptyNodesRecursive(fullPath, 0, stateRoot);
+}
+
 function updateProofHashForStateTree(stateTree) {
   let numAffectedNodes = 0;
   if (!stateTree.getIsLeaf()) {
@@ -729,6 +752,7 @@ module.exports = {
   deleteStateTreeVersion,
   makeCopyOfStateTree,
   equalStateTrees,
+  removeEmptyNodesFromStateRoot,
   updateProofHashForStateTree,
   updateProofHashForAllRootPaths,
   verifyProofHashForStateTree,

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -2861,7 +2861,6 @@ describe("DB operations", () => {
         "terminal_1c": "",
         "node_1a": {
           "node_2": {
-            "terminal_3": null,
             "node_3": "a value"
           }
         },
@@ -2953,7 +2952,6 @@ describe("DB operations", () => {
         "terminal_1c": "",
         "node_1a": {
           "node_2": {
-            "terminal_3": null,
             "node_3": "another value"
           }
         },
@@ -2967,6 +2965,8 @@ describe("DB operations", () => {
       expect(node.db.setValue(
           "/apps/test/empty_values/node_0/node_1a/node_2/node_3", null).code).to.equal(0);
       assert.deepEqual(node.db.getValue("/apps/test/empty_values/node_0"), {
+        "terminal_1a": null,
+        "terminal_1b": null,
         "terminal_1c": "",
         "node_1b": {
           "terminal_2": null,

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -4572,7 +4572,7 @@ describe("State info (getStateInfo)", () => {
       assert.deepEqual(result.code, 0);
 
       assert.deepEqual(node.db.getStateInfo('/values/apps/test/label1'), {
-        "proof_hash": "0xc751739c3275e0b4c143835fcc0342b80af43a74cf338a8571c17e727643bbe7",
+        "proof_hash": "0xe037f0083e30127f0e5088be69c2629a7e14e18518ee736fc31d86ec39b3c459",
         "tree_bytes": 348,
         "tree_height": 1,
         "tree_size": 2,

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -6,7 +6,7 @@ const assert = chai.assert;
 const CommonUtil = require('../common/common-util');
 const { GET_OPTIONS_INCLUDE_ALL } = require('./test-util');
 const {
-  updateProofHashForStateTree,
+  updateStateInfoForStateTree,
   verifyProofHashForStateTree,
 } = require('../db/state-util');
 
@@ -109,7 +109,7 @@ describe("state-node", () => {
       assert.deepEqual(child3.getParentNodes(), [stateTree]);
       assert.deepEqual(child4.getParentNodes(), [stateTree]);
       expect(verifyProofHashForStateTree(stateTree)).to.equal(false);
-      updateProofHashForStateTree(stateTree);
+      updateStateInfoForStateTree(stateTree);
       expect(verifyProofHashForStateTree(stateTree)).to.equal(true);
 
       const clone = stateTree.clone();
@@ -123,7 +123,7 @@ describe("state-node", () => {
       assert.deepEqual(clone.getChildLabels(), stateTree.getChildLabels());
       assert.deepEqual(clone.getChildNodes(), stateTree.getChildNodes());
       assert.deepEqual(clone.numChildren(), stateTree.numChildren());
-      // Proof hash is verified without updateProofHashForStateTree() call!
+      // Proof hash is verified without updateStateInfoForStateTree() call!
       expect(verifyProofHashForStateTree(clone)).to.equal(true);
       expect(clone.getLabel()).to.equal('label_root');
       expect(clone.getValue()).to.equal(null);
@@ -1310,11 +1310,11 @@ describe("state-node", () => {
     });
   });
 
-  describe("updateProofHashAndStateInfo / verifyProofHash", () => {
+  describe("updateStateInfo / verifyProofHash", () => {
     it("leaf node", () => {
       node.setValue(true);
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1322,7 +1322,7 @@ describe("state-node", () => {
 
       node.setValue(10);
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1330,7 +1330,7 @@ describe("state-node", () => {
 
       node.setValue(-200);
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1338,7 +1338,7 @@ describe("state-node", () => {
 
       node.setValue('');
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1346,7 +1346,7 @@ describe("state-node", () => {
 
       node.setValue('str');
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1354,7 +1354,7 @@ describe("state-node", () => {
 
       node.setValue(null);
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1362,7 +1362,7 @@ describe("state-node", () => {
 
       node.setValue(undefined);
       expect(node.verifyProofHash()).to.equal(false);
-      node.updateProofHashAndStateInfo();
+      node.updateStateInfo();
       expect(node.getProofHash()).to.equal(node.buildProofHash());
       expect(node.verifyProofHash()).to.equal(true);
       expect(node.getTreeHeight()).to.equal(node.computeTreeHeight());
@@ -1385,7 +1385,7 @@ describe("state-node", () => {
       expect(stateTree.verifyProofHash()).to.equal(false);
 
       // update without updatedChildLabel
-      stateTree.updateProofHashAndStateInfo();
+      stateTree.updateStateInfo();
       const proofHash = stateTree.getProofHash();
       expect(proofHash).to.equal(stateTree.buildProofHash());
       expect(stateTree.verifyProofHash()).to.equal(true);
@@ -1398,7 +1398,7 @@ describe("state-node", () => {
       expect(stateTree.verifyProofHash()).to.equal(false);
 
       // update with updatedChildLabel
-      stateTree.updateProofHashAndStateInfo(label2);
+      stateTree.updateStateInfo(label2);
       const newProofHash = stateTree.getProofHash();
       expect(newProofHash).not.equal(proofHash);  // Updated
       expect(newProofHash).to.equal(stateTree.buildProofHash());
@@ -1413,7 +1413,7 @@ describe("state-node", () => {
       expect(stateTree.verifyProofHash(label2)).to.equal(false);
 
       // update with updatedChildLabel
-      stateTree.updateProofHashAndStateInfo(label2);
+      stateTree.updateStateInfo(label2);
       // verify with updatedChildLabel
       expect(stateTree.verifyProofHash(label2)).to.equal(true);
       // verify without updatedChildLabel
@@ -1437,7 +1437,7 @@ describe("state-node", () => {
       child4.setProofHash('proofHash4');
       stateTree.setProofHash('proofHash');
 
-      stateTree.updateProofHashAndStateInfo();
+      stateTree.updateStateInfo();
       assert.deepEqual(stateTree.radixTree.toJsObject(true), {
         ".radix_ph": "0xea2df03d09e72671391dc8af7e9bc5e5d3ac9ae6d64cb78df2c27e391f89388e",
         "00aaaa": {

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -853,7 +853,7 @@ describe("state-node", () => {
       assert.deepEqual(child2.getParentNodes(), [parent]);
       expect(child1.numParents()).to.equal(0);
       expect(child2.numParents()).to.equal(1);
-      expect(child1.hasLabel()).to.equal(false);
+      expect(child1.hasLabel()).to.equal(true);
       expect(child2.hasLabel()).to.equal(true);
       expect(child2.getLabel()).to.equal(label2);
       expect(parent.getIsLeaf()).to.equal(false);
@@ -867,8 +867,8 @@ describe("state-node", () => {
       assert.deepEqual(child2.getParentNodes(), []);
       expect(child1.numParents()).to.equal(0);
       expect(child2.numParents()).to.equal(0);
-      expect(child1.hasLabel()).to.equal(false);
-      expect(child2.hasLabel()).to.equal(false);
+      expect(child1.hasLabel()).to.equal(true);
+      expect(child2.hasLabel()).to.equal(true);
       expect(parent.getIsLeaf()).to.equal(true);
     });
 
@@ -975,8 +975,8 @@ describe("state-node", () => {
       assert.deepEqual(child2.getParentNodes(), []);
       expect(child1.numParents()).to.equal(0);
       expect(child2.numParents()).to.equal(0);
-      expect(child1.hasLabel()).to.equal(false);
-      expect(child2.hasLabel()).to.equal(false);
+      expect(child1.hasLabel()).to.equal(true);
+      expect(child2.hasLabel()).to.equal(true);
       expect(parent1.getIsLeaf()).to.equal(true);
       expect(parent2.getIsLeaf()).to.equal(true);
     });

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -22,8 +22,8 @@ const {
   makeCopyOfStateTree,
   equalStateTrees,
   removeEmptyNodesForAllRootPaths,
-  updateProofHashForStateTree,
-  updateProofHashForAllRootPaths,
+  updateStateInfoForStateTree,
+  updateStateInfoForAllRootPaths,
   verifyProofHashForStateTree,
   getProofOfStatePath,
 } = require('../db/state-util');
@@ -2087,7 +2087,7 @@ describe("state-util", () => {
       stateTree = new StateNode(ver3);
       stateTree.setChild('label1', child1);
       stateTree.setChild('label2', child2);
-      updateProofHashForStateTree(stateTree);
+      updateStateInfoForStateTree(stateTree);
     })
 
     it("leaf node", () => {
@@ -2095,7 +2095,7 @@ describe("state-util", () => {
 
       // Delete a leaf node without version.
       const stateNode1 = StateNode.fromJsObject(true);
-      updateProofHashForStateTree(stateNode1);
+      updateStateInfoForStateTree(stateNode1);
       const numNodes1 = deleteStateTree(stateNode1);
       expect(numNodes1).to.equal(1);
       expect(stateNode1.numChildren()).to.equal(0);
@@ -2105,7 +2105,7 @@ describe("state-util", () => {
 
       // Delete a leaf node with version.
       const stateNode2 = StateNode.fromJsObject(true, ver1);
-      updateProofHashForStateTree(stateNode2);
+      updateStateInfoForStateTree(stateNode2);
       const numNodes2 = deleteStateTree(stateNode2);
       expect(numNodes2).to.equal(1);
       expect(stateNode2.numChildren()).to.equal(0);
@@ -2149,13 +2149,13 @@ describe("state-util", () => {
       node = new StateNode(ver3);
       node.setChild('label1', child1);
       node.setChild('label2', child2);
-      updateProofHashForStateTree(node);
+      updateStateInfoForStateTree(node);
     })
 
     it("leaf node", () => {
       // Delete a leaf node without version.
       const stateNode1 = StateNode.fromJsObject(true);
-      updateProofHashForStateTree(stateNode1);
+      updateStateInfoForStateTree(stateNode1);
       const numNodes1 = deleteStateTreeVersion(stateNode1);
       expect(numNodes1).to.equal(1);
       expect(stateNode1.getValue()).to.equal(null);
@@ -2164,7 +2164,7 @@ describe("state-util", () => {
 
       // Delete a leaf node with a different version.
       const stateNode2 = StateNode.fromJsObject(true, 'ver2');
-      updateProofHashForStateTree(stateNode2);
+      updateStateInfoForStateTree(stateNode2);
       const numNodes2 = deleteStateTreeVersion(stateNode2);
       expect(numNodes2).to.equal(1);
       expect(stateNode2.getValue()).to.equal(null);
@@ -2173,7 +2173,7 @@ describe("state-util", () => {
 
       // Delete a leaf node with the same version.
       const stateNode3 = StateNode.fromJsObject(true, ver1);
-      updateProofHashForStateTree(stateNode3);
+      updateStateInfoForStateTree(stateNode3);
       const numNodes3 = deleteStateTreeVersion(stateNode3);
       expect(numNodes3).to.equal(1);
       expect(stateNode3.getValue()).to.equal(null);
@@ -2183,7 +2183,7 @@ describe("state-util", () => {
       // Delete a leaf node with the same version but with non-zero numParents() value.
       const stateNode4 = StateNode.fromJsObject(true, ver1);
       parent.setChild(nodeLabel, stateNode4);
-      updateProofHashForStateTree(stateNode4);
+      updateStateInfoForStateTree(stateNode4);
       const numNodes4 = deleteStateTreeVersion(stateNode4);
       expect(numNodes4).to.equal(0);
       expect(stateNode4.getValue()).to.equal(true);
@@ -2677,8 +2677,8 @@ describe("state-util", () => {
       child21 = child2.getChild(label21);
     });
 
-    it("updateProofHashForStateTree", () => {
-      const numAffectedNodes = updateProofHashForStateTree(child1);
+    it("updateStateInfoForStateTree", () => {
+      const numAffectedNodes = updateStateInfoForStateTree(child1);
       expect(numAffectedNodes).to.equal(5);
       // Checks proof hashes.
       expect(child1111.verifyProofHash()).to.equal(true);
@@ -2718,9 +2718,9 @@ describe("state-util", () => {
       expect(stateTree.getTreeBytes()).to.equal(0);
     });
 
-    it("updateProofHashForAllRootPaths with a single root path", () => {
+    it("updateStateInfoForAllRootPaths with a single root path", () => {
       const numAffectedNodes =
-          updateProofHashForAllRootPaths([label1, label11, label111, label1112], stateTree);
+          updateStateInfoForAllRootPaths([label1, label11, label111, label1112], stateTree);
       expect(numAffectedNodes).to.equal(4);
       // Checks proof hashes.
       expect(child1111.verifyProofHash()).to.equal(false);
@@ -2763,7 +2763,7 @@ describe("state-util", () => {
       expect(stateTree.getTreeBytes()).to.equal(stateTree.computeTreeBytes());
     });
 
-    it("updateProofHashForAllRootPaths with multiple root paths", () => {
+    it("updateStateInfoForAllRootPaths with multiple root paths", () => {
       const stateTreeClone = stateTree.clone();
       const child1Clone = child1.clone();
       const child11Clone = child11.clone();
@@ -2771,7 +2771,7 @@ describe("state-util", () => {
       const child2Clone = child2.clone();
 
       const numAffectedNodes =
-          updateProofHashForAllRootPaths([label1, label11, label111, label1112], stateTree);
+          updateStateInfoForAllRootPaths([label1, label11, label111, label1112], stateTree);
       expect(numAffectedNodes).to.equal(7);
 
       // Checks proof hashes.
@@ -2793,8 +2793,8 @@ describe("state-util", () => {
       expect(stateTreeClone.getProofHash()).to.equal(stateTree.getProofHash());
     });
 
-    it("updateProofHashForAllRootPaths with deleted nodes", () => {
-      const numAffectedNodes = updateProofHashForAllRootPaths(
+    it("updateStateInfoForAllRootPaths with deleted nodes", () => {
+      const numAffectedNodes = updateStateInfoForAllRootPaths(
           [label1, label11, label111, 'deleted1', 'deleted2'], stateTree);  // with deleted nodes
       expect(numAffectedNodes).to.equal(4);
 
@@ -2810,14 +2810,14 @@ describe("state-util", () => {
     });
 
     it("verifyProofHashForStateTree ", () => {
-      updateProofHashForStateTree(stateTree);
+      updateStateInfoForStateTree(stateTree);
       expect(verifyProofHashForStateTree(stateTree)).to.equal(true);
       child111.setProofHash('new ph');
       expect(verifyProofHashForStateTree(stateTree)).to.equal(false);
     });
 
     it("getProofOfState", () => {
-      updateProofHashForStateTree(stateTree);
+      updateStateInfoForStateTree(stateTree);
       assert.deepEqual(getProofOfStatePath(stateTree, [label1, label11]), {
         ".radix_ph": "0xeef6cf891adc1b4755cb54085116c08d7ced1afe8eee3bdaac2259d935b2befe",
         "000": {

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -2487,8 +2487,8 @@ describe("state-util", () => {
     const label11 = '0x0011';
     const label111 = '0x0111';
     const label1111 = '0x1111';
-    const label2 = '0x0002';
-    const label21 = '0x0021';
+    const label12 = '0x0012';
+    const label121 = '0x0121';
     let stateTree;
     let child1;
     let child11;
@@ -2500,10 +2500,10 @@ describe("state-util", () => {
           [label111]: {
             [label1111]: null,
           }
+        },
+        [label12]: {
+          [label121]: 'V0121'
         }
-      },
-      [label2]: {
-        [label21]: 'V0021'
       }
     };
 
@@ -2522,18 +2522,20 @@ describe("state-util", () => {
             "0x0111": {
               "0x1111": null
             }
+          },
+          "0x0012": {
+            "0x0121": "V0121"
           }
-        },
-        "0x0002": {
-          "0x0021": "V0021"
         }
       });
       const numAffectedNodes =
           removeEmptyNodesForAllRootPaths([label1, label11, label111, label1111], stateTree);
-      expect(numAffectedNodes).to.equal(4);
+      expect(numAffectedNodes).to.equal(3);
       assert.deepEqual(stateTree.toJsObject(), {
-        "0x0002": {
-          "0x0021": "V0021"
+        "0x0001": {
+          "0x0012": {
+            "0x0121": "V0121"
+          }
         }
       });
     });
@@ -2551,17 +2553,16 @@ describe("state-util", () => {
       const label3 = '0x003';
       stateTreeClone.setChild(label3, child3);
 
-
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0011": {
             "0x0111": {
               "0x1111": null
             }
+          },
+          "0x0012": {
+            "0x0121": "V0121"
           }
-        },
-        "0x0002": {
-          "0x0021": "V0021"
         }
       });
       assert.deepEqual(stateTreeClone.toJsObject(), {
@@ -2577,10 +2578,12 @@ describe("state-util", () => {
       assert.deepEqual(child1111.getParentNodes(), [child111, child111Clone]);
       const numAffectedNodes =
           removeEmptyNodesForAllRootPaths([label1, label11, label111, label1111], stateTree);
-      expect(numAffectedNodes).to.equal(8);
+      expect(numAffectedNodes).to.equal(7);
       assert.deepEqual(stateTree.toJsObject(), {
-        "0x0002": {
-          "0x0021": "V0021"
+        "0x0001": {
+          "0x0012": {
+            "0x0121": "V0121"
+          }
         }
       });
       assert.deepEqual(stateTreeClone.toJsObject(), {
@@ -2595,10 +2598,10 @@ describe("state-util", () => {
             "0x0111": {
               "0x1111": null
             }
+          },
+          "0x0012": {
+            "0x0121": "V0121"
           }
-        },
-        "0x0002": {
-          "0x0021": "V0021"
         }
       });
       const numAffectedNodes =
@@ -2610,10 +2613,10 @@ describe("state-util", () => {
             "0x0111": {
               "0x1111": null
             }
+          },
+          "0x0012": {
+            "0x0121": "V0121"
           }
-        },
-        "0x0002": {
-          "0x0021": "V0021"
         }
       });
     });
@@ -2622,10 +2625,12 @@ describe("state-util", () => {
       // with deleted nodes
       const numAffectedNodes = removeEmptyNodesForAllRootPaths(
           [label1, label11, label111, label1111, 'deleted1', 'deleted2'], stateTree);
-      expect(numAffectedNodes).to.equal(4);
+      expect(numAffectedNodes).to.equal(3);
       assert.deepEqual(stateTree.toJsObject(), {
-        "0x0002": {
-          "0x0021": "V0021"
+        "0x0001": {
+          "0x0012": {
+            "0x0121": "V0121"
+          }
         }
       });
     })

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -21,9 +21,8 @@ const {
   deleteStateTreeVersion,
   makeCopyOfStateTree,
   equalStateTrees,
-  removeEmptyNodesForAllRootPaths,
-  updateStateInfoForStateTree,
   updateStateInfoForAllRootPaths,
+  updateStateInfoForStateTree,
   verifyProofHashForStateTree,
   getProofOfStatePath,
 } = require('../db/state-util');
@@ -2482,7 +2481,7 @@ describe("state-util", () => {
     })
   })
 
-  describe("empty nodes", () => {
+  describe("empty nodes removal", () => {
     const label1 = '0x0001';
     const label11 = '0x0011';
     const label111 = '0x0111';
@@ -2515,7 +2514,7 @@ describe("state-util", () => {
       child1111 = child111.getChild(label1111);
     });
 
-    it("removeEmptyNodesForAllRootPaths on empty node with a single root path", () => {
+    it("updateStateInfoForAllRootPaths on empty node with a single root path", () => {
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0011": {
@@ -2529,8 +2528,8 @@ describe("state-util", () => {
         }
       });
       const numAffectedNodes =
-          removeEmptyNodesForAllRootPaths([label1, label11, label111, label1111], stateTree);
-      expect(numAffectedNodes).to.equal(3);
+          updateStateInfoForAllRootPaths([label1, label11, label111, label1111], stateTree);
+      expect(numAffectedNodes).to.equal(5);
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0012": {
@@ -2540,7 +2539,7 @@ describe("state-util", () => {
       });
     });
 
-    it("removeEmptyNodesForAllRootPaths on empty node with multiple root paths", () => {
+    it("updateStateInfoForAllRootPaths on empty node with multiple root paths", () => {
       const child111Clone = child111.clone();
       const child11Clone = new StateNode();
       child11Clone.setChild(label111, child111Clone);
@@ -2577,8 +2576,8 @@ describe("state-util", () => {
       });
       assert.deepEqual(child1111.getParentNodes(), [child111, child111Clone]);
       const numAffectedNodes =
-          removeEmptyNodesForAllRootPaths([label1, label11, label111, label1111], stateTree);
-      expect(numAffectedNodes).to.equal(7);
+          updateStateInfoForAllRootPaths([label1, label11, label111, label1111], stateTree);
+      expect(numAffectedNodes).to.equal(10);
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0012": {
@@ -2591,7 +2590,7 @@ describe("state-util", () => {
       });
     });
 
-    it("removeEmptyNodesForAllRootPaths on non-empty node", () => {
+    it("updateStateInfoAllRootPaths on non-empty node", () => {
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0011": {
@@ -2605,8 +2604,8 @@ describe("state-util", () => {
         }
       });
       const numAffectedNodes =
-          removeEmptyNodesForAllRootPaths([label1, label11, label111], stateTree);
-      expect(numAffectedNodes).to.equal(0);
+          updateStateInfoForAllRootPaths([label1, label11, label111], stateTree);
+      expect(numAffectedNodes).to.equal(3);
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0011": {
@@ -2621,11 +2620,11 @@ describe("state-util", () => {
       });
     });
 
-    it("removeEmptyNodesForAllRootPaths with deleted nodes", () => {
+    it("updateStateInfoForAllRootPaths with deleted nodes", () => {
       // with deleted nodes
-      const numAffectedNodes = removeEmptyNodesForAllRootPaths(
+      const numAffectedNodes = updateStateInfoForAllRootPaths(
           [label1, label11, label111, label1111, 'deleted1', 'deleted2'], stateTree);
-      expect(numAffectedNodes).to.equal(3);
+      expect(numAffectedNodes).to.equal(5);
       assert.deepEqual(stateTree.toJsObject(), {
         "0x0001": {
           "0x0012": {
@@ -2636,7 +2635,7 @@ describe("state-util", () => {
     })
   });
 
-  describe("proof hash", () => {
+  describe("state info updates", () => {
     const label1 = '0x0001';
     const label11 = '0x0011';
     const label111 = '0x0111';
@@ -2772,13 +2771,13 @@ describe("state-util", () => {
 
       const numAffectedNodes =
           updateStateInfoForAllRootPaths([label1, label11, label111, label1112], stateTree);
-      expect(numAffectedNodes).to.equal(7);
+      expect(numAffectedNodes).to.equal(8);
 
       // Checks proof hashes.
       expect(child1111.verifyProofHash()).to.equal(false);
-      expect(child1112.verifyProofHash()).to.equal(false);
+      expect(child1112.verifyProofHash()).to.equal(false);  // not verified!!
       expect(child111.verifyProofHash(label1112)).to.equal(true);  // verified
-      expect(child111Clone.verifyProofHash(label1112)).to.equal(false);  // not verified!!
+      expect(child111Clone.verifyProofHash(label1112)).to.equal(true);  // verified
       expect(child11.verifyProofHash()).to.equal(true);  // verified
       expect(child11Clone.verifyProofHash()).to.equal(true);  // verified
       expect(child11Clone.getProofHash()).to.equal(child11.getProofHash());
@@ -2801,7 +2800,7 @@ describe("state-util", () => {
       // Checks proof hashes.
       expect(child1111.verifyProofHash()).to.equal(false);
       expect(child1112.verifyProofHash()).to.equal(false);
-      expect(child111.verifyProofHash(label1112)).to.equal(true);  // verified!!
+      expect(child111.verifyProofHash()).to.equal(true);  // verified!!
       expect(child11.verifyProofHash()).to.equal(true);  // verified
       expect(child21.verifyProofHash()).to.equal(false);
       expect(child2.verifyProofHash()).to.equal(false);


### PR DESCRIPTION
Change summary:
- Make recursive empty node removal applied for all parent paths
- Apply empty node removal to only relevant child label not all child labels
- Apply empty node removal and state info update at the same time
- Add test cases

Related issue: 
https://github.com/ainblockchain/ain-blockchain/issues/517
https://github.com/ainblockchain/ain-blockchain/issues/519