### PR TITLE
Fix state proof verification bug

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -28,8 +28,6 @@ const FeatureFlags = {
   enableStateTreeTransfer: false,
   // Enables receipts recording to the state.
   enableReceiptsRecording: true,  // Some test cases assume this value true.
-  // Enables receipt path's prefix layers.
-  enableReceiptPathPrefixLayers: false,  // Some test cases assume this value false.
   // Enables radix layers.
   enableRadixTreeLayers: true,  // Some test cases assume this value true.
   // Enables ntp-sync for global time syncing.

--- a/common/constants.js
+++ b/common/constants.js
@@ -28,8 +28,6 @@ const FeatureFlags = {
   enableStateTreeTransfer: false,
   // Enables receipts recording to the state.
   enableReceiptsRecording: true,  // Some test cases assume this value true.
-  // Enables radix layers.
-  enableRadixTreeLayers: true,  // Some test cases assume this value true.
   // Enables ntp-sync for global time syncing.
   enableNtpSync: true,
   // Enables traffic monitoring.

--- a/common/path-util.js
+++ b/common/path-util.js
@@ -325,27 +325,7 @@ class PathUtil {
   }
 
   static getReceiptPath(txHash) {
-    const RECEIPT_NUM_PREFIX_LAYERS = 5;
-    const RECEIPT_PREFIX_LABEL_LENGTH = 1;
-
-    const hashPath = FeatureFlags.enableReceiptPathPrefixLayers ?
-        PathUtil.getPrefixedHashPath(
-            txHash, RECEIPT_NUM_PREFIX_LAYERS, RECEIPT_PREFIX_LABEL_LENGTH) : txHash;
-    return CommonUtil.formatPath([PredefinedDbPaths.RECEIPTS, hashPath]);
-  }
-
-  static getPrefixedHashPath(hash, numPrefixLayers, prefixLabelLength) {
-    if (!CommonUtil.isString(hash) ||
-        hash.length <= 2 + numPrefixLayers * prefixLabelLength) {
-      return hash;
-    }
-    const prefixLabels = [];
-    for (let i = 0; i < numPrefixLayers; i++) {
-      const from = i === 0 ? 0 : 2 + i * prefixLabelLength;
-      const to = 2 + (i + 1) * prefixLabelLength;
-      prefixLabels.push(hash.substring(from, to));
-    }
-    return CommonUtil.formatPath([...prefixLabels, hash]);
+    return CommonUtil.formatPath([PredefinedDbPaths.RECEIPTS, txHash]);
   }
 }
 

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -279,13 +279,13 @@ class RadixNode {
   getChildLabelRadices() {
     // NOTE(platfowner): Sort child nodes by label radix for stability.
     return [...this.radixChildMap.keys()]
-        .sort((a, b) => a[0].localeCompare(b[0]));
+        .sort((a, b) => a.localeCompare(b));
   }
 
   getChildNodes() {
     // NOTE(platfowner): Sort child nodes by label radix for stability.
     return [...this.radixChildMap.entries()]
-        .sort((a, b) => a[0].localeCompare(b[0]))
+        .sort((a, b) => a[0].localeCompare(b[0]))  // compare keys (label radices)
         .map((entry) => entry[1]);
   }
 

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -277,11 +277,16 @@ class RadixNode {
   }
 
   getChildLabelRadices() {
-    return [...this.radixChildMap.keys()];
+    // NOTE(platfowner): Sort child nodes by label radix for stability.
+    return [...this.radixChildMap.keys()]
+        .sort((a, b) => a[0].localeCompare(b[0]));
   }
 
   getChildNodes() {
-    return [...this.radixChildMap.values()];
+    // NOTE(platfowner): Sort child nodes by label radix for stability.
+    return [...this.radixChildMap.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map((entry) => entry[1]);
   }
 
   numChildren() {

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -696,7 +696,9 @@ function verifyStateProofInternal(proof, curLabels) {
   let childIsVerified = true;
   let childMismatchedPath = null;
   const subProofList = [];
-  for (const [label, value] of Object.entries(proof)) {
+  // NOTE(platfowner): Sort child nodes by label radix for stability.
+  const sortedProof = Object.entries(proof).sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [label, value] of sortedProof) {
     let childProofHash = null;
     if (CommonUtil.isDict(value)) {
       const subProof = verifyStateProofInternal(value, [...curLabels, label]);

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -537,15 +537,7 @@ function deleteStateTreeVersion(node) {
   }
 
   // 1. Delete children
-  if (FeatureFlags.enableRadixTreeLayers) {
-    numAffectedNodes += node.deleteRadixTreeVersion();
-  } else {
-    for (const label of node.getChildLabels()) {
-      const child = node.getChild(label);
-      node.deleteChild(label, false);  // shouldUpdateStateInfo = false
-      numAffectedNodes += deleteStateTreeVersion(child);
-    }
-  }
+  numAffectedNodes += node.deleteRadixTreeVersion();
   // 2. Reset node
   node.reset();
   numAffectedNodes++;

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -21,6 +21,9 @@ const {
 } = require('../common/constants');
 const CommonUtil = require('../common/common-util');
 const PathUtil = require('../common/path-util');
+const {
+  verifyStateProof,
+} = require('../db/state-util');
 const DB = require('../db');
 const {
   parseOrLog,
@@ -504,16 +507,23 @@ describe('Blockchain Node', () => {
 
     describe('/get_state_proof', () => {
       it('get_state_proof', () => {
-        const body = parseOrLog(syncRequest('GET', server1 + '/get_state_proof?ref=/')
+        const body = parseOrLog(syncRequest('GET', server1 + '/get_state_proof?ref=/values/token/symbol')
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result['#state_ph']).to.not.equal(null);
+        const verifResult = verifyStateProof(body.result);
+        _.set(verifResult, 'rootProofHash', 'erased');
+        assert.deepEqual(verifResult, {
+          "isVerified": true,
+          "mismatchedPath": null,
+          "rootProofHash": "erased",
+        });
       });
     });
 
     describe('/get_proof_hash', () => {
       it('get_proof_hash', () => {
-        const body = parseOrLog(syncRequest('GET', server1 + '/get_proof_hash?ref=/')
+        const body = parseOrLog(syncRequest('GET', server1 + '/get_proof_hash?ref=/values/token/symbol')
             .body.toString('utf-8'));
         expect(body.code).to.equal(0);
         expect(body.result).to.not.equal(null);
@@ -690,18 +700,25 @@ describe('Blockchain Node', () => {
 
     describe('ain_getStateProof', () => {
       it('returns correct value', () => {
-        const ref = '/';
+        const ref = '/values/token/symbol';
         const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
         return jayson.client.http(server1 + '/json-rpc').request('ain_getStateProof', request)
         .then(res => {
           expect(res.result.result['#state_ph']).to.not.equal(null);
+          const verifResult = verifyStateProof(res.result.result);
+          _.set(verifResult, 'rootProofHash', 'erased');
+          assert.deepEqual(verifResult, {
+            "isVerified": true,
+            "mismatchedPath": null,
+            "rootProofHash": "erased",
+          });
         })
       })
     })
 
     describe('ain_getProofHash', () => {
       it('returns correct value', () => {
-        const ref = '/';
+        const ref = '/values/token/symbol';
         const request = { ref, protoVer: CURRENT_PROTOCOL_VERSION };
         return jayson.client.http(server1 + '/json-rpc').request('ain_getProofHash', request)
         .then(res => {

--- a/tools/proof-hash/samples/proof-symbol.json
+++ b/tools/proof-hash/samples/proof-symbol.json
@@ -1,0 +1,54 @@
+    {
+        "6": {
+            "#radix_ph": "0xec53e72e9f7c03275b7b31b4e16c0919c53c771f92aac4241c5e2e7e3c1efad6"
+        },
+        "7": {
+            "#radix_ph": "0x0ea0cad7036732bf44cca5675495b73de27ab41f6b6ca7006c6ce8d38adf2944",
+            "2756c6573": {
+                "#radix_ph": "0x8c377a0e571131af16bf4a2b88424486a060f45c48e519394fdf28e8dcea7ec5"
+            },
+            "6616c756573": {
+                "#radix_ph": "0x2ffc38bc33aab6c97c42518b95db9bad754982ca8c7cc997cb91e5300b8cc420",
+                "values": {
+                    "6": {
+                        "#radix_ph": "0xc5f1183ef58152dd756dd5125128680dea57385f19f1c31801be0832d71cfdbe"
+                    },
+                    "7": {
+                        "3": {
+                            "#radix_ph": "0xc37806a9865a5bc5a099bd75f528eef1147ca55503d1c43041edad77adc8ca97"
+                        },
+                        "4": {
+                            "#radix_ph": "0x9557e51e5cf4fdca1c5d7176f6e289daa9f94458c06064a09d0b581fd3487aa7",
+                            "6f6b656e": {
+                                "#radix_ph": "0x2994c1885e6ac10ed512f8f1f8b7c454693c180020eb2cb4cb68af2be6c03528",
+                                "token": {
+                                    "6": {
+                                        "#radix_ph": "0x01e32000d059db738b20e49e9be627af7fdd13d34a7f8b77e8f6c1ce0f9cb113"
+                                    },
+                                    "7": {
+                                        "#radix_ph": "0x14cc6e10e0e07e657d6629bdb0131f88b8f0b52729e0aafcb3af184f844850c0",
+                                        "3796d626f6c": {
+                                            "#radix_ph": "0x1e5823b56d1a93deba3ffdb6d3b10ee7dd566a8bfff5c4882cba7eb8ce0b5222",
+                                            "symbol": {
+                                                "#state_ph": "0x3bc0aad65ce90114fc8a48c048c6ccd863f87d3e0f8ee0e377fe8ce936aca8f2"
+                                            }
+                                        },
+                                        "46f74616c5f737570706c79": {
+                                            "#radix_ph": "0x57c1947584cc3b5e4dfb72e5fed66c9d7beb45957e34e4f9a0255cf509e8ade4"
+                                        }
+                                    },
+                                    "#state_ph": "0x4f016c8092617c32116779ac921700fe1bf0f89805820d4fea960d7e7546cc58"
+                                }
+                            },
+                            "72616e73666572": {
+                                "#radix_ph": "0x72b934f427a080f90245d54e147fb8b099c48361df6a5806ce8cb2835f477f11"
+                            }
+                        },
+                        "#radix_ph": "0xb26775d2d1de51532453859050f3940660461305452ec58ce0c6b492d3e0c047"
+                    },
+                    "#state_ph": "0x658a2072f115603327a05d63849543825da743cfcd5f4779fb0856b02074d76e"
+                }
+            }
+        },
+        "#state_ph": "0xa9bae7718195f14295a095eb5a1fa254040ee68ac0ae51b407d0770c4c86516f"
+    }

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -420,9 +420,9 @@ describe("DB operations", () => {
 
       it('when retrieving value with include_proof', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { includeProof: true }), {
-          "#state_ph": "0xf1f51cb458ef3881fefbecf91db5450e601d462099e43776863f2cbb78642286",
+          "#state_ph": "0x147ecaf6c56166b504cce1cbe690bc1d14c8e2f68c7937416eac32aaf97ecf2c",
           "ai": {
-            "#state_ph": "0xc49ca014a4d5328cfdb74164bcb8c00578719335194b07a8b91af1db0048f0bb",
+            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec",
             "#state_ph:baz": "0x74e6d7e9818333ef5d6f4eb74dc0ee64537c9e142e4fe55e583476a62b539edf",
             "#state_ph:comcom": "0x90840252cdaacaf90d95c14f9d366f633fd53abf7a2c359f7abfb7f651b532b5",
             "#state_ph:foo": "0xea86f62ccb8ed9240afb6c9090be001ef7859bf40e0782f2b8d3579b3d8310a4",
@@ -449,7 +449,7 @@ describe("DB operations", () => {
             }
           },
           "shards": {
-            "#state_ph": "0x8ab46f23c6dddce173709cbc935a33d816825ffebabc4f23d02c3d2aea85fba3",
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223",
             "disabled_shard": {
               "#state_ph": "0xc0d5ac161046ecbf67ae597b3e1d96e53e78d71c0193234f78f2514dbf952161",
               "#state_ph:path": "0xd024945cba75febe35837d24c977a187a6339888d99d505c1be63251fec52279",
@@ -458,7 +458,7 @@ describe("DB operations", () => {
                 "#state_ph:sharding_enabled": "0x055600b34c3a8a69ea5dfc2cd2f92336933be237c8b265089f3114b38b4a540a",
                 "sharding_enabled": false,
               },
-              "path": 10,
+              "path": 10
             },
             "enabled_shard": {
               "#state_ph": "0x4b754c4a1a1f99d1ad9bc4a1edbeb7e2ceec6828313b52f8b880ee1cded3e4d3",
@@ -468,10 +468,10 @@ describe("DB operations", () => {
                 "#state_ph:sharding_enabled": "0x1eafc1e61d5b7b28f90a34330bf62265eeb466e012aa7318098003f37e4c61cc",
                 "sharding_enabled": true,
               },
-              "path": 10,
+              "path": 10
             }
           }
-        })
+        });
       });
 
       it('when retrieving value with include_version', () => {

--- a/unittest/radix-node.test.js
+++ b/unittest/radix-node.test.js
@@ -427,6 +427,31 @@ describe("radix-node", () => {
       expect(child2.getLabelSuffix()).to.equal(labelSuffix2);
     });
 
+    it("getChildLabelRadices / getChildNodes", () => {
+      const labelRadix1 = '0';
+      const labelSuffix1 = '0000';
+      const child1 = new RadixNode();
+
+      const labelRadix2 = '1';
+      const labelSuffix2 = '1111';
+      const child2 = new RadixNode();
+
+      const labelRadix3 = '2';
+      const labelSuffix3 = '2222';
+      const child3 = new RadixNode();
+
+      // setChild() with child3 first!
+      node.setChild(labelRadix3, labelSuffix3, child3);
+      // setChild() with child2 first!
+      node.setChild(labelRadix2, labelSuffix2, child2);
+      // setChild() with child1
+      node.setChild(labelRadix1, labelSuffix1, child1);
+      // sorted by label radix
+      assert.deepEqual(node.getChildLabelRadices(), [labelRadix1, labelRadix2, labelRadix3]);
+      // sorted by label radix
+      assert.deepEqual(node.getChildNodes(), [child1, child2, child3]);
+    });
+
     it("set existing child", () => {
       const labelRadix = '0';
       const labelSuffix = '0000';

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -1235,7 +1235,7 @@ describe("state-node", () => {
 
       stateTree.updateStateInfo();
       assert.deepEqual(stateTree.radixTree.toJsObject(false, false, true), {
-        "#radix_ph": "0xd9251f484361885000e88f2385777e1c4558a08125199a99c6b3296b459628c6",
+        "#radix_ph": "0xea2df03d09e72671391dc8af7e9bc5e5d3ac9ae6d64cb78df2c27e391f89388e",
         "00aaaa": {
           "#radix_ph": "0xd8895ab36f227519e479a4bf7cfcbf963deb8e69e8172f395af8db83172bf22c",
           "0x00aaaa": {
@@ -1249,7 +1249,7 @@ describe("state-node", () => {
               "#state_ph": "proofHash4",
             }
           },
-          "#radix_ph": "0x099ad81295e3257147362606afc34b47757dd5c1508d441e248302be8577ed44",
+          "#radix_ph": "0xbfbfc5f5c2e7b1d694fa822a0017c8d691dd99e003798cfcc068a26505dd6430",
           "00": {
             "#radix_ph": "0x3dfb52c0d974feb0559c9efafa996fb286717785e98871336e68ffb52d04bdf4",
             "0x11bb00": {
@@ -1266,21 +1266,21 @@ describe("state-node", () => {
       });
 
       assert.deepEqual(stateTree.getProofOfStateNode(label2, 'child_proof2'), {
-        "#state_ph": "0xd9251f484361885000e88f2385777e1c4558a08125199a99c6b3296b459628c6",
+        "#state_ph": "0xea2df03d09e72671391dc8af7e9bc5e5d3ac9ae6d64cb78df2c27e391f89388e",
         "00aaaa": {
-          "#radix_ph": "0xd8895ab36f227519e479a4bf7cfcbf963deb8e69e8172f395af8db83172bf22c",
+          "#radix_ph": "0xd8895ab36f227519e479a4bf7cfcbf963deb8e69e8172f395af8db83172bf22c"
         },
         "11bb": {
           "11": {
-            "#radix_ph": "0x741ba4788b06907f8c99c60a6f483f885cc1b4fb27f9e1bed71dfd1d8a213214",
+            "#radix_ph": "0x741ba4788b06907f8c99c60a6f483f885cc1b4fb27f9e1bed71dfd1d8a213214"
           },
-          "#radix_ph": "0x099ad81295e3257147362606afc34b47757dd5c1508d441e248302be8577ed44",
+          "#radix_ph": "0xbfbfc5f5c2e7b1d694fa822a0017c8d691dd99e003798cfcc068a26505dd6430",
           "00": {
-            "#radix_ph": "0x3dfb52c0d974feb0559c9efafa996fb286717785e98871336e68ffb52d04bdf4",
+            "#radix_ph": "0x3dfb52c0d974feb0559c9efafa996fb286717785e98871336e68ffb52d04bdf4"
           },
           "bb": {
             "#radix_ph": "0xbbc5610ad726c88350abbe6513ab8f7441cbe8ff09ece86642a827feb53ce184",
-            "0x11bbbb": "child_proof2",
+            "0x11bbbb": "child_proof2"
           }
         }
       });

--- a/unittest/state-node.test.js
+++ b/unittest/state-node.test.js
@@ -53,7 +53,6 @@ describe("state-node", () => {
       expect(node.parentSet.size).to.equal(0);
       expect(node.radixTree.numChildStateNodes()).to.equal(0);
       expect(node.radixTree.root.version).to.equal(null);
-      expect(node.childMap.size).to.equal(0);
       expect(node.proofHash).to.equal(null);
       expect(node.treeHeight).to.equal(0);
       expect(node.treeSize).to.equal(0);
@@ -90,7 +89,6 @@ describe("state-node", () => {
       expect(node.parentSet.size).to.equal(0);
       expect(node.radixTree.numChildStateNodes()).to.equal(0);
       expect(node.radixTree.root.version).to.equal(null);
-      expect(node.childMap.size).to.equal(0);
       expect(node.proofHash).to.equal(null);
       expect(node.treeHeight).to.equal(0);
       expect(node.treeSize).to.equal(0);
@@ -108,7 +106,6 @@ describe("state-node", () => {
       expect(node2.parentSet.size).to.equal(0);
       expect(node2.radixTree.numChildStateNodes()).to.equal(0);
       expect(node2.radixTree.root.version).to.equal('version1');
-      expect(node2.childMap.size).to.equal(0);
       expect(node2.proofHash).to.equal(null);
       expect(node2.treeHeight).to.equal(0);
       expect(node2.treeSize).to.equal(0);
@@ -625,149 +622,6 @@ describe("state-node", () => {
       expect(node.numParents()).to.equal(3);
     });
   });
-
-  /*
-  // NOTE(platfowner): These test cases are for enableRadixTreeLayers=false case.
-  describe("parent", () => {
-    it("add / has / delete / getParentNodes / numParents with single child", () => {
-      const child = new StateNode();
-      child.setValue('value1');
-      const parent1 = new StateNode();
-      const parent2 = new StateNode();
-      expect(child.hasParent(parent1)).to.equal(false);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), []);
-      expect(child.numParents()).to.equal(0);
-
-      child.addParent(parent1);
-      expect(child.hasParent(parent1)).to.equal(true);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), [parent1]);
-      expect(child.numParents()).to.equal(1);
-
-      child.addParent(parent2);
-      expect(child.hasParent(parent1)).to.equal(true);
-      expect(child.hasParent(parent2)).to.equal(true);
-      assert.deepEqual(child.getParentNodes(), [parent1, parent2]);
-      expect(child.numParents()).to.equal(2);
-
-      child.deleteParent(parent1);
-      expect(child.hasParent(parent1)).to.equal(false);
-      expect(child.hasParent(parent2)).to.equal(true);
-      assert.deepEqual(child.getParentNodes(), [parent2]);
-      expect(child.numParents()).to.equal(1);
-
-      child.deleteParent(parent2);
-      expect(child.hasParent(parent1)).to.equal(false);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), []);
-      expect(child.numParents()).to.equal(0);
-    });
-
-    it("add / has / delete / getParentNodes / numParents with multiple children", () => {
-      const child1 = new StateNode();
-      const child2 = new StateNode();
-      child1.setValue('value1');
-      child2.setValue('value2');
-      const parent1 = new StateNode();
-      const parent2 = new StateNode();
-      expect(child1.hasParent(parent1)).to.equal(false);
-      expect(child1.hasParent(parent2)).to.equal(false);
-      expect(child2.hasParent(parent1)).to.equal(false);
-      expect(child2.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child1.getParentNodes(), []);
-      assert.deepEqual(child2.getParentNodes(), []);
-      expect(child1.numParents()).to.equal(0);
-      expect(child2.numParents()).to.equal(0);
-
-      child1.addParent(parent1);
-      child2.addParent(parent2);
-      expect(child1.hasParent(parent1)).to.equal(true);
-      expect(child1.hasParent(parent2)).to.equal(false);
-      expect(child2.hasParent(parent1)).to.equal(false);
-      expect(child2.hasParent(parent2)).to.equal(true);
-      assert.deepEqual(child1.getParentNodes(), [parent1]);
-      assert.deepEqual(child2.getParentNodes(), [parent2]);
-      expect(child1.numParents()).to.equal(1);
-      expect(child2.numParents()).to.equal(1);
-
-      child1.addParent(parent2);
-      child2.addParent(parent1);
-      expect(child1.hasParent(parent1)).to.equal(true);
-      expect(child1.hasParent(parent2)).to.equal(true);
-      expect(child2.hasParent(parent1)).to.equal(true);
-      expect(child2.hasParent(parent2)).to.equal(true);
-      assert.deepEqual(child1.getParentNodes(), [parent1, parent2]);
-      assert.deepEqual(child2.getParentNodes(), [parent2, parent1]);
-      expect(child1.numParents()).to.equal(2);
-      expect(child2.numParents()).to.equal(2);
-
-      child1.deleteParent(parent1);
-      child2.deleteParent(parent2);
-      expect(child1.hasParent(parent1)).to.equal(false);
-      expect(child1.hasParent(parent2)).to.equal(true);
-      expect(child2.hasParent(parent1)).to.equal(true);
-      expect(child2.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child1.getParentNodes(), [parent2]);
-      assert.deepEqual(child2.getParentNodes(), [parent1]);
-      expect(child1.numParents()).to.equal(1);
-      expect(child2.numParents()).to.equal(1);
-
-      child1.deleteParent(parent2);
-      child2.deleteParent(parent1);
-      expect(child1.hasParent(parent1)).to.equal(false);
-      expect(child1.hasParent(parent2)).to.equal(false);
-      expect(child2.hasParent(parent1)).to.equal(false);
-      expect(child2.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child1.getParentNodes(), []);
-      assert.deepEqual(child2.getParentNodes(), []);
-      expect(child1.numParents()).to.equal(0);
-      expect(child2.numParents()).to.equal(0);
-    });
-
-    it("add existing parent", () => {
-      const child = new StateNode();
-      child.setValue('value1');
-      const parent = new StateNode();
-      expect(child.hasParent(parent)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), []);
-      expect(child.numParents()).to.equal(0);
-
-      child.addParent(parent);
-      expect(child.hasParent(parent)).to.equal(true);
-      assert.deepEqual(child.getParentNodes(), [parent]);
-      expect(child.numParents()).to.equal(1);
-
-      child.addParent(parent);
-      expect(child.hasParent(parent)).to.equal(true);
-      assert.deepEqual(child.getParentNodes(), [parent]);
-      expect(child.numParents()).to.equal(1);
-    });
-
-    it("delete non-existing parent", () => {
-      const child = new StateNode();
-      child.setValue('value1');
-      const parent1 = new StateNode();
-      const parent2 = new StateNode();
-      expect(child.hasParent(parent1)).to.equal(false);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), []);
-      expect(child.numParents()).to.equal(0);
-
-      child.addParent(parent1);
-      expect(child.hasParent(parent1)).to.equal(true);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), [parent1]);
-      expect(child.numParents()).to.equal(1);
-
-      child.deleteParent(parent2);
-      expect(child.hasParent(parent1)).to.equal(true);
-      expect(child.hasParent(parent2)).to.equal(false);
-      assert.deepEqual(child.getParentNodes(), [parent1]);
-      expect(child.numParents()).to.equal(1);
-    });
-  });
-  */
 
   describe("child", () => {
     const label1 = 'label1';


### PR DESCRIPTION
Change summary:
- Fix state proof verification bug by fixing the order of children in radix proof hash computation
- Set enableReceiptPathPrefixLayers=true always and remove the flag
- Set enableRadixTreeLayers=true always and remove the flag

Related issue:
https://github.com/ainblockchain/ain-blockchain/issues/626