### PR TITLE
Add block and root_proof_hash to blockchain snapshots

### DIFF
--- a/blockchain/block.js
+++ b/blockchain/block.js
@@ -338,7 +338,7 @@ class Block {
   static executeGenesisTxsAndGetData(genesisTxs, genesisTime) {
     const tempGenesisDb = new DB(
         new StateNode(StateVersions.EMPTY), StateVersions.EMPTY, null, -1, null);
-    tempGenesisDb.initDbStates();
+    tempGenesisDb.initDb();
     const resList = [];
     for (const tx of genesisTxs) {
       const res = tempGenesisDb.executeTransaction(Transaction.toExecutable(tx), true, false, 0, genesisTime);

--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -18,7 +18,6 @@ class Blockchain {
     // Finalized chain
     this.chain = [];
     this.blockchainPath = path.resolve(CHAINS_DIR, basePath);
-    this.initSnapshotBlockNumber = -1;
     this.genesisBlockHash = Block.genesis().hash; // TODO(liayoo): update with the genesis_block.json
 
     // Mapping of a block number to the finalized block's info
@@ -28,8 +27,10 @@ class Blockchain {
   /**
    * Initializes the blockchain and returns whether there are block files to load.
    */
-  initBlockchain(isFirstNode, latestSnapshotBlockNumber) {
-    this.initSnapshotBlockNumber = latestSnapshotBlockNumber;
+  initBlockchain(isFirstNode, snapshot) {
+    if (snapshot) {
+      this.addBlockToChain(snapshot.block);
+    }
     const wasBlockDirEmpty = FileUtil.createBlockchainDir(this.blockchainPath);
     let isGenesisStart = false;
     if (wasBlockDirEmpty) {
@@ -121,13 +122,10 @@ class Blockchain {
 
   lastBlockNumber() {
     const lastBlock = this.lastBlock();
-    if (!lastBlock) {
-      if (this.initSnapshotBlockNumber) {
-        return this.initSnapshotBlockNumber;
-      }
-      return -1;
+    if (lastBlock) {
+      return lastBlock.number;
     }
-    return lastBlock.number;
+    return -1;
   }
 
   lastBlockEpoch() {

--- a/blockchain/index.js
+++ b/blockchain/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const { Block } = require('./block');
 const FileUtil = require('../common/file-util');
 const {
+  BlockchainSnapshotProperties,
   CHAINS_DIR,
   CHAIN_SEGMENT_LENGTH,
   ON_MEMORY_CHAIN_LENGTH,
@@ -29,7 +30,7 @@ class Blockchain {
    */
   initBlockchain(isFirstNode, snapshot) {
     if (snapshot) {
-      this.addBlockToChain(snapshot.block);
+      this.addBlockToChain(snapshot[BlockchainSnapshotProperties.BLOCK]);
     }
     const wasBlockDirEmpty = FileUtil.createBlockchainDir(this.blockchainPath);
     let isGenesisStart = false;

--- a/common/constants.js
+++ b/common/constants.js
@@ -34,8 +34,6 @@ const FeatureFlags = {
   enableTrafficMonitoring: true,
   // Enables state info updates.
   enableStateInfoUpdates: true,
-  // Enables radix level snapshots.
-  enableRadixLevelSnapshots: true,
 };
 
 // ** Environment variables **

--- a/common/constants.js
+++ b/common/constants.js
@@ -435,6 +435,19 @@ const StateInfoProperties = {
 };
 
 /**
+ * Properties of blockchain snapshot.
+ *
+ * @enum {string}
+ */
+const BlockchainSnapshotProperties = {
+  BLOCK: 'block',
+  BLOCK_NUMBER: 'block_number',
+  RADIX_SNAPSHOT: 'radix_snapshot',
+  ROOT_PROOF_HASH: 'root_proof_hash',
+  STATE_SNAPSHOT: 'state_snapshot',
+};
+
+/**
  * IDs of native functions.
  *
  * @enum {string}
@@ -1042,6 +1055,7 @@ module.exports = {
   FunctionTypes,
   FunctionResultCode,
   StateInfoProperties,
+  BlockchainSnapshotProperties,
   NativeFunctionIds,
   isNativeFunctionId,
   ShardingProperties,

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -692,8 +692,7 @@ class Consensus {
     if (stateProofHash !== expectedStateProofHash) {
       if (takeSnapshot) {
         // NOTE(platfowner): Write the current snapshot for debugging.
-        const snapshot = FeatureFlags.enableRadixLevelSnapshots ? db.takeRadixSnapshot() :
-            db.takeStateSnapshot();
+        const snapshot = node.buildBlockchainSnapshot(number, db.stateRoot);
         FileUtil.writeSnapshot(node.snapshotDir, number, snapshot, true);
       }
       throw new ConsensusError({

--- a/db/index.js
+++ b/db/index.js
@@ -10,6 +10,7 @@ const {
   OwnerProperties,
   RuleProperties,
   StateInfoProperties,
+  BlockchainSnapshotProperties,
   ShardingProperties,
   GenesisAccounts,
   GenesisSharding,
@@ -113,13 +114,15 @@ class DB {
   initDbStates(snapshot = null) {
     const LOG_HEADER = 'initDbStates';
     if (snapshot) {
-      const newRoot = StateNode.fromRadixSnapshot(snapshot.radix_snapshot);
+      const newRoot =
+          StateNode.fromRadixSnapshot(snapshot[BlockchainSnapshotProperties.RADIX_SNAPSHOT]);
       updateStateInfoForStateTree(newRoot);
+      const rootProofHash = snapshot[BlockchainSnapshotProperties.ROOT_PROOF_HASH];
       // Checks the state proof hash
-      if (newRoot.getProofHash() !== snapshot.root_proof_hash) {
+      if (newRoot.getProofHash() !== rootProofHash) {
         CommonUtil.finishWithStackTrace(
             logger,
-            `[${LOG_HEADER}] Root proof hash mismatch: ${newRoot.getProofHash()} / ${snapshot.root_proof_hash}`);
+            `[${LOG_HEADER}] Root proof hash mismatch: ${newRoot.getProofHash()} / ${rootProofHash}`);
       }
       this.replaceStateRoot(newRoot);
     } else {

--- a/db/index.js
+++ b/db/index.js
@@ -111,9 +111,16 @@ class DB {
   }
 
   initDbStates(snapshot = null) {
+    const LOG_HEADER = 'initDbStates';
     if (snapshot) {
       const newRoot = StateNode.fromRadixSnapshot(snapshot.radix_snapshot);
       updateStateInfoForStateTree(newRoot);
+      // Checks the state proof hash
+      if (newRoot.getProofHash() !== snapshot.root_proof_hash) {
+        CommonUtil.finishWithStackTrace(
+            logger,
+            `[${LOG_HEADER}] Root proof hash mismatch: ${newRoot.getProofHash()} / ${snapshot.root_proof_hash}`);
+      }
       this.replaceStateRoot(newRoot);
     } else {
       // Initialize DB owners.

--- a/node/index.js
+++ b/node/index.js
@@ -195,7 +195,7 @@ class BlockchainNode {
     const startingDb = DB.create(
         StateVersions.EMPTY, StateVersions.START, this.bc, true, latestSnapshotBlockNumber,
         this.stateManager);
-    startingDb.initDbStates(latestSnapshot);
+    startingDb.initDb(latestSnapshot);
 
     // 3. Initialize the blockchain, starting from `latestSnapshotBlockNumber`.
     logger.info(`[${LOG_HEADER}] Initializing blockchain..`);

--- a/node/index.js
+++ b/node/index.js
@@ -172,10 +172,10 @@ class BlockchainNode {
       logger.info(`[${LOG_HEADER}] Initializing node in 'fast' mode..`);
       const latestSnapshotInfo = FileUtil.getLatestSnapshotInfo(this.snapshotDir);
       latestSnapshotPath = latestSnapshotInfo.latestSnapshotPath;
-      latestSnapshotBlockNumber = latestSnapshotInfo.latestSnapshotBlockNumber;
       if (latestSnapshotPath) {
         try {
           latestSnapshot = FileUtil.readCompressedJson(latestSnapshotPath);
+          latestSnapshotBlockNumber = latestSnapshot.block_number;
         } catch (err) {
           CommonUtil.finishWithStackTrace(
               logger, 

--- a/node/index.js
+++ b/node/index.js
@@ -16,6 +16,7 @@ const {
   MAX_NUM_SNAPSHOTS,
   BlockchainNodeStates,
   PredefinedDbPaths,
+  BlockchainSnapshotProperties,
   ShardingProperties,
   ShardingProtocols,
   GenesisAccounts,
@@ -175,7 +176,7 @@ class BlockchainNode {
       if (latestSnapshotPath) {
         try {
           latestSnapshot = FileUtil.readCompressedJson(latestSnapshotPath);
-          latestSnapshotBlockNumber = latestSnapshot.block_number;
+          latestSnapshotBlockNumber = latestSnapshot[BlockchainSnapshotProperties.BLOCK_NUMBER];
         } catch (err) {
           CommonUtil.finishWithStackTrace(
               logger, 
@@ -299,11 +300,11 @@ class BlockchainNode {
     const radixSnapshot = stateRoot.toRadixSnapshot();
     const rootProofHash = stateRoot.getProofHash();
     return {
-      block_number: blockNumber,
-      block,
-      state_snapshot: stateSnapshot,
-      radix_snapshot: radixSnapshot,
-      root_proof_hash: rootProofHash,
+      [BlockchainSnapshotProperties.BLOCK_NUMBER]: blockNumber,
+      [BlockchainSnapshotProperties.BLOCK]: block,
+      [BlockchainSnapshotProperties.STATE_SNAPSHOT]: stateSnapshot,
+      [BlockchainSnapshotProperties.RADIX_SNAPSHOT]: radixSnapshot,
+      [BlockchainSnapshotProperties.ROOT_PROOF_HASH]: rootProofHash,
     }
   }
 

--- a/node/index.js
+++ b/node/index.js
@@ -297,11 +297,13 @@ class BlockchainNode {
     const block = this.bc.getBlockByNumber(blockNumber);
     const stateSnapshot = stateRoot.toStateSnapshot();
     const radixSnapshot = stateRoot.toRadixSnapshot();
+    const rootProofHash = stateRoot.getProofHash();
     return {
       block_number: blockNumber,
       block,
       state_snapshot: stateSnapshot,
       radix_snapshot: radixSnapshot,
+      root_proof_hash: rootProofHash,
     }
   }
 

--- a/tools/proof-hash/verifyBlock.js
+++ b/tools/proof-hash/verifyBlock.js
@@ -23,7 +23,7 @@ async function verifyBlock(snapshotFile, blockFileList) {
   const stateManager = new StateManager();
   const db = DB.create(
       StateVersions.EMPTY, 'verifyBlock', bc, false, bc.lastBlockNumber(), stateManager);
-  db.initDbStates(snapshot);
+  db.initDb(snapshot);
   console.log(`  Done.`);
 
   let prevBlock = null;


### PR DESCRIPTION
Change summary:
- Add block to blockchain snapshots and add it to bc.chain[] in node restarting
- Add root_proof_hash to blockchain snapshots and verify it in node restarting 
- Finalize loaded state version in node restarting
- Remove enableRadixLevelSnapshots feature flag

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/649
- https://github.com/ainblockchain/ain-blockchain/issues/687
