### PR TITLE
Execute votes in evidence

### DIFF
--- a/consensus/index.js
+++ b/consensus/index.js
@@ -788,7 +788,7 @@ class Consensus {
     }
     const { proposer, number, epoch, hash, last_hash, validators, last_votes, transactions,
       receipts, gas_amount_total, gas_cost_total, state_proof_hash, timestamp } = block;
-    logger.info(`[${LOG_HEADER}] Checking block proposal: ${number} / ${epoch}`);
+    logger.info(`[${LOG_HEADER}] Checking block proposal: ${number} / ${epoch} / ${hash} / ${proposer}`);
     this.precheckProposal(block, proposalTx, proposer, hash, number, validators);
 
     const prevBlockInfo = this.getPrevBlockInfo(number, last_hash);

--- a/integration/sharding.test.js
+++ b/integration/sharding.test.js
@@ -1543,7 +1543,7 @@ describe('Sharding', async () => {
               },
               "state": {
                 "app": {
-                  "test": 4198
+                  "test": 4194
                 },
                 "service": 0
               }

--- a/node/index.js
+++ b/node/index.js
@@ -513,6 +513,16 @@ class BlockchainNode {
           return false;
         }
       }
+      if (!CommonUtil.isEmpty(block.evidence)) {
+        for (const evidenceList of Object.values(block.evidence)) {
+          for (const evidenceForOffense of evidenceList) {
+            if (!db.executeTransactionList(evidenceForOffense.votes, true, false, block.number, block.timestamp)) {
+              logger.error(`[${LOG_HEADER}] Failed to execute evidence (${block.number})`);
+              return false;
+            }
+          }
+        }
+      }
       if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {
         logger.error(`[${LOG_HEADER}] Failed to execute transactions of block: ` +
             `${JSON.stringify(block, null, 2)}`);
@@ -607,6 +617,16 @@ class BlockchainNode {
         // NOTE(liayoo): Quick fix for the problem. May be fixed by deleting the block files.
         CommonUtil.exitWithStackTrace(
             logger, `[${LOG_HEADER}] Failed to execute last_votes (${block.number})`);
+      }
+    }
+    if (!CommonUtil.isEmpty(block.evidence)) {
+      for (const evidenceList of Object.values(block.evidence)) {
+        for (const evidenceForOffense of evidenceList) {
+          if (!db.executeTransactionList(evidenceForOffense.votes, true, false, block.number, block.timestamp)) {
+            CommonUtil.exitWithStackTrace(
+                logger, `[${LOG_HEADER}] Failed to execute evidence (${block.number})`);
+          }
+        }
       }
     }
     if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {

--- a/tools/proof-hash/verifyBlock.js
+++ b/tools/proof-hash/verifyBlock.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { StateVersions } = require('../../common/constants');
+const CommonUtil = require('../../common/common-util');
 const FileUtil = require('../../common/file-util');
 const Blockchain = require('../../blockchain');
 const StateManager = require('../../db/state-manager');
@@ -40,6 +41,16 @@ async function verifyBlock(snapshotFile, blockFileList) {
       if (!db.executeTransactionList(block.last_votes, true, false, block.number, block.timestamp)) {
         logger.error(`  Failed to execute last_votes (${block.number})`);
         process.exit(0);
+      }
+    }
+    if (!CommonUtil.isEmpty(block.evidence)) {
+      for (const evidenceList of Object.values(block.evidence)) {
+        for (const evidenceForOffense of evidenceList) {
+          if (!db.executeTransactionList(evidenceForOffense.votes, true, false, block.number, block.timestamp)) {
+            logger.error(`  Failed to execute evidence (${block.number})`);
+            process.exit(0);
+          }
+        }
       }
     }
     if (!db.executeTransactionList(block.transactions, block.number === 0, true, block.number, block.timestamp)) {


### PR DESCRIPTION
Added missing executeTransactionList() calls for evidence votes. This might have been one of the causes of the invalid state proof hash errors (#649).