### PR TITLE
Fix async/await in p2p unit test

### DIFF
--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -34,8 +34,7 @@ describe("P2P", () => {
   before(async () => {
     p2pClient = new P2pClient(node, minProtocolVersion, maxProtocolVersion);
     p2pServer = p2pClient.server;
-    p2pServer.listen();
-    await p2pServer.setUpIpAddresses();
+    await p2pServer.listen();
   });
 
   after(() => {

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -42,6 +42,10 @@ describe("P2P", () => {
   });
 
   describe("Server Status", () => {
+    before(async () => {
+      await p2pServer.setUpIpAddresses();
+    });
+
     describe("getIpAddress", () => {
       it("gets ip address", async () => {
         const actual = await p2pServer.getIpAddress();

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -31,10 +31,11 @@ setNodeForTesting(node, 0, true, true);
 describe("P2P", () => {
   let p2pClient;
   let p2pServer;
-  before(() => {
+  before(async () => {
     p2pClient = new P2pClient(node, minProtocolVersion, maxProtocolVersion);
     p2pServer = p2pClient.server;
     p2pServer.listen();
+    await p2pServer.setUpIpAddresses();
   });
 
   after(() => {
@@ -42,10 +43,6 @@ describe("P2P", () => {
   });
 
   describe("Server Status", () => {
-    before(async () => {
-      await p2pServer.setUpIpAddresses();
-    });
-
     describe("getIpAddress", () => {
       it("gets ip address", async () => {
         const actual = await p2pServer.getIpAddress();


### PR DESCRIPTION
Fixes #580 by awaiting the p2pServer.listen() call in before().