### PR TITLE
Add punctuator token blacklist for write rules

### DIFF
--- a/db/state-util.js
+++ b/db/state-util.js
@@ -37,9 +37,12 @@ const WRITE_RULE_ID_TOKEN_WHITELIST_BASE = [
   'newData',
   'util',
   // 2) from language
-  'Number',
-  'String',
-  'Boolean',
+  'Number',  // type casting
+  'String',  // type casting
+  'Boolean',  // type casting
+];
+const WRITE_RULE_PUNC_TOKEN_BLACKLIST = [
+  '=',  // assignment
 ];
 
 function isEmptyNode(node) {
@@ -243,6 +246,13 @@ function getTopLevelIdTokens(tokenList) {
   }).map((token) => token.value);
 }
 
+/**
+ * Extract punctuator tokens from the given token list.
+ */
+function getPuncTokens(tokenList) {
+  return tokenList.filter((token) => token.type === 'Punctuator').map((token) => token.value);
+}
+
 function isValidWriteRule(parsedRulePath, ruleString) {
   const LOG_HEADER = 'isValidWriteRule';
 
@@ -262,6 +272,18 @@ function isValidWriteRule(parsedRulePath, ruleString) {
       if (!idTokenWhitelistSet.has(token)) {
         logger.info(
             `[${LOG_HEADER}] Rule includes a not-allowed identifier token (${token}) ` +
+            `in rule string: ${ruleString}`);
+        return false;
+      }
+    }
+    const puncTokenBlacklistSet = new Set([
+      ...WRITE_RULE_PUNC_TOKEN_BLACKLIST
+    ]);
+    const puncTokens = getPuncTokens(tokenList);
+    for (const token of puncTokens) {
+      if (puncTokenBlacklistSet.has(token)) {
+        logger.info(
+            `[${LOG_HEADER}] Rule includes a not-allowed punctuator token (${token}) ` +
             `in rule string: ${ruleString}`);
         return false;
       }

--- a/integration/node.test.js
+++ b/integration/node.test.js
@@ -1923,7 +1923,7 @@ describe('Blockchain Node', () => {
                 ref: "/apps/test/test_rule/other200/path",
                 value: {
                   ".rule": {
-                    "write": "auth.addr = 'xyz200'"
+                    "write": "auth.addr === 'xyz200'"
                   }
                 }
               },
@@ -2133,7 +2133,7 @@ describe('Blockchain Node', () => {
                 },
                 "state": {
                   "app": {
-                    "test": 724
+                    "test": 728
                   },
                   "service": 0
                 }

--- a/tools/eval-rule/samples/assignment.txt
+++ b/tools/eval-rule/samples/assignment.txt
@@ -1,0 +1,1 @@
+newData = 'some code'; newData();

--- a/unittest/db.test.js
+++ b/unittest/db.test.js
@@ -1841,7 +1841,7 @@ describe("DB operations", () => {
       it("when writing with variable path", () => {
         const ruleConfig = {
           ".rule": {
-            "write": "auth.addr = 'xyz'"
+            "write": "auth.addr === 'xyz'"
           }
         };
         expect(node.db.setRule("/apps/test/test_rule/some/$variable/path", ruleConfig).code)
@@ -2324,7 +2324,7 @@ describe("DB operations", () => {
             ref: "/apps/test/test_rule/some/path",
             value: {
               ".rule": {
-                "write": "auth.addr = 'xyz'"
+                "write": "auth.addr === 'xyz'"
               }
             }
           },
@@ -2409,7 +2409,7 @@ describe("DB operations", () => {
         });
         assert.deepEqual(node.db.getRule("/apps/test/test_rule/some/path"), {
           ".rule": {
-            "write": "auth.addr = 'xyz'"
+            "write": "auth.addr === 'xyz'"
           }
         });
         assert.deepEqual(

--- a/unittest/state-util.test.js
+++ b/unittest/state-util.test.js
@@ -655,6 +655,10 @@ describe("state-util", () => {
       expect(isValidWriteRule([], 1)).to.equal(false);
       expect(isValidStateRule([], { "invalid_top_level_token": true })).to.equal(false);
       expect(isValidWriteRule([], 'process.exit(0)')).to.equal(false);
+      // assignment
+      expect(isValidWriteRule([], "newData = 'some code'")).to.equal(false);
+      // assignment & invoke
+      expect(isValidWriteRule([], "newData = 'some code'; newData();")).to.equal(false);
     })
 
     it('when valid input', () => {
@@ -666,6 +670,7 @@ describe("state-util", () => {
       expect(isValidWriteRule([], "newData")).to.equal(true);
       expect(isValidWriteRule([], "currentTime")).to.equal(true);
       expect(isValidWriteRule([], "lastBlockNumber")).to.equal(true);
+      expect(isValidWriteRule([], "auth.fid == '_stake'")).to.equal(true);
       expect(isValidWriteRule([], "auth.fid === '_stake'")).to.equal(true);
       expect(isValidWriteRule([], "auth.addr === 'some addr'")).to.equal(true);
       expect(isValidWriteRule([], "newData.proposer === auth.addr")).to.equal(true);


### PR DESCRIPTION
Change summary:
- Add punctuator token blacklist for write rules
- Do not allow assignment punctuator ('=')

Background:
- Value assignment could be harmful in javascript

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/614