### PR TITLE
Fix lastBlockNumber = -1 for removeOldReceipts when loading blocks.

### DIFF
--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -150,6 +150,11 @@ class Blockchain {
 
     this.chain.push(block);
     logger.info(`[${LOG_HEADER}] Successfully added block ${block.number} to chain.`);
+
+    // Keep up to latest ON_MEMORY_CHAIN_LENGTH blocks
+    while (this.chain.length > ON_MEMORY_CHAIN_LENGTH) {
+      this.chain.shift();
+    }
   }
 
   updateNumberToBlockInfo(block) {
@@ -178,10 +183,6 @@ class Blockchain {
     this.addBlockToChain(newBlock);
     this.updateNumberToBlockInfo(newBlock);
     this.writeBlock(newBlock);
-    // Keep up to latest ON_MEMORY_CHAIN_LENGTH blocks
-    while (this.chain.length > ON_MEMORY_CHAIN_LENGTH) {
-      this.chain.shift();
-    }
     return true;
   }
 

--- a/node/index.js
+++ b/node/index.js
@@ -678,9 +678,7 @@ class BlockchainNode {
         this.bc.deleteBlock(lastBlockWithoutProposal);
       } else {
         this.executeBlockOnDb(block, db);
-        if (numBlockFiles - number <= ON_MEMORY_CHAIN_LENGTH) {
-          this.bc.addBlockToChain(block)
-        }
+        this.bc.addBlockToChain(block);
       }
       prevBlockNumber = block.number;
       prevBlockHash = block.hash;


### PR DESCRIPTION
Fixed lastBlockNumber being -1 when loading more than ON_MEMORY_CHAIN_LENGTH  blocks. 
It was causing issues with removeOldReceipts() & thus state hashes.

Related: #649 


- With that said, if a node is fast-syncing, it would have a similar issue as it may not have old blocks to get the transactions from. We need a way to get around this!

- This fixed the state hash issues with loading blocks, but I still see state hash issues when merging blocks from the peers (after successfully loading blocks)
