### PR TITLE
Bugfix/liayoo/invalid state proof hash

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1283,7 +1283,7 @@ class DB {
     return true;
   }
 
-  precheckTransaction(tx, blockNumber) {
+  precheckTransaction(tx, skipFees, blockNumber) {
     const LOG_HEADER = 'precheckTransaction';
     // NOTE(platfowner): A transaction needs to be converted to an executable form
     //                   before being executed.
@@ -1304,6 +1304,9 @@ class DB {
     if (checkNonceTimestampResult !== true) {
       return checkNonceTimestampResult;
     }
+    if (skipFees) {
+      return true;
+    }
     const checkBillingResult = this.precheckTxBillingParams(op, addr, billing, blockNumber);
     if (checkBillingResult !== true) {
       return checkBillingResult;
@@ -1317,7 +1320,7 @@ class DB {
 
   executeTransaction(tx, skipFees = false, restoreIfFails = false, blockNumber = 0, blockTime = null) {
     const LOG_HEADER = 'executeTransaction';
-    const precheckResult = this.precheckTransaction(tx, blockNumber);
+    const precheckResult = this.precheckTransaction(tx, skipFees, blockNumber);
     if (precheckResult !== true) {
       logger.debug(`[${LOG_HEADER}] Pre-check failed`);
       return precheckResult;

--- a/db/index.js
+++ b/db/index.js
@@ -1304,16 +1304,15 @@ class DB {
     if (checkNonceTimestampResult !== true) {
       return checkNonceTimestampResult;
     }
-    if (skipFees) {
-      return true;
-    }
-    const checkBillingResult = this.precheckTxBillingParams(op, addr, billing, blockNumber);
-    if (checkBillingResult !== true) {
-      return checkBillingResult;
-    }
-    const checkBalanceResult = this.precheckBalanceAndStakes(op, addr, billing, blockNumber);
-    if (checkBalanceResult !== true) {
-      return checkBalanceResult;
+    if (!skipFees) {
+      const checkBillingResult = this.precheckTxBillingParams(op, addr, billing, blockNumber);
+      if (checkBillingResult !== true) {
+        return checkBillingResult;
+      }
+      const checkBalanceResult = this.precheckBalanceAndStakes(op, addr, billing, blockNumber);
+      if (checkBalanceResult !== true) {
+        return checkBalanceResult;
+      }
     }
     return true;
   }

--- a/node/index.js
+++ b/node/index.js
@@ -513,7 +513,7 @@ class BlockchainNode {
           return false;
         }
       }
-      if (!db.executeTransactionList(block.transactions, block.number === 0, false, block.number, block.timestamp)) {
+      if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {
         logger.error(`[${LOG_HEADER}] Failed to execute transactions of block: ` +
             `${JSON.stringify(block, null, 2)}`);
         return false;
@@ -609,7 +609,7 @@ class BlockchainNode {
             logger, `[${LOG_HEADER}] Failed to execute last_votes (${block.number})`);
       }
     }
-    if (!db.executeTransactionList(block.transactions, block.number === 0, false, block.number, block.timestamp)) {
+    if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {
       // NOTE(liayoo): Quick fix for the problem. May be fixed by deleting the block files.
       CommonUtil.exitWithStackTrace(
             logger, `[${LOG_HEADER}] Failed to execute transactions (${block.number})`)

--- a/tools/proof-hash/verifyBlock.js
+++ b/tools/proof-hash/verifyBlock.js
@@ -42,7 +42,7 @@ async function verifyBlock(snapshotFile, blockFileList) {
         process.exit(0);
       }
     }
-    if (!db.executeTransactionList(block.transactions, block.number === 0, false, block.number, block.timestamp)) {
+    if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {
       logger.error(`  Failed to execute transactions (${block.number})`)
       process.exit(0);
     }

--- a/unittest/p2p.test.js
+++ b/unittest/p2p.test.js
@@ -97,11 +97,9 @@ describe("P2P", () => {
 
     describe("getStateVersionStatus", () => {
       it("gets initial state version status", () => {
-        assert.deepEqual(p2pServer.getStateVersionStatus(), {
-          numVersions: 3,
-          versionList: ['EMPTY', 'FINAL:0', 'NODE:0'],
-          finalVersion: 'FINAL:0',
-        });
+        const stateVersionStatus = p2pServer.getStateVersionStatus();
+        expect(stateVersionStatus.numVersions).to.equal(4);
+        expect(stateVersionStatus.finalVersion).to.equal('FINAL:0');
       });
     });
 
@@ -136,6 +134,7 @@ describe("P2P", () => {
         actual.dbStatus.stateInfo['#tree_bytes'] = 'erased';
         actual.dbStatus.stateInfo['#state_ph'] = 'erased';
         actual.dbStatus.stateProof['#state_ph'] = 'erased';
+        actual.stateVersionStatus.versionList = 'erased';
         assert.deepEqual(actual, {
           address: p2pServer.getNodeAddress(),
           state: 'SYNCING',
@@ -154,8 +153,8 @@ describe("P2P", () => {
             }
           },
           stateVersionStatus: {
-            numVersions: 3,
-            versionList: [ 'EMPTY', 'FINAL:0', 'NODE:0' ],
+            numVersions: 4,
+            versionList: 'erased',
             finalVersion: 'FINAL:0'
           }
         });


### PR DESCRIPTION
- Fixed #649 by always setting `restoreIfFails = true` when executing transactions 
- Changed to skip billing & balance pre-checks if `skipFees = true`
