### PR TITLE
Extend verifyBlock.js to support multiple blocks

### DIFF
--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -95,7 +95,7 @@ function inject_account() {
 }
 
 FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ tools/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
 
 TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-tracker-taiwan"
 NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-node-0-taiwan"

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -95,7 +95,7 @@ function inject_account() {
 }
 
 FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ tools/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
 
 TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-tracker-taiwan"
 NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-node-0-taiwan"

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -95,7 +95,7 @@ if [[ "$KEYSTORE_OPTION" != "" ]]; then
 fi
 
 FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ tools/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
 
 NUM_PARENT_NODES=5
 NUM_SHARD_NODES=3

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -95,7 +95,7 @@ if [[ "$KEYSTORE_OPTION" != "" ]]; then
 fi
 
 FILES_FOR_TRACKER="blockchain/ client/ common/ consensus/ db/ genesis-configs/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh restart_tracker_gcp.sh"
-FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
+FILES_FOR_NODE="blockchain/ client/ common/ consensus/ db/ genesis-configs/ json_rpc/ logger/ node/ p2p/ traffic/ tx-pool/ tools/ package.json setup_blockchain_ubuntu.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh restart_node_gcp.sh wait_until_node_sync_gcp.sh $KEYSTORE_DIR"
 
 NUM_PARENT_NODES=5
 NUM_SHARD_NODES=3

--- a/node/index.js
+++ b/node/index.js
@@ -158,7 +158,7 @@ class BlockchainNode {
           logger.error(`[${LOG_HEADER}] ${err.stack}`);
         }
       }
-      logger.info(`[${LOG_HEADER}] Fast mode sync done!`);
+      logger.info(`[${LOG_HEADER}] Fast mode DB snapshot loading done!`);
     } else {
       logger.info(`[${LOG_HEADER}] Initializing node in 'full' mode..`);
     }
@@ -259,7 +259,7 @@ class BlockchainNode {
   }
 
   updateSnapshots(blockNumber) {
-    if (blockNumber > 0 && blockNumber % SNAPSHOTS_INTERVAL_BLOCK_NUMBER === 0) {
+    if (blockNumber % SNAPSHOTS_INTERVAL_BLOCK_NUMBER === 0) {
       const snapshot = this.dumpFinalDbStates();
       FileUtil.writeSnapshot(this.snapshotDir, blockNumber, snapshot);
       FileUtil.writeSnapshot(

--- a/tools/proof-hash/verifyBlock.js
+++ b/tools/proof-hash/verifyBlock.js
@@ -5,7 +5,8 @@ const Blockchain = require('../../blockchain');
 const StateManager = require('../../db/state-manager');
 const DB = require('../../db');
 
-async function verifyBlock(snapshotFile, blockFile) {
+async function verifyBlock(snapshotFile, blockFileList) {
+  console.log(`\n<< [0]: ${snapshotFile} >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n`);
   console.log(`* Reading snapshot file: ${snapshotFile}...`);
   const snapshot = FileUtil.isCompressedFile(snapshotFile) ?
       FileUtil.readCompressedJson(snapshotFile) : FileUtil.readJson(snapshotFile);
@@ -14,60 +15,70 @@ async function verifyBlock(snapshotFile, blockFile) {
     process.exit(0)
   }
   console.log(`  Done.`);
-  console.log(`* Reading block file: ${blockFile}...`);
-  const block = FileUtil.isCompressedFile(blockFile) ?
-      FileUtil.readCompressedJson(blockFile) : FileUtil.readJson(blockFile);
-  if (block === null) {
-    console.log(`  Failed to read block file: ${blockFile}`);
-    process.exit(0);
-  }
-  console.log(`  Done.`);
+
+  console.log(`* Initializing db states with snapshot...`);
   const bc = new Blockchain(String(8888));
   const stateManager = new StateManager();
   const db = DB.create(
       StateVersions.EMPTY, 'verifyBlock', bc, false, bc.lastBlockNumber(), stateManager);
-  console.log(`* Initializing db states with snapshot...`);
   db.initDbStates(snapshot);
   console.log(`  Done.`);
-  console.log(`* Executing block on db...`);
-  if (block.number > 0) {
-    if (!db.executeTransactionList(block.last_votes, true, false, block.number, block.timestamp)) {
-      logger.error(`  Failed to execute last_votes (${block.number})`);
+
+  for (let i = 0; i < blockFileList.length; i++) {
+    const blockFile = blockFileList[i];
+    console.log(`\n<< [${i + 1}]: ${blockFile} >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n`);
+    console.log(`* Reading block file: ${blockFile}...`);
+    const block = FileUtil.isCompressedFile(blockFile) ?
+        FileUtil.readCompressedJson(blockFile) : FileUtil.readJson(blockFile);
+    if (block === null) {
+      console.log(`  Failed to read block file: ${blockFile}`);
       process.exit(0);
     }
+    console.log(`  Done.`);
+    console.log(`* Executing block on db...`);
+    if (block.number > 0) {
+      if (!db.executeTransactionList(block.last_votes, true, false, block.number, block.timestamp)) {
+        logger.error(`  Failed to execute last_votes (${block.number})`);
+        process.exit(0);
+      }
+    }
+    if (!db.executeTransactionList(block.transactions, block.number === 0, false, block.number, block.timestamp)) {
+      logger.error(`  Failed to execute transactions (${block.number})`)
+      process.exit(0);
+    }
+    console.log(`  Done.`);
+    console.log(`* Comparing root proof hashes...`);
+    console.log(`  > Root proof hash from block header: ${block.state_proof_hash}`);
+    console.log(`  > Root proof hash from recomputation: ${db.stateRoot.getProofHash()}`);
+    if (db.stateRoot.getProofHash() === block.state_proof_hash) {
+      console.log(`  *************`);
+      console.log(`  * VERIFIED! *`);
+      console.log(`  *************`);
+    } else {
+      console.log(`  *****************`);
+      console.log(`  * NOT-VERIFIED! *`);
+      console.log(`  *****************`);
+      console.log(`  Halting verification...`);
+      break;
+    }
+    console.log(`  Done.`);
   }
-  if (!db.executeTransactionList(block.transactions, block.number === 0, false, block.number, block.timestamp)) {
-    logger.error(`  Failed to execute transactions (${block.number})`)
-    process.exit(0);
-  }
-  console.log(`  Done.`);
-  console.log(`* Comparing root proof hashes...`);
-  console.log(`  > Root proof hash from block header: ${block.state_proof_hash}`);
-  console.log(`  > Root proof hash from recomputation: ${db.stateRoot.getProofHash()}`);
-  if (db.stateRoot.getProofHash() === block.state_proof_hash) {
-    console.log(`  *************`);
-    console.log(`  * VERIFIED! *`);
-    console.log(`  *************`);
-  } else {
-    console.log(`  *****************`);
-    console.log(`  * NOT-VERIFIED! *`);
-    console.log(`  *****************`);
-  }
-  console.log(`  Done.`);
 }
 
 async function processArguments() {
-  if (process.argv.length !== 4) {
+  if (process.argv.length < 4) {
     usage();
   }
-  await verifyBlock(process.argv[2], process.argv[3]);
+  await verifyBlock(process.argv[2], process.argv.slice(3));
 }
 
 function usage() {
-  console.log('\nUsage:\n  node verifyBlock.js <snapshot file> <block file>\n')
+  console.log('\nUsage:\n  node verifyBlock.js <snapshot file> <block file 1> [<block file 2> ... <block file k>\n')
   console.log('Examples:')
   console.log('  node verifyBlock.js samples/snapshot-100.json samples/block-101.json')
-  console.log('  node verifyBlock.js samples/snapshot-100.json.gz samples/block-101.json.gz\n')
+  console.log('  node verifyBlock.js samples/snapshot-100.json.gz samples/block-101.json.gz')
+  console.log('  node verifyBlock.js samples/snapshot-100.json samples/block-101.json samples/block-102.json')
+  console.log('  node verifyBlock.js samples/snapshot-100.json.gz samples/block-101.json.gz samples/block-102.json.gz\n')
   process.exit(0)
 }
 


### PR DESCRIPTION
Change summary:
- Extend verifyBlock.js to support multiple blocks
- Include verification tools in the deploy file list for convenience
- Leave DB snapshot for the genesis block as well

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/610