### PR TITLE
Feature/liayoo/function url wildcard

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -129,6 +129,10 @@ class CommonUtil {
     return ruleUtil.isValidatorOffenseType(type);
   }
 
+  static isValidUrl(url) {
+    return ruleUtil.isValidUrl(url);
+  }
+
   static boolOrFalse(value) {
     return ruleUtil.boolOrFalse(value);
   }

--- a/common/constants.js
+++ b/common/constants.js
@@ -130,10 +130,10 @@ const TRAFFIC_DB_INTERVAL_MS = 60000;  // 1 min
 const TRAFFIC_DB_MAX_INTERVALS = 180;  // 3 hours
 const DEFAULT_REQUEST_BODY_SIZE_LIMIT = '100mb';
 const DEFAULT_DEVELOPERS_URL_WHITELIST = [
-  'https://events.ainetwork.ai/trigger',
-  'https://events.ainize.ai/trigger',
-  'http://echo-bot.ainetwork.ai/trigger',
-  'http://localhost:3000/trigger'
+  'https://*.ainetwork.ai',
+  'https://*.ainize.ai',
+  'https://*.afan.ai',
+  'http://localhost:3000'
 ];
 
 // ** Enums **

--- a/db/functions.js
+++ b/db/functions.js
@@ -2,6 +2,7 @@ const logger = new (require('../logger'))('FUNCTIONS');
 
 const axios = require('axios');
 const _ = require('lodash');
+const matchUrl = require('match-url-wildcard');
 const {
   FeatureFlags,
   PredefinedDbPaths,
@@ -175,7 +176,7 @@ class Functions {
           }
         } else if (functionEntry.function_type === FunctionTypes.REST) {
           if (ENABLE_REST_FUNCTION_CALL && functionEntry.function_url &&
-              functionEntry.function_url in this.db.getRestFunctionsUrlWhitelist()) {
+            matchUrl(functionEntry.function_url, this.db.getRestFunctionsUrlWhitelist())) {
             if (FeatureFlags.enableRichFunctionLogging) {
               logger.info(
                   `  ==> Triggering REST function [[ ${functionEntry.function_id} ]] of ` +

--- a/db/index.js
+++ b/db/index.js
@@ -71,19 +71,19 @@ class DB {
     this.stateManager = stateManager;
     this.ownerAddress = CommonUtil.getJsObject(
         GenesisAccounts, [AccountProperties.OWNER, AccountProperties.ADDRESS]);
-    this.restFunctionsUrlWhitelistCache = { hash: null, whitelist: {} };
+    this.restFunctionsUrlWhitelistCache = { hash: null, whitelist: [] };
     this.updateRestFunctionsUrlWhitelistCache();
   }
 
   static formatRawRestFunctionsWhitelist(raw) {
-    if (CommonUtil.isEmpty(raw) || !CommonUtil.isDict(raw)) return {};
-    const whitelist = {};
+    if (CommonUtil.isEmpty(raw) || !CommonUtil.isDict(raw)) return [];
+    const whitelist = new Set();
     for (const val of Object.values(raw)) {
       for (const url of Object.values(val)) {
-        whitelist[url] = true;
+        whitelist.add(url);
       }
     }
-    return whitelist;
+    return [...whitelist];
   }
 
   /**

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -298,9 +298,21 @@ class RuleUtil {
     return !!ValidatorOffenseTypes[type];
   }
 
+  isValidUrl(url) {
+    try {
+      new URL(url);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
   validateRestFunctionsUrlWhitelistData(userAddr, data, newData, getValue) {
     const PathUtil = require('../common/path-util');
     if (getValue(PathUtil.getDevelopersRestFunctionsUserWhitelistUserPath(userAddr)) !== true) {
+      return false;
+    }
+    if (newData !== null && !this.isValidUrl(newData)) {
       return false;
     }
     const maxUrlsPerDeveloper = getValue(PathUtil.getDevelopersRestFunctionsParamsMaxUrlsPerDeveloperPath());

--- a/db/rule-util.js
+++ b/db/rule-util.js
@@ -298,7 +298,8 @@ class RuleUtil {
     return !!ValidatorOffenseTypes[type];
   }
 
-  isValidUrl(url) {
+  // NOTE(liayoo): Allows wildcards for function url whitelist items.
+  isValidUrlWhitelistItem(url) {
     try {
       new URL(url);
     } catch (e) {
@@ -307,12 +308,19 @@ class RuleUtil {
     return true;
   }
 
+  // NOTE(liayoo): Applies a stricter rule than isValidUrlWhitelistItem() does.
+  // Asterisks are not allowed in the domain name, for instance.
+  isValidUrl(url) {
+    const strictUrlRegex = /^(?:(?:https?|ftp):\/\/)(?:(?:(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)|localhost)(?::\d{2,5})?)(?:[/?#]\S*)?$/i
+    return this.isString(url) ? strictUrlRegex.test(url) : false;
+  }
+
   validateRestFunctionsUrlWhitelistData(userAddr, data, newData, getValue) {
     const PathUtil = require('../common/path-util');
     if (getValue(PathUtil.getDevelopersRestFunctionsUserWhitelistUserPath(userAddr)) !== true) {
       return false;
     }
-    if (newData !== null && !this.isValidUrl(newData)) {
+    if (newData !== null && !this.isValidUrlWhitelistItem(newData)) {
       return false;
     }
     const maxUrlsPerDeveloper = getValue(PathUtil.getDevelopersRestFunctionsParamsMaxUrlsPerDeveloperPath());

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -2,7 +2,6 @@
 const logger = new (require('../logger'))('STATE_UTIL');
 
 const _ = require('lodash');
-const validUrl = require('valid-url');
 const CommonUtil = require('../common/common-util');
 const {
   FeatureFlags,
@@ -288,8 +287,7 @@ function isValidFunctionInfo(functionInfoObj) {
     return false;
   }
   const functionUrl = functionInfoObj[FunctionProperties.FUNCTION_URL];
-  if (functionUrl !== undefined &&
-      !validUrl.isUri(functionInfoObj[FunctionProperties.FUNCTION_URL])) {
+  if (functionUrl !== undefined && !CommonUtil.isValidUrl(functionUrl)) {
     return false;
   }
   return true;

--- a/integration/function.test.js
+++ b/integration/function.test.js
@@ -975,6 +975,34 @@ describe('Native Function', () => {
         });
       });
 
+      it('cannot add an invalid function url', async () => {
+        const body = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {
+          ref: `/developers/rest_functions/url_whitelist/${serviceUser}/1`,
+          value: '*.ainetwork.ai', // missing protocol
+          timestamp: Date.now(),
+          nonce: -1,
+        }}).body.toString('utf-8'));
+        if (!(await waitUntilTxFinalized([server2], _.get(body, 'result.tx_hash')))) {
+          console.error(`Failed to check finalization of tx.`);
+        }
+
+        assert.deepEqual(body.result.result, {
+          "gas_amount_total": {
+            "bandwidth": {
+              "service": 1
+            },
+            "state": {
+              "service": 0
+            }
+          },
+          "gas_cost_total": 0,
+          "error_message": "No write permission on: /developers/rest_functions/url_whitelist/0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204/1",
+          "code": 103,
+          "bandwidth_gas_amount": 1,
+          "gas_amount_charged": 1
+        });
+      });
+
       it('cannot add more than the max number of function urls per developer', async () => {
         // Add 2 more & try to add 1 more
         const addRestFunctionUrl2 = parseOrLog(syncRequest('POST', server2 + '/set_value', {json: {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jayson": "^3.1.1",
     "json-diff": "^0.5.4",
     "lodash": "^4.17.21",
+    "match-url-wildcard": "^0.0.4",
     "moment": "^2.24.0",
     "natural-orderby": "^2.0.3",
     "node-cron": "^2.0.3",
@@ -78,7 +79,6 @@
     "shuffle-seed": "^1.1.6",
     "util": "^0.11.1",
     "uuid": "^3.4.0",
-    "valid-url": "^1.0.9",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.4.2",
     "ws": "^7.4.6"

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -2889,7 +2889,7 @@ describe("DB operations", () => {
         const overSizeTx = Transaction.fromTxBody(overSizeTxBody, node.account.private_key);
         const res = node.db.executeTransaction(overSizeTx, false, true, node.bc.lastBlockNumber() + 1);
         assert.deepEqual(res.code, 25);
-        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (11305320 > 10000000)");
+        assert.deepEqual(res.error_message, "Exceeded state budget limit for services (11305214 > 10000000)");
         assert.deepEqual(res.gas_amount_total, expectedGasAmountTotal);
         assert.deepEqual(res.gas_cost_total, 5.59512);
       });

--- a/unittest/functions.test.js
+++ b/unittest/functions.test.js
@@ -345,12 +345,12 @@ describe("Functions", () => {
       })
 
       it('REST function newly whitelisted', () => {
-        node.db.writeDatabase(CommonUtil.parsePath(refFullPathFunctionUrlWhitelist), 'http://localhost:3000');
+        node.db.writeDatabase(CommonUtil.parsePath(refFullPathFunctionUrlWhitelist), 'http://localhost:5000');
         node.db.setFunction(refPathRestNewlyWhitelisted, {
           ".function": {
             "newly_whitelisted": {
               "function_type": "REST",
-              "function_url": "http://localhost:3000",
+              "function_url": "http://localhost:5000",
               "function_id": "newly_whitelisted"
             }
           }

--- a/unittest/rule-util.test.js
+++ b/unittest/rule-util.test.js
@@ -245,13 +245,41 @@ describe("RuleUtil", () => {
       expect(util.isValidUrl('0x')).to.equal(false);
       expect(util.isValidUrl('0x6af1ec8d4f0a55bac328cb20336ed0eff46fa6334ebd112147892f1b15aafc8')).to.equal(false);
       expect(util.isValidUrl('ainetwork.ai')).to.equal(false);
+      expect(util.isValidUrl('https://*.ainetwork.ai')).to.equal(false);
     })
 
     it("when valid input", () => {
       expect(util.isValidUrl('http://ainetwork.ai')).to.equal(true);
       expect(util.isValidUrl('https://ainetwork.ai')).to.equal(true);
-      expect(util.isValidUrl('https://*.ainetwork.ai')).to.equal(true);
       expect(util.isValidUrl('https://ainetwork.ai/some/api')).to.equal(true);
+    })
+  })
+
+  describe("isValidUrlWhitelistItem", () => {
+    it("when invalid input", () => {
+      expect(util.isValidUrlWhitelistItem(true)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(false)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(0)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(10)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(null)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(undefined)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(Infinity)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem(NaN)).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('')).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('abc')).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('0')).to.equal(false);
+      expect(util.isValidUrlWhitelistItem([10])).to.equal(false);
+      expect(util.isValidUrlWhitelistItem({a: 'A'})).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('0x')).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('0x6af1ec8d4f0a55bac328cb20336ed0eff46fa6334ebd112147892f1b15aafc8')).to.equal(false);
+      expect(util.isValidUrlWhitelistItem('ainetwork.ai')).to.equal(false);
+    })
+
+    it("when valid input", () => {
+      expect(util.isValidUrlWhitelistItem('http://ainetwork.ai')).to.equal(true);
+      expect(util.isValidUrlWhitelistItem('https://ainetwork.ai')).to.equal(true);
+      expect(util.isValidUrlWhitelistItem('https://ainetwork.ai/some/api')).to.equal(true);
+      expect(util.isValidUrlWhitelistItem('https://*.ainetwork.ai')).to.equal(true);
     })
   })
 

--- a/unittest/rule-util.test.js
+++ b/unittest/rule-util.test.js
@@ -227,6 +227,34 @@ describe("RuleUtil", () => {
     })
   })
 
+  describe("isValidUrl", () => {
+    it("when invalid input", () => {
+      expect(util.isValidUrl(true)).to.equal(false);
+      expect(util.isValidUrl(false)).to.equal(false);
+      expect(util.isValidUrl(0)).to.equal(false);
+      expect(util.isValidUrl(10)).to.equal(false);
+      expect(util.isValidUrl(null)).to.equal(false);
+      expect(util.isValidUrl(undefined)).to.equal(false);
+      expect(util.isValidUrl(Infinity)).to.equal(false);
+      expect(util.isValidUrl(NaN)).to.equal(false);
+      expect(util.isValidUrl('')).to.equal(false);
+      expect(util.isValidUrl('abc')).to.equal(false);
+      expect(util.isValidUrl('0')).to.equal(false);
+      expect(util.isValidUrl([10])).to.equal(false);
+      expect(util.isValidUrl({a: 'A'})).to.equal(false);
+      expect(util.isValidUrl('0x')).to.equal(false);
+      expect(util.isValidUrl('0x6af1ec8d4f0a55bac328cb20336ed0eff46fa6334ebd112147892f1b15aafc8')).to.equal(false);
+      expect(util.isValidUrl('ainetwork.ai')).to.equal(false);
+    })
+
+    it("when valid input", () => {
+      expect(util.isValidUrl('http://ainetwork.ai')).to.equal(true);
+      expect(util.isValidUrl('https://ainetwork.ai')).to.equal(true);
+      expect(util.isValidUrl('https://*.ainetwork.ai')).to.equal(true);
+      expect(util.isValidUrl('https://ainetwork.ai/some/api')).to.equal(true);
+    })
+  })
+
   describe("keys", () => {
     it("when invalid input", () => {
       assert.deepEqual(util.keys(true), []);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,6 +3533,13 @@ map-obj@^4.1.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
   integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
 
+match-url-wildcard@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/match-url-wildcard/-/match-url-wildcard-0.0.4.tgz#c8533da7ec0901eddf01fc0893effa68d4e727d6"
+  integrity sha512-R1XhQaamUZPWLOPtp4ig5j+3jctN+skhgRmEQTUamMzmNtRG69QEirQs0NZKLtHMR7tzWpmtnS4Eqv65DcgXUA==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -5423,11 +5430,6 @@ v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
-
-valid-url@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
-  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
- Allow wildcards in REST function URLs using [match-url-wildcard](https://www.npmjs.com/package/match-url-wildcard)
- Updated URL validity checks to follow the WHATWG URL Standard ([node.js URL](https://nodejs.org/dist/latest-v16.x/docs/api/url.html#the-whatwg-url-api), [WHATWG valid url string](https://url.spec.whatwg.org/#valid-url-string))
- Examples
  - http://localhost:3000 => matches http://localhost:3000/*
  - http://127.0.0.1:3000 => matches http://127.0.0.1:3000/*
  - http://ainetwork.ai => matches http://ainetwork.ai/*
  - https://ainetwork.ai => matches https://ainetwork.ai/*
  - https://\*.ainetwork.ai => matches https://\*.ainetwork.ai/\*