### PR TITLE
Turn off enableArrayRadixChildMap and enableHexLabelCache by default

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -32,9 +32,9 @@ const FeatureFlags = {
   // Enables radix layers.
   enableRadixTreeLayers: true,  // Some test cases assume this value true.
   // Enables hex label cache.
-  enableHexLabelCache: true,
+  enableHexLabelCache: false,
   // Enables array radix child map.
-  enableArrayRadixChildMap: true,
+  enableArrayRadixChildMap: false,
 };
 
 // ** Environment variables **

--- a/db/radix-child-map.js
+++ b/db/radix-child-map.js
@@ -51,7 +51,7 @@ class RadixChildMap {
     if (index >= 0 && index < 16) {
       return this.childArray[index];
     }
-    return null;
+    return undefined;  // Keep compatable with Map.
   }
 
   set(labelRadix, child) {

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -105,7 +105,7 @@ class RadixNode {
 
   setChild(labelRadix, labelSuffix, child) {
     const LOG_HEADER = 'setChild';
-    if (!CommonUtil.isString(labelRadix) || labelRadix.length === 0) {
+    if (!CommonUtil.isString(labelRadix) || labelRadix.length !== 1) {
       logger.error(
           `[${LOG_HEADER}] Setting a child with invalid label radix ${labelRadix} ` +
           `at: ${new Error().stack}.`);
@@ -142,7 +142,7 @@ class RadixNode {
 
   deleteChild(labelRadix) {
     const LOG_HEADER = 'deleteChild';
-    if (!CommonUtil.isString(labelRadix) || labelRadix.length === 0) {
+    if (!CommonUtil.isString(labelRadix) || labelRadix.length !== 1) {
       logger.error(
           `[${LOG_HEADER}] Deleting a child with invalid label radix ${labelRadix} ` +
           `at: ${new Error().stack}.`);

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -413,9 +413,9 @@ describe("DB operations", () => {
 
       it('when retrieving value with include_proof', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { includeProof: true }), {
-          ".proof_hash": "0x147ecaf6c56166b504cce1cbe690bc1d14c8e2f68c7937416eac32aaf97ecf2c",
+          ".proof_hash": "0xf1f51cb458ef3881fefbecf91db5450e601d462099e43776863f2cbb78642286",
           "ai": {
-            ".proof_hash": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec",
+            ".proof_hash": "0xc49ca014a4d5328cfdb74164bcb8c00578719335194b07a8b91af1db0048f0bb",
             ".proof_hash:baz": "0x74e6d7e9818333ef5d6f4eb74dc0ee64537c9e142e4fe55e583476a62b539edf",
             ".proof_hash:comcom": "0x90840252cdaacaf90d95c14f9d366f633fd53abf7a2c359f7abfb7f651b532b5",
             ".proof_hash:foo": "0xea86f62ccb8ed9240afb6c9090be001ef7859bf40e0782f2b8d3579b3d8310a4",
@@ -442,7 +442,7 @@ describe("DB operations", () => {
             }
           },
           "shards": {
-            ".proof_hash": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223",
+            ".proof_hash": "0x8ab46f23c6dddce173709cbc935a33d816825ffebabc4f23d02c3d2aea85fba3",
             "disabled_shard": {
               ".proof_hash": "0xc0d5ac161046ecbf67ae597b3e1d96e53e78d71c0193234f78f2514dbf952161",
               ".proof_hash:path": "0xd024945cba75febe35837d24c977a187a6339888d99d505c1be63251fec52279",

--- a/unittest/radix-child-map.test.js
+++ b/unittest/radix-child-map.test.js
@@ -142,11 +142,11 @@ describe("radix-child-map", () => {
         expect(map.has(0)).to.equal(false);
         expect(map.has('A')).to.equal(false);
 
-        expect(map.get(undefined)).to.equal(null);
-        expect(map.get(null)).to.equal(null);
-        expect(map.get(false)).to.equal(null);
-        expect(map.get(0)).to.equal(null);
-        expect(map.get('A')).to.equal(null);
+        expect(map.get(undefined)).to.equal(undefined);
+        expect(map.get(null)).to.equal(undefined);
+        expect(map.get(false)).to.equal(undefined);
+        expect(map.get(0)).to.equal(undefined);
+        expect(map.get('A')).to.equal(undefined);
 
         expect(map.set(undefined, child1)).to.equal(false);
         expect(map.set(null, child1)).to.equal(false);

--- a/unittest/radix-node.test.js
+++ b/unittest/radix-node.test.js
@@ -114,6 +114,7 @@ describe("radix-node", () => {
       expect(node.setChild(true, labelSuffix, child)).to.equal(false);
       expect(node.setChild(1, labelSuffix, child)).to.equal(false);
       expect(node.setChild('', labelSuffix, child)).to.equal(false);
+      expect(node.setChild('00', labelSuffix, child)).to.equal(false);
 
       // setChild() with invalid label suffix
       expect(node.setChild(labelRadix, undefined, child)).to.equal(false);

--- a/unittest/radix-tree.test.js
+++ b/unittest/radix-tree.test.js
@@ -81,7 +81,8 @@ describe("radix-tree", () => {
       const child = new RadixNode();
 
       expect(RadixTree._setChildWithLabel(node, '1234567890abcdef', child)).to.equal(true);
-      assert.deepEqual(node.getChild('1234567890abcdef'), child);
+      expect(node.hasChild('1')).to.equal(true);
+      assert.deepEqual(node.getChild('1'), child);
       expect(child.getLabelRadix()).to.equal('1');
       expect(child.getLabelSuffix()).to.equal('234567890abcdef');
     });

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -1439,7 +1439,7 @@ describe("state-node", () => {
 
       stateTree.updateStateInfo();
       assert.deepEqual(stateTree.radixTree.toJsObject(true), {
-        ".radix_ph": "0xea2df03d09e72671391dc8af7e9bc5e5d3ac9ae6d64cb78df2c27e391f89388e",
+        ".radix_ph": "0xd9251f484361885000e88f2385777e1c4558a08125199a99c6b3296b459628c6",
         "00aaaa": {
           ".label": "0x00aaaa",
           ".proof_hash": "proofHash1",
@@ -1451,7 +1451,7 @@ describe("state-node", () => {
             ".proof_hash": "proofHash4",
             ".radix_ph": "0x741ba4788b06907f8c99c60a6f483f885cc1b4fb27f9e1bed71dfd1d8a213214"
           },
-          ".radix_ph": "0xbfbfc5f5c2e7b1d694fa822a0017c8d691dd99e003798cfcc068a26505dd6430",
+          ".radix_ph": "0x099ad81295e3257147362606afc34b47757dd5c1508d441e248302be8577ed44",
           "00": {
             ".label": "0x11bb00",
             ".proof_hash": "proofHash3",
@@ -1466,7 +1466,7 @@ describe("state-node", () => {
       });
 
       assert.deepEqual(stateTree.getProofOfState(label2, 'childProof2'), {
-        ".radix_ph": "0xea2df03d09e72671391dc8af7e9bc5e5d3ac9ae6d64cb78df2c27e391f89388e",
+        ".radix_ph": "0xd9251f484361885000e88f2385777e1c4558a08125199a99c6b3296b459628c6",
         "00aaaa": {
           ".radix_ph": "0xd8895ab36f227519e479a4bf7cfcbf963deb8e69e8172f395af8db83172bf22c"
         },
@@ -1474,7 +1474,7 @@ describe("state-node", () => {
           "11": {
             ".radix_ph": "0x741ba4788b06907f8c99c60a6f483f885cc1b4fb27f9e1bed71dfd1d8a213214"
           },
-          ".radix_ph": "0xbfbfc5f5c2e7b1d694fa822a0017c8d691dd99e003798cfcc068a26505dd6430",
+          ".radix_ph": "0x099ad81295e3257147362606afc34b47757dd5c1508d441e248302be8577ed44",
           "00": {
             ".radix_ph": "0x3dfb52c0d974feb0559c9efafa996fb286717785e98871336e68ffb52d04bdf4"
           },


### PR DESCRIPTION
Change summary:
- Turn off enableArrayRadixChildMap and enableHexLabelCache by default
- Fix compatibility bug of RadixChildMap.get()

Related issues:
https://github.com/ainblockchain/ain-blockchain/issues/519
https://github.com/ainblockchain/ain-blockchain/issues/517