### PR TITLE
Fix log file prefix for nodes with accounts injected with keystores.

### DIFF
--- a/logger/winston-util.js
+++ b/logger/winston-util.js
@@ -12,13 +12,15 @@ const {
   PORT,
   ACCOUNT_INDEX,
   HOSTING_ENV,
-  LIGHTWEIGHT
+  LIGHTWEIGHT,
+  KEYSTORE_FILE_PATH,
 } = require('../common/constants');
 
 const { combine, timestamp, label, printf, colorize } = winston.format;
 
 const logDir = path.join(LOGS_DIR, String(PORT));
-const prefix = ACCOUNT_INDEX ? `node-${ACCOUNT_INDEX}-${PORT}` : `tracker-${PORT}`;
+const prefix = ACCOUNT_INDEX ? `node-${ACCOUNT_INDEX}-${PORT}` :
+    KEYSTORE_FILE_PATH ? `node-${PORT}` : `tracker-${PORT}`;
 const logFormat = printf(({level, message, label, timestamp}) => {
   return `${timestamp} [${label}] ${level}: ${message}`;
 });


### PR DESCRIPTION
- Updated to use `node-${PORT}` prefix for nodes that start with KEYSTORE_FILE_PATH env var
- Fixes #603 