### PR TITLE
Bugfix/seonghwa/node 14 write file sync

### DIFF
--- a/common/file-util.js
+++ b/common/file-util.js
@@ -161,7 +161,7 @@ class FileUtil {
       if (!fs.existsSync(h2nDirPath)) {
         fs.mkdirSync(h2nDirPath);
       }
-      fs.writeFileSync(h2nPath, blockNumber);
+      fs.writeFileSync(h2nPath, blockNumber.toString());
     } else {
       logger.debug(`${h2nPath} file already exists!`);
     }


### PR DESCRIPTION
Fix ERR_INVALID_ARG_TYPE error of fs.writeFileSync function in node 14.

`
(node:1248) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (0)
`