### PR TITLE
Fix "offenses and evidence don't match" error

### DIFF
--- a/consensus/consensus-util.js
+++ b/consensus/consensus-util.js
@@ -67,7 +67,15 @@ class ConsensusUtil {
   }
 
   static getOffensesFromProposalTx(tx) {
-    return _get(tx, 'tx_body.operation.value.offenses', {});
+    const op = _get(tx, 'tx_body.operation');
+    if (!tx || !op) return {};
+    if (op.type === WriteDbOperations.SET_VALUE) {
+      return _get(op, 'value.offenses');
+    } else if (op.type === WriteDbOperations.SET) {
+      return _get(op, 'op_list.0.value.offenses');
+    } else {
+      return {};
+    }
   }
 
   static getTotalAtStake(validators) {


### PR DESCRIPTION
Updated offenses getting logic in getOffensesFromProposalTx (). (after blockNumber > 1000, proposal tx becomes a SET operation)

Fixes https://github.com/ainblockchain/ain-blockchain/issues/577