### PR TITLE
Add express rate limit config for ddos protection

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -7,12 +7,14 @@ const cors = require('cors');
 // NOTE(liayoo): To use async/await (ref: https://github.com/tedeh/jayson#promises)
 const jayson = require('jayson/promise');
 const _ = require('lodash');
+const rateLimit = require("express-rate-limit");
 const BlockchainNode = require('../node');
 const P2pClient = require('../p2p');
 const CommonUtil = require('../common/common-util');
 const VersionUtil = require('../common/version-util');
 const {
   ENABLE_DEV_CLIENT_SET_API,
+  ENABLE_EXPRESS_RATE_LIMIT,
   CURRENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION_MAP,
   PORT,
@@ -36,6 +38,13 @@ app.use(express.urlencoded({
   limit: REQUEST_BODY_SIZE_LIMIT
 }));
 app.use(cors({ origin: CORS_WHITELIST }));
+if (ENABLE_EXPRESS_RATE_LIMIT) {
+  const limiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 60 // limit each IP to 60 requests per windowMs
+  });
+  app.use(limiter);
+}
 
 
 const node = new BlockchainNode();

--- a/common/constants.js
+++ b/common/constants.js
@@ -49,6 +49,8 @@ const ENABLE_GAS_FEE_WORKAROUND =
     CommonUtil.convertEnvVarInputToBool(process.env.ENABLE_GAS_FEE_WORKAROUND, true);
 const ENABLE_REST_FUNCTION_CALL =
     CommonUtil.convertEnvVarInputToBool(process.env.ENABLE_REST_FUNCTION_CALL);
+const ENABLE_EXPRESS_RATE_LIMIT =
+    CommonUtil.convertEnvVarInputToBool(process.env.ENABLE_EXPRESS_RATE_LIMIT, true);
 const ACCOUNT_INDEX = process.env.ACCOUNT_INDEX || null;
 const PORT = process.env.PORT || getPortNumber(8080, 8080);
 const P2P_PORT = process.env.P2P_PORT || getPortNumber(5000, 5000);
@@ -1013,6 +1015,7 @@ module.exports = {
   ENABLE_TX_SIG_VERIF_WORKAROUND,
   ENABLE_GAS_FEE_WORKAROUND,
   ENABLE_REST_FUNCTION_CALL,
+  ENABLE_EXPRESS_RATE_LIMIT,
   ACCOUNT_INDEX,
   ACCOUNT_INJECTION_OPTION,
   KEYSTORE_FILE_PATH,

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -3,8 +3,10 @@
 if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
     printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic] [--restart|--reset]\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev lia 0 --setup --keystore\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ deploy_blockchain_genesis_gcp.sh ]]]]]\n\n"
 
 if [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'dev' ]] || [[ "$1" = 'staging' ]]; then
     SEASON="$1"
@@ -93,10 +95,9 @@ fi
 
 if [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
     # Get keystore password
-    echo -n "Enter password: "
+    printf "Enter password: "
     read -s PASSWORD
-    echo
-    echo
+    printf "\n\n"
 
     # Read node ip addresses
     IFS=$'\n' read -d '' -r -a IP_ADDR_LIST < ./testnet_ip_addresses/$SEASON.txt

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -23,6 +23,11 @@ printf "PROJECT_ID=$PROJECT_ID\n"
 GCP_USER="$2"
 printf "GCP_USER=$GCP_USER\n"
 
+number_re='^[0-9]+$'
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <# of Shards> argument: $3\n"
+    exit
+fi
 NUM_SHARDS=$3
 printf "NUM_SHARDS=$NUM_SHARDS\n"
 

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -3,8 +3,10 @@
 if [[ $# -lt 3 ]] || [[ $# -gt 9 ]]; then
     printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|spring|summer] <GCP Username> <# of Shards> [--setup] [--canary] [--full-sync] [--keystore|--mnemonic] [--restart|--reset]\n"
     printf "Example: bash deploy_blockchain_incremental_gcp.sh dev lia 0 --setup --canary --full-sync --keystore\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ deploy_blockchain_incremental_gcp.sh ]]]]]\n\n"
 
 if [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'dev' ]] || [[ "$1" = 'staging' ]]; then
     SEASON="$1"
@@ -99,10 +101,9 @@ fi
 
 if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
     # Get keystore password
-    echo -n "Enter password: "
+    printf "Enter password: "
     read -s PASSWORD
-    echo
-    echo
+    printf "\n\n"
 
     # Read node ip addresses
     IFS=$'\n' read -d '' -r -a IP_ADDR_LIST < ./testnet_ip_addresses/$SEASON.txt
@@ -146,7 +147,7 @@ function deploy_tracker() {
 
     if [[ $RESET_RESTART_OPTION = "" ]]; then
         # 1. Copy files for tracker
-        printf "\n\n[[[[ Copying files for tracker ]]]]\n\n"
+        printf "\n\n[[[ Copying files for tracker ]]]\n\n"
         SCP_CMD="gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ --project $PROJECT_ID --zone $TRACKER_ZONE"
         printf "SCP_CMD=$SCP_CMD\n\n"
         eval $SCP_CMD
@@ -155,14 +156,14 @@ function deploy_tracker() {
     # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
     if [[ $SETUP_OPTION = "--setup" ]]; then
         # 2. Set up tracker
-        printf "\n\n[[[[ Setting up tracker ]]]]\n\n"
+        printf "\n\n[[[ Setting up tracker ]]]\n\n"
         SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '. setup_blockchain_ubuntu.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
         printf "SETUP_CMD=$SETUP_CMD\n\n"
         eval $SETUP_CMD
     fi
 
     # 3. Start tracker
-    printf "\n\n[[[[ Starting tracker ]]]]\n\n"
+    printf "\n\n[[[ Starting tracker ]]]\n\n"
 
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 
@@ -184,7 +185,7 @@ function deploy_node() {
 
     if [[ $RESET_RESTART_OPTION = "" ]]; then
         # 1. Copy files for node
-        printf "\n\n[[[[ Copying files for node $node_index ]]]]\n\n"
+        printf "\n\n[[[ Copying files for node $node_index ]]]\n\n"
         SCP_CMD="gcloud compute scp --recurse $FILES_FOR_NODE ${node_target_addr}:~/ --project $PROJECT_ID --zone $node_zone"
         printf "SCP_CMD=$SCP_CMD\n\n"
         eval $SCP_CMD
@@ -193,14 +194,14 @@ function deploy_node() {
     # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
     if [[ $SETUP_OPTION = "--setup" ]]; then
         # 2. Set up node
-        printf "\n\n[[[[ Setting up node $node_index ]]]]\n\n"
+        printf "\n\n[[[ Setting up node $node_index ]]]\n\n"
         SETUP_CMD="gcloud compute ssh $node_target_addr --command '. setup_blockchain_ubuntu.sh' --project $PROJECT_ID --zone $node_zone"
         printf "SETUP_CMD=$SETUP_CMD\n\n"
         eval $SETUP_CMD
     fi
 
     # 3. Start node
-    printf "\n\n[[[[ Starting node $node_index ]]]]\n\n"
+    printf "\n\n[[[ Starting node $node_index ]]]\n\n"
     if [[ $node_index -gt 4 ]]; then
         JSON_RPC_OPTION="--json-rpc"
         REST_FUNC_OPTION="--rest-func"
@@ -241,7 +242,7 @@ function deploy_node() {
     fi
 
     #5. Wait until node is synced
-    printf "\n\n[[[[ Waiting until node is synced $node_index ]]]]\n\n"
+    printf "\n\n[[[ Waiting until node is synced $node_index ]]]\n\n"
     WAIT_CMD="gcloud compute ssh $node_target_addr --command 'cd \$(find /home/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync_gcp.sh' --project $PROJECT_ID --zone $node_zone"
     printf "WAIT_CMD=$WAIT_CMD\n\n"
     eval $WAIT_CMD

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -19,8 +19,15 @@ else
 fi
 printf "SEASON=$SEASON\n"
 printf "PROJECT_ID=$PROJECT_ID\n"
+
 printf "GCP_USER=$GCP_USER\n"
 GCP_USER="$2"
+
+number_re='^[0-9]+$'
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <# of Shards> argument: $3\n"
+    exit
+fi
 printf "NUM_SHARDS=$NUM_SHARDS\n"
 NUM_SHARDS=$3
 
@@ -90,7 +97,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
-if [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
+if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
     # Get keystore password
     echo -n "Enter password: "
     read -s PASSWORD
@@ -100,12 +107,12 @@ if [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
     # Read node ip addresses
     IFS=$'\n' read -d '' -r -a IP_ADDR_LIST < ./testnet_ip_addresses/$SEASON.txt
 
-    if [[ "$SEASON" = "spring" ]] || [[ "$SEASON" = "summer" ]]; then
+    if [[ $SEASON = "spring" ]] || [[ $SEASON = "summer" ]]; then
         KEYSTORE_DIR="testnet_prod_keys/"
     else
         KEYSTORE_DIR="testnet_dev_staging_keys/"
     fi
-elif [[ "$ACCOUNT_INJECTION_OPTION" = "--mnemonic" ]]; then
+elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
     # Read node ip addresses
     IFS=$'\n' read -d '' -r -a IP_ADDR_LIST < ./testnet_ip_addresses/$SEASON.txt
 
@@ -214,13 +221,13 @@ function deploy_node() {
     eval $START_NODE_CMD
 
     # 4. Init account if necessary (if --keystore specified)
-    if [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
+    if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
         local node_ip_addr=${IP_ADDR_LIST[${node_index}]}
         printf "\n* >> Initializing account for node $node_index ********************\n\n"
         printf "node_ip_addr='$node_ip_addr'\n"
 
         echo $PASSWORD | node inject_account_gcp.js $node_ip_addr $ACCOUNT_INJECTION_OPTION
-    elif [[ "$ACCOUNT_INJECTION_OPTION" = "--mnemonic" ]]; then
+    elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
         local node_ip_addr=${IP_ADDR_LIST[${node_index}]}
         local MNEMONIC=${MNEMONIC_LIST[${node_index}]}
         printf "\n* >> Injecting an account for node $node_index ********************\n\n"
@@ -285,7 +292,7 @@ else
         done
 fi
 
-if [[ "$NUM_SHARDS" -gt 0 ]]; then
+if [[ $NUM_SHARDS -gt 0 ]]; then
     for i in $(seq $NUM_SHARDS)
         do
             printf "###############################################################################\n"

--- a/deploy_monitoring_gcp.sh
+++ b/deploy_monitoring_gcp.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 if [[ "$#" -lt 2 ]]; then
-    echo "Usage: bash deploy_monitoring_gcp.sh [dev|staging|spring|summer] <GCP Username>  [--setup]"
-    echo "Example: bash deploy_monitoring_gcp.sh dev seo"
+    printf "Usage: bash deploy_monitoring_gcp.sh [dev|staging|spring|summer] <GCP Username>  [--setup]\n"
+    printf "Example: bash deploy_monitoring_gcp.sh dev seo\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ deploy_monitoring_gcp.sh ]]]]]\n\n"
 
 if [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'dev' ]] || [[ "$1" = 'staging' ]]; then
     SEASON="$1"
@@ -14,23 +16,22 @@ if [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'dev' ]] || [[ "$
         PROJECT_ID="testnet-$1-ground"
     fi
 else
-    echo "Invalid project/season argument: $1"
+    printf "Invalid project/season argument: $1\n"
     exit
 fi
-echo "SEASON=$SEASON"
-echo "PROJECT_ID=$PROJECT_ID"
+printf "SEASON=$SEASON\n"
+printf "PROJECT_ID=$PROJECT_ID\n"
 
 GCP_USER="$2"
-echo "GCP_USER=$GCP_USER"
+printf "GCP_USER=$GCP_USER\n"
 
 OPTIONS="$3"
-echo "OPTIONS=$OPTIONS"
+printf "OPTIONS=$OPTIONS\n"
 
 # Get confirmation.
-echo
+printf "\n"
 read -p "Do you want to proceed? >> (y/N) " -n 1 -r
-echo
-echo
+printf "\n\n"
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "escape-string-regexp": "^2.0.0",
     "espree": "^9.0.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.5.1",
     "ext-ip": "^0.3.9",
     "fast-json-stable-stringify": "^2.0.0",
     "geoip-lite": "^1.3.8",

--- a/setup_blockchain_ubuntu.sh
+++ b/setup_blockchain_ubuntu.sh
@@ -1,41 +1,50 @@
 #!/bin/bash
 
-echo 'Upgrading apt..'
+printf "\n[[[[[ setup_blockchain_ubuntu.sh ]]]]]\n\n"
+
+printf 'Upgrading apt..\n'
 sudo apt update
 # skip prompting (see https://serverfault.com/questions/527789/how-to-automate-changed-config-files-during-apt-get-upgrade-in-ubuntu-12)
 apt-get --yes --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 
-echo 'Installing NodeJS..'
+printf 'Installing NodeJS..\n'
 sudo apt update
 sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates
 curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt -y install nodejs
 
-echo 'node -v'
+printf 'node -v\n'
 node -v
 
-echo 'npm --version'
+printf 'npm --version\n'
 npm --version
 
 
-echo 'Installing make..'
+printf 'Installing yarn..\n'
+sudo npm install -g yarn
+
+printf 'yarn --version\n'
+yarn --version
+
+
+printf 'Installing make..\n'
 sudo apt update
 sudo apt-get install -y build-essential
 
-echo 'make --version'
+printf 'make --version\n'
 make --version
 
 
-echo 'Installing vim..'
+printf 'Installing vim..\n'
 sudo apt update
 sudo apt install -y vim
 
-echo 'vim --version'
+printf 'vim --version\n'
 vim --version
 
-echo 'Installing jq..'
+printf 'Installing jq..\n'
 sudo apt update
 sudo apt install -y jq
 
-echo 'jq --version'
+printf 'jq --version\n'
 jq --version

--- a/setup_monitoring_gcp.sh
+++ b/setup_monitoring_gcp.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
 
 if [[ "$#" -lt 1 ]]; then
-    echo "Usage: bash setup_monitoring_gcp.sh [dev|staging|spring|summer]"
-    echo "Example: bash setup_monitoring_gcp.sh dev"
+    printf "Usage: bash setup_monitoring_gcp.sh [dev|staging|spring|summer]\n"
+    printf "Example: bash setup_monitoring_gcp.sh dev\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ setup_monitoring_gcp.sh ]]]]]\n\n"
 
 if [[ "$1" != 'spring' ]] && [[ "$1" != 'summer' ]] && [[ "$1" != 'dev' ]] && [[ "$1" != 'staging' ]]; then
-    echo "Invalid season argument: $1"
+    printf "Invalid season argument: $1\n"
     exit
 fi
 
 SEASON="$1"
 
 
-echo 'Killing old jobs..'
+printf 'Killing old jobs..\n'
 killall prometheus
 killall grafana-server
 
 
-echo 'Setting up working directory..'
+printf 'Setting up working directory..\n'
 cd
 sudo rm -rf ../ain-blockchain
 sudo mkdir ../ain-blockchain
@@ -28,7 +30,7 @@ mv * ../ain-blockchain
 cd ../ain-blockchain
 
 
-echo 'Installing Prometheus..'
+printf 'Installing Prometheus..\n'
 curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest \
   | grep browser_download_url \
   | grep linux-amd64 \
@@ -37,11 +39,11 @@ curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest \
 
 tar xvf prometheus*.tar.gz
 
-echo 'Renaming Prometheus folder..'
+printf 'Renaming Prometheus folder..\n'
 mv prometheus*/ prometheus
 
 
-echo 'Copying Prometheus yml file..'
+printf 'Copying Prometheus yml file..\n'
 PROMETHEUS_CONFIG_FILE="prometheus-${SEASON}.yml"
-echo "PROMETHEUS_CONFIG_FILE=${PROMETHEUS_CONFIG_FILE}"
+printf "PROMETHEUS_CONFIG_FILE=${PROMETHEUS_CONFIG_FILE}\n"
 cp -f monitoring/${PROMETHEUS_CONFIG_FILE} prometheus/prometheus.yml

--- a/setup_monitoring_ubuntu.sh
+++ b/setup_monitoring_ubuntu.sh
@@ -1,45 +1,54 @@
 #!/bin/bash
 
-echo 'Installing NodeJS..'
+printf "\n[[[[[ setup_monitoring_ubuntu.sh ]]]]]\n\n"
+
+printf 'Installing NodeJS..\n'
 sudo apt update
 curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt install -y nodejs
 
-echo 'node -v'
+printf 'node -v\n'
 node -v
 
-echo 'npm --version'
+printf 'npm --version\n'
 npm --version
 
 
-echo 'Installing make..'
+printf 'Installing yarn..\n'
+sudo npm install -g yarn
+
+printf 'yarn --version\n'
+yarn --version
+
+
+printf 'Installing make..\n'
 sudo apt update
 sudo apt-get install -y build-essential
 
-echo 'make --version'
+printf 'make --version\n'
 make --version
 
 
-echo 'Installing vim..'
+printf 'Installing vim..\n'
 sudo apt update
 sudo apt install -y vim
 
-echo 'vim --version'
+printf 'vim --version\n'
 vim --version
 
 
-echo 'Installing apt-transport-https..'
+printf 'Installing apt-transport-https..\n'
 sudo apt-get install -y apt-transport-https
 
 
-echo 'Installing wget..'
+printf 'Installing wget..\n'
 sudo apt-get install -y software-properties-common wget
 
-echo 'wget --version'
+printf 'wget --version\n'
 wget --version
 
 
-echo 'Installing Grafana..'
+printf 'Installing Grafana..\n'
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 
 echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list

--- a/start_monitoring_gcp.sh
+++ b/start_monitoring_gcp.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-echo 'Starting up Prometheus..'
+printf "\n[[[[[ start_monitoring_gcp.sh ]]]]]\n\n"
+
+printf 'Starting up Prometheus..\n'
 cd prometheus
 
 nohup ./prometheus --config.file=prometheus.yml >logs.txt 2>&1 &
-echo "Prometheus is now up!"
+printf "Prometheus is now up!\n"
 
 cd ..
 
 
-echo 'Starting up Grafana..'
+printf 'Starting up Grafana..\n'
 sudo systemctl daemon-reload
 sudo systemctl start grafana-server
 sudo systemctl status grafana-server
-echo "Grafana is now up!"
+printf "Grafana is now up!\n"

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -3,8 +3,10 @@
 if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
     printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index> [--keep-code] [--full-sync] [--keystore|--mnemonic] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_genesis_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ start_node_genesis_gcp.sh ]]]]]\n\n"
 
 function parse_options() {
     local option="$1"
@@ -117,7 +119,7 @@ if [[ $KEEP_CODE_OPTION = "" ]]; then
 
     printf '\n'
     printf 'Installing node modules..\n'
-    npm install
+    yarn install
 else
     printf '\n'
     printf 'Using old directory..\n'

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -35,6 +35,10 @@ function parse_options() {
 }
 
 # Parse options.
+SEASON="$1"
+SHARD_INDEX="$2"
+NODE_INDEX="$3"
+
 KEEP_CODE_OPTION=""
 FULL_SYNC_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
@@ -47,6 +51,10 @@ do
   parse_options "${!ARG_INDEX}"
   ((ARG_INDEX++))
 done
+
+printf "SEASON=$SEASON\n"
+printf "SHARD_INDEX=$SHARD_INDEX\n"
+printf "NODE_INDEX=$NODE_INDEX\n"
 
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
@@ -103,67 +111,67 @@ fi
 
 export GENESIS_CONFIGS_DIR=genesis-configs/testnet
 KEYSTORE_DIR=testnet_dev_staging_keys
-if [[ "$1" = 'spring' ]]; then
+if [[ "$SEASON" = 'spring' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.137.80:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$1" = 'summer' ]]; then
+elif [[ "$SEASON" = 'summer' ]]; then
     export TRACKER_WS_ADDR=ws://35.194.172.106:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$1" = 'staging' ]]; then
+elif [[ "$SEASON" = 'staging' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.150.73:5000
-elif [[ "$1" = 'dev' ]]; then
-  if [[ "$2" -gt 0 ]]; then
+elif [[ "$SEASON" = 'dev' ]]; then
+  if [[ "$SHARD_INDEX" -gt 0 ]]; then
     export GENESIS_CONFIGS_DIR=genesis-configs/sim-shard
   fi
 
-  if [[ "$2" = 0 ]]; then
+  if [[ "$SHARD_INDEX" = 0 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
-  elif [[ "$2" = 1 ]]; then
+  elif [[ "$SHARD_INDEX" = 1 ]]; then
     export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
-  elif [[ "$2" = 2 ]]; then
+  elif [[ "$SHARD_INDEX" = 2 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
-  elif [[ "$2" = 3 ]]; then
+  elif [[ "$SHARD_INDEX" = 3 ]]; then
     export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
-  elif [[ "$2" = 4 ]]; then
+  elif [[ "$SHARD_INDEX" = 4 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
-  elif [[ "$2" = 5 ]]; then
+  elif [[ "$SHARD_INDEX" = 5 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
-  elif [[ "$2" = 6 ]]; then
+  elif [[ "$SHARD_INDEX" = 6 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
-  elif [[ "$2" = 7 ]]; then
+  elif [[ "$SHARD_INDEX" = 7 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
-  elif [[ "$2" = 8 ]]; then
+  elif [[ "$SHARD_INDEX" = 8 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
-  elif [[ "$2" = 9 ]]; then
+  elif [[ "$SHARD_INDEX" = 9 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
-  elif [[ "$2" = 10 ]]; then
+  elif [[ "$SHARD_INDEX" = 10 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
-  elif [[ "$2" = 11 ]]; then
+  elif [[ "$SHARD_INDEX" = 11 ]]; then
     export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
-  elif [[ "$2" = 12 ]]; then
+  elif [[ "$SHARD_INDEX" = 12 ]]; then
     export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
-  elif [[ "$2" = 13 ]]; then
+  elif [[ "$SHARD_INDEX" = 13 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
-  elif [[ "$2" = 14 ]]; then
+  elif [[ "$SHARD_INDEX" = 14 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
-  elif [[ "$2" = 15 ]]; then
+  elif [[ "$SHARD_INDEX" = 15 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
-  elif [[ "$2" = 16 ]]; then
+  elif [[ "$SHARD_INDEX" = 16 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
-  elif [[ "$2" = 17 ]]; then
+  elif [[ "$SHARD_INDEX" = 17 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
-  elif [[ "$2" = 18 ]]; then
+  elif [[ "$SHARD_INDEX" = 18 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
-  elif [[ "$2" = 19 ]]; then
+  elif [[ "$SHARD_INDEX" = 19 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
-  elif [[ "$2" = 20 ]]; then
+  elif [[ "$SHARD_INDEX" = 20 ]]; then
     export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
   else
-    printf "Invalid shard ID argument: $2\n"
+    printf "Invalid shard ID argument: $SHARD_INDEX\n"
     exit
   fi
 else
-    printf "Invalid season argument: $1\n"
+    printf "Invalid season argument: $SEASON\n"
     exit
 fi
 
@@ -172,29 +180,29 @@ printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
 printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
 printf "KEYSTORE_DIR=$KEYSTORE_DIR\n"
 
-if [[ "$3" -lt 0 ]] || [[ "$3" -gt 6 ]]; then
-    printf "Invalid account_index argument: $2\n"
+if [[ "$NODE_INDEX" -lt 0 ]] || [[ "$NODE_INDEX" -gt 6 ]]; then
+    printf "Invalid account_index argument: $SHARD_INDEX\n"
     exit
 fi
 
 # NOTE(liayoo): Currently this script supports [--keystore|--mnemonic] option only for the parent chain.
-if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$2" -gt 0 ]]; then
-    export ACCOUNT_INDEX="$3"
+if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$SHARD_INDEX" -gt 0 ]]; then
+    export ACCOUNT_INDEX="$NODE_INDEX"
     printf "ACCOUNT_INDEX=$ACCOUNT_INDEX\n"
 elif [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
-    if [[ "$3" = 0 ]]; then
+    if [[ "$NODE_INDEX" = 0 ]]; then
         KEYSTORE_FILENAME="keystore_node_0.json"
-    elif [[ "$3" = 1 ]]; then
+    elif [[ "$NODE_INDEX" = 1 ]]; then
         KEYSTORE_FILENAME="keystore_node_1.json"
-    elif [[ "$3" = 2 ]]; then
+    elif [[ "$NODE_INDEX" = 2 ]]; then
         KEYSTORE_FILENAME="keystore_node_2.json"
-    elif [[ "$3" = 3 ]]; then
+    elif [[ "$NODE_INDEX" = 3 ]]; then
         KEYSTORE_FILENAME="keystore_node_3.json"
-    elif [[ "$3" = 4 ]]; then
+    elif [[ "$NODE_INDEX" = 4 ]]; then
         KEYSTORE_FILENAME="keystore_node_4.json"
-    elif [[ "$3" = 5 ]]; then
+    elif [[ "$NODE_INDEX" = 5 ]]; then
         KEYSTORE_FILENAME="keystore_node_5.json"
-    elif [[ "$3" = 6 ]]; then
+    elif [[ "$NODE_INDEX" = 6 ]]; then
         KEYSTORE_FILENAME="keystore_node_6.json"
     fi
     printf "KEYSTORE_FILENAME=$KEYSTORE_FILENAME\n"
@@ -227,4 +235,4 @@ printf "START_CMD=$START_CMD\n" >> start_commands.txt
 eval $START_CMD
 
 
-printf "\nBlockchain Node server [$1 $2 $3] is now up!\n\n"
+printf "\nBlockchain Node server [$SEASON $SHARD_INDEX $NODE_INDEX] is now up!\n\n"

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -36,7 +36,20 @@ function parse_options() {
 
 # Parse options.
 SEASON="$1"
+number_re='^[0-9]+$'
+if ! [[ $2 =~ $number_re ]] ; then
+    printf "Invalid <Shard Index> argument: $2\n"
+    exit
+fi
 SHARD_INDEX="$2"
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <Node Index> argument: $3\n"
+    exit
+fi
+if [[ "$3" -lt 0 ]] || [[ "$3" -gt 6 ]]; then
+    printf "Invalid <Node Index> argument: $3\n"
+    exit
+fi
 NODE_INDEX="$3"
 
 KEEP_CODE_OPTION=""
@@ -62,6 +75,12 @@ printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
 printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
+if [[ $SEASON = "staging" ]]; then
+  # for performance test pipeline
+  export ENABLE_EXPRESS_RATE_LIMIT=false
+else
+  export ENABLE_EXPRESS_RATE_LIMIT=true
+fi
 if [[ $FULL_SYNC_OPTION = "" ]]; then
   export SYNC_MODE=fast
 else
@@ -111,60 +130,60 @@ fi
 
 export GENESIS_CONFIGS_DIR=genesis-configs/testnet
 KEYSTORE_DIR=testnet_dev_staging_keys
-if [[ "$SEASON" = 'spring' ]]; then
+if [[ $SEASON = 'spring' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.137.80:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$SEASON" = 'summer' ]]; then
+elif [[ $SEASON = 'summer' ]]; then
     export TRACKER_WS_ADDR=ws://35.194.172.106:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$SEASON" = 'staging' ]]; then
+elif [[ $SEASON = 'staging' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.150.73:5000
-elif [[ "$SEASON" = 'dev' ]]; then
-  if [[ "$SHARD_INDEX" -gt 0 ]]; then
+elif [[ $SEASON = 'dev' ]]; then
+  if [[ $SHARD_INDEX -gt 0 ]]; then
     export GENESIS_CONFIGS_DIR=genesis-configs/sim-shard
   fi
 
-  if [[ "$SHARD_INDEX" = 0 ]]; then
+  if [[ $SHARD_INDEX = 0 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
-  elif [[ "$SHARD_INDEX" = 1 ]]; then
+  elif [[ $SHARD_INDEX = 1 ]]; then
     export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
-  elif [[ "$SHARD_INDEX" = 2 ]]; then
+  elif [[ $SHARD_INDEX = 2 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
-  elif [[ "$SHARD_INDEX" = 3 ]]; then
+  elif [[ $SHARD_INDEX = 3 ]]; then
     export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
-  elif [[ "$SHARD_INDEX" = 4 ]]; then
+  elif [[ $SHARD_INDEX = 4 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
-  elif [[ "$SHARD_INDEX" = 5 ]]; then
+  elif [[ $SHARD_INDEX = 5 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
-  elif [[ "$SHARD_INDEX" = 6 ]]; then
+  elif [[ $SHARD_INDEX = 6 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
-  elif [[ "$SHARD_INDEX" = 7 ]]; then
+  elif [[ $SHARD_INDEX = 7 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
-  elif [[ "$SHARD_INDEX" = 8 ]]; then
+  elif [[ $SHARD_INDEX = 8 ]]; then
     export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
-  elif [[ "$SHARD_INDEX" = 9 ]]; then
+  elif [[ $SHARD_INDEX = 9 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
-  elif [[ "$SHARD_INDEX" = 10 ]]; then
+  elif [[ $SHARD_INDEX = 10 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
-  elif [[ "$SHARD_INDEX" = 11 ]]; then
+  elif [[ $SHARD_INDEX = 11 ]]; then
     export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
-  elif [[ "$SHARD_INDEX" = 12 ]]; then
+  elif [[ $SHARD_INDEX = 12 ]]; then
     export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
-  elif [[ "$SHARD_INDEX" = 13 ]]; then
+  elif [[ $SHARD_INDEX = 13 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
-  elif [[ "$SHARD_INDEX" = 14 ]]; then
+  elif [[ $SHARD_INDEX = 14 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
-  elif [[ "$SHARD_INDEX" = 15 ]]; then
+  elif [[ $SHARD_INDEX = 15 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
-  elif [[ "$SHARD_INDEX" = 16 ]]; then
+  elif [[ $SHARD_INDEX = 16 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
-  elif [[ "$SHARD_INDEX" = 17 ]]; then
+  elif [[ $SHARD_INDEX = 17 ]]; then
     export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
-  elif [[ "$SHARD_INDEX" = 18 ]]; then
+  elif [[ $SHARD_INDEX = 18 ]]; then
     export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
-  elif [[ "$SHARD_INDEX" = 19 ]]; then
+  elif [[ $SHARD_INDEX = 19 ]]; then
     export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
-  elif [[ "$SHARD_INDEX" = 20 ]]; then
+  elif [[ $SHARD_INDEX = 20 ]]; then
     export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
   else
     printf "Invalid shard ID argument: $SHARD_INDEX\n"
@@ -180,33 +199,28 @@ printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
 printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
 printf "KEYSTORE_DIR=$KEYSTORE_DIR\n"
 
-if [[ "$NODE_INDEX" -lt 0 ]] || [[ "$NODE_INDEX" -gt 6 ]]; then
-    printf "Invalid account_index argument: $SHARD_INDEX\n"
-    exit
-fi
-
 # NOTE(liayoo): Currently this script supports [--keystore|--mnemonic] option only for the parent chain.
 if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$SHARD_INDEX" -gt 0 ]]; then
     export ACCOUNT_INDEX="$NODE_INDEX"
     printf "ACCOUNT_INDEX=$ACCOUNT_INDEX\n"
-elif [[ "$ACCOUNT_INJECTION_OPTION" = "--keystore" ]]; then
-    if [[ "$NODE_INDEX" = 0 ]]; then
+elif [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
+    if [[ $NODE_INDEX = 0 ]]; then
         KEYSTORE_FILENAME="keystore_node_0.json"
-    elif [[ "$NODE_INDEX" = 1 ]]; then
+    elif [[ $NODE_INDEX = 1 ]]; then
         KEYSTORE_FILENAME="keystore_node_1.json"
-    elif [[ "$NODE_INDEX" = 2 ]]; then
+    elif [[ $NODE_INDEX = 2 ]]; then
         KEYSTORE_FILENAME="keystore_node_2.json"
-    elif [[ "$NODE_INDEX" = 3 ]]; then
+    elif [[ $NODE_INDEX = 3 ]]; then
         KEYSTORE_FILENAME="keystore_node_3.json"
-    elif [[ "$NODE_INDEX" = 4 ]]; then
+    elif [[ $NODE_INDEX = 4 ]]; then
         KEYSTORE_FILENAME="keystore_node_4.json"
-    elif [[ "$NODE_INDEX" = 5 ]]; then
+    elif [[ $NODE_INDEX = 5 ]]; then
         KEYSTORE_FILENAME="keystore_node_5.json"
-    elif [[ "$NODE_INDEX" = 6 ]]; then
+    elif [[ $NODE_INDEX = 6 ]]; then
         KEYSTORE_FILENAME="keystore_node_6.json"
     fi
     printf "KEYSTORE_FILENAME=$KEYSTORE_FILENAME\n"
-    if [[ "$KEEP_CODE_OPTION" = "" ]]; then
+    if [[ $KEEP_CODE_OPTION = "" ]]; then
         sudo mkdir -p ../ain_blockchain_data/keys/8080
         sudo mv ./$KEYSTORE_DIR/$KEYSTORE_FILENAME ../ain_blockchain_data/keys/8080/
     fi

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -36,7 +36,20 @@ function parse_options() {
 
 # Parse options.
 SEASON="$1"
+number_re='^[0-9]+$'
+if ! [[ $2 =~ $number_re ]] ; then
+    printf "Invalid <Shard Index> argument: $2\n"
+    exit
+fi
 SHARD_INDEX="$2"
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <Node Index> argument: $3\n"
+    exit
+fi
+if [[ "$3" -lt 0 ]] || [[ "$3" -gt 6 ]]; then
+    printf "Invalid <Node Index> argument: $3\n"
+    exit
+fi
 NODE_INDEX="$3"
 
 KEEP_CODE_OPTION=""
@@ -67,62 +80,62 @@ printf "\n#### [Step 1] Configure env vars ####\n\n"
 
 export GENESIS_CONFIGS_DIR=genesis-configs/testnet
 KEYSTORE_DIR=testnet_dev_staging_keys
-if [[ "$SEASON" = 'spring' ]]; then
+if [[ $SEASON = 'spring' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.137.80:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$SEASON" = 'summer' ]]; then
+elif [[ $SEASON = 'summer' ]]; then
     export TRACKER_WS_ADDR=ws://35.194.172.106:5000
     KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$SEASON" = 'staging' ]]; then
+elif [[ $SEASON = 'staging' ]]; then
     export TRACKER_WS_ADDR=ws://35.221.150.73:5000
-elif [[ "$SEASON" = 'dev' ]]; then
-    if [[ "$SHARD_INDEX" = 0 ]]; then
+elif [[ $SEASON = 'dev' ]]; then
+    if [[ $SHARD_INDEX = 0 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
-    elif [[ "$SHARD_INDEX" = 1 ]]; then
+    elif [[ $SHARD_INDEX = 1 ]]; then
         export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
-    elif [[ "$SHARD_INDEX" = 2 ]]; then
+    elif [[ $SHARD_INDEX = 2 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
-    elif [[ "$SHARD_INDEX" = 3 ]]; then
+    elif [[ $SHARD_INDEX = 3 ]]; then
         export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
-    elif [[ "$SHARD_INDEX" = 4 ]]; then
+    elif [[ $SHARD_INDEX = 4 ]]; then
         export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
-    elif [[ "$SHARD_INDEX" = 5 ]]; then
+    elif [[ $SHARD_INDEX = 5 ]]; then
         export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
-    elif [[ "$SHARD_INDEX" = 6 ]]; then
+    elif [[ $SHARD_INDEX = 6 ]]; then
         export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
-    elif [[ "$SHARD_INDEX" = 7 ]]; then
+    elif [[ $SHARD_INDEX = 7 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
-    elif [[ "$SHARD_INDEX" = 8 ]]; then
+    elif [[ $SHARD_INDEX = 8 ]]; then
         export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
-    elif [[ "$SHARD_INDEX" = 9 ]]; then
+    elif [[ $SHARD_INDEX = 9 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
-    elif [[ "$SHARD_INDEX" = 10 ]]; then
+    elif [[ $SHARD_INDEX = 10 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
-    elif [[ "$SHARD_INDEX" = 11 ]]; then
+    elif [[ $SHARD_INDEX = 11 ]]; then
         export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
-    elif [[ "$SHARD_INDEX" = 12 ]]; then
+    elif [[ $SHARD_INDEX = 12 ]]; then
         export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
-    elif [[ "$SHARD_INDEX" = 13 ]]; then
+    elif [[ $SHARD_INDEX = 13 ]]; then
         export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
-    elif [[ "$SHARD_INDEX" = 14 ]]; then
+    elif [[ $SHARD_INDEX = 14 ]]; then
         export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
-    elif [[ "$SHARD_INDEX" = 15 ]]; then
+    elif [[ $SHARD_INDEX = 15 ]]; then
         export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
-    elif [[ "$SHARD_INDEX" = 16 ]]; then
+    elif [[ $SHARD_INDEX = 16 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
-    elif [[ "$SHARD_INDEX" = 17 ]]; then
+    elif [[ $SHARD_INDEX = 17 ]]; then
         export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
-    elif [[ "$SHARD_INDEX" = 18 ]]; then
+    elif [[ $SHARD_INDEX = 18 ]]; then
         export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
-    elif [[ "$SHARD_INDEX" = 19 ]]; then
+    elif [[ $SHARD_INDEX = 19 ]]; then
         export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
-    elif [[ "$SHARD_INDEX" = 20 ]]; then
+    elif [[ $SHARD_INDEX = 20 ]]; then
         export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
     else
         printf "Invalid <Shard Index> argument: $SHARD_INDEX\n"
         exit
     fi
-    if [[ "$SHARD_INDEX" -gt 0 ]]; then
+    if [[ $SHARD_INDEX -gt 0 ]]; then
         # Create a genesis_params.json
         export GENESIS_CONFIGS_DIR="genesis-configs/shard_$SHARD_INDEX"
         mkdir -p "./$GENESIS_CONFIGS_DIR"
@@ -142,11 +155,12 @@ printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
 printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
 printf "KEYSTORE_DIR=$KEYSTORE_DIR\n"
 
-if [[ "$NODE_INDEX" -lt 0 ]] || [[ "$NODE_INDEX" -gt 6 ]]; then
-    printf "Invalid <Node Index> argument: $NODE_INDEX\n"
-    exit
+if [[ $SEASON = "staging" ]]; then
+  # for performance test pipeline
+  export ENABLE_EXPRESS_RATE_LIMIT=false
+else
+  export ENABLE_EXPRESS_RATE_LIMIT=true
 fi
-
 if [[ $FULL_SYNC_OPTION = "" ]]; then
   export SYNC_MODE=fast
 else
@@ -238,13 +252,13 @@ if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$SHARD_INDEX" -gt 0 ]]; then
     printf "ACCOUNT_INDEX=$ACCOUNT_INDEX\n"
     COMMAND_PREFIX=""
 elif [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
-    if [[ "$NODE_INDEX" = 0 ]]; then
+    if [[ $NODE_INDEX = 0 ]]; then
         KEYSTORE_FILENAME="keystore_node_0.json"
-    elif [[ "$NODE_INDEX" = 1 ]]; then
+    elif [[ $NODE_INDEX = 1 ]]; then
         KEYSTORE_FILENAME="keystore_node_1.json"
-    elif [[ "$NODE_INDEX" = 2 ]]; then
+    elif [[ $NODE_INDEX = 2 ]]; then
         KEYSTORE_FILENAME="keystore_node_2.json"
-    elif [[ "$NODE_INDEX" = 3 ]]; then
+    elif [[ $NODE_INDEX = 3 ]]; then
         KEYSTORE_FILENAME="keystore_node_3.json"
     else
         KEYSTORE_FILENAME="keystore_node_4.json"

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -6,91 +6,6 @@ if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
     exit
 fi
 
-# 1. Configure env vars (GENESIS_CONFIGS_DIR, TRACKER_WS_ADDR, ...)
-printf "\n#### [Step 1] Configure env vars ####\n\n"
-
-export GENESIS_CONFIGS_DIR=genesis-configs/testnet
-KEYSTORE_DIR=testnet_dev_staging_keys
-if [[ "$1" = 'spring' ]]; then
-    export TRACKER_WS_ADDR=ws://35.221.137.80:5000
-    KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$1" = 'summer' ]]; then
-    export TRACKER_WS_ADDR=ws://35.194.172.106:5000
-    KEYSTORE_DIR=testnet_prod_keys
-elif [[ "$1" = 'staging' ]]; then
-    export TRACKER_WS_ADDR=ws://35.221.150.73:5000
-elif [[ "$1" = 'dev' ]]; then
-    if [[ "$2" = 0 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
-    elif [[ "$2" = 1 ]]; then
-        export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
-    elif [[ "$2" = 2 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
-    elif [[ "$2" = 3 ]]; then
-        export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
-    elif [[ "$2" = 4 ]]; then
-        export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
-    elif [[ "$2" = 5 ]]; then
-        export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
-    elif [[ "$2" = 6 ]]; then
-        export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
-    elif [[ "$2" = 7 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
-    elif [[ "$2" = 8 ]]; then
-        export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
-    elif [[ "$2" = 9 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
-    elif [[ "$2" = 10 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
-    elif [[ "$2" = 11 ]]; then
-        export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
-    elif [[ "$2" = 12 ]]; then
-        export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
-    elif [[ "$2" = 13 ]]; then
-        export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
-    elif [[ "$2" = 14 ]]; then
-        export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
-    elif [[ "$2" = 15 ]]; then
-        export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
-    elif [[ "$2" = 16 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
-    elif [[ "$2" = 17 ]]; then
-        export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
-    elif [[ "$2" = 18 ]]; then
-        export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
-    elif [[ "$2" = 19 ]]; then
-        export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
-    elif [[ "$2" = 20 ]]; then
-        export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
-    else
-        printf "Invalid <Shard Index> argument: $2\n"
-        exit
-    fi
-    if [[ "$2" -gt 0 ]]; then
-        # Create a genesis_params.json
-        export GENESIS_CONFIGS_DIR="genesis-configs/shard_$2"
-        mkdir -p "./$GENESIS_CONFIGS_DIR"
-        node > "./$GENESIS_CONFIGS_DIR/genesis_params.json" <<EOF
-        const data = require('./genesis-configs/testnet/genesis_params.json');
-        data.blockchain.TRACKER_WS_ADDR = '$TRACKER_WS_ADDR';
-        data.consensus.MIN_NUM_VALIDATORS = 3;
-        console.log(JSON.stringify(data, null, 2));
-EOF
-    fi
-else
-    printf "Invalid <Project/Season> argument: $1\n"
-    exit
-fi
-
-printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
-printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
-printf "KEYSTORE_DIR=$KEYSTORE_DIR\n"
-
-if [[ "$3" -lt 0 ]] || [[ "$3" -gt 6 ]]; then
-    printf "Invalid <Node Index> argument: $3\n"
-    exit
-fi
-
 function parse_options() {
     local option="$1"
     if [[ $option = '--keep-code' ]]; then
@@ -120,6 +35,10 @@ function parse_options() {
 }
 
 # Parse options.
+SEASON="$1"
+SHARD_INDEX="$2"
+NODE_INDEX="$3"
+
 KEEP_CODE_OPTION=""
 FULL_SYNC_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
@@ -133,11 +52,100 @@ do
   ((ARG_INDEX++))
 done
 
+printf "SEASON=$SEASON\n"
+printf "SHARD_INDEX=$SHARD_INDEX\n"
+printf "NODE_INDEX=$NODE_INDEX\n"
+
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
 printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
+
+# 1. Configure env vars (GENESIS_CONFIGS_DIR, TRACKER_WS_ADDR, ...)
+printf "\n#### [Step 1] Configure env vars ####\n\n"
+
+export GENESIS_CONFIGS_DIR=genesis-configs/testnet
+KEYSTORE_DIR=testnet_dev_staging_keys
+if [[ "$SEASON" = 'spring' ]]; then
+    export TRACKER_WS_ADDR=ws://35.221.137.80:5000
+    KEYSTORE_DIR=testnet_prod_keys
+elif [[ "$SEASON" = 'summer' ]]; then
+    export TRACKER_WS_ADDR=ws://35.194.172.106:5000
+    KEYSTORE_DIR=testnet_prod_keys
+elif [[ "$SEASON" = 'staging' ]]; then
+    export TRACKER_WS_ADDR=ws://35.221.150.73:5000
+elif [[ "$SEASON" = 'dev' ]]; then
+    if [[ "$SHARD_INDEX" = 0 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.184.73:5000  # dev-tracker-ip
+    elif [[ "$SHARD_INDEX" = 1 ]]; then
+        export TRACKER_WS_ADDR=ws://35.187.153.22:5000  # dev-shard-1-tracker-ip
+    elif [[ "$SHARD_INDEX" = 2 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.203.104:5000  # dev-shard-2-tracker-ip
+    elif [[ "$SHARD_INDEX" = 3 ]]; then
+        export TRACKER_WS_ADDR=ws://35.189.174.17:5000  # dev-shard-3-tracker-ip
+    elif [[ "$SHARD_INDEX" = 4 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.164.158:5000  # dev-shard-4-tracker-ip
+    elif [[ "$SHARD_INDEX" = 5 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.46.65:5000  # dev-shard-5-tracker-ip
+    elif [[ "$SHARD_INDEX" = 6 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.210.171:5000  # dev-shard-6-tracker-ip
+    elif [[ "$SHARD_INDEX" = 7 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.222.121:5000  # dev-shard-7-tracker-ip
+    elif [[ "$SHARD_INDEX" = 8 ]]; then
+        export TRACKER_WS_ADDR=ws://35.221.200.95:5000  # dev-shard-8-tracker-ip
+    elif [[ "$SHARD_INDEX" = 9 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.216.199:5000  # dev-shard-9-tracker-ip
+    elif [[ "$SHARD_INDEX" = 10 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.161.85:5000  # dev-shard-10-tracker-ip
+    elif [[ "$SHARD_INDEX" = 11 ]]; then
+        export TRACKER_WS_ADDR=ws://35.194.239.169:5000  # dev-shard-11-tracker-ip
+    elif [[ "$SHARD_INDEX" = 12 ]]; then
+        export TRACKER_WS_ADDR=ws://35.185.156.22:5000  # dev-shard-12-tracker-ip
+    elif [[ "$SHARD_INDEX" = 13 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.247.143:5000  # dev-shard-13-tracker-ip
+    elif [[ "$SHARD_INDEX" = 14 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.226.47:5000  # dev-shard-14-tracker-ip
+    elif [[ "$SHARD_INDEX" = 15 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.61.23:5000  # dev-shard-15-tracker-ip
+    elif [[ "$SHARD_INDEX" = 16 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.66.41:5000  # dev-shard-16-tracker-ip
+    elif [[ "$SHARD_INDEX" = 17 ]]; then
+        export TRACKER_WS_ADDR=ws://35.229.143.18:5000  # dev-shard-17-tracker-ip
+    elif [[ "$SHARD_INDEX" = 18 ]]; then
+        export TRACKER_WS_ADDR=ws://35.234.58.137:5000  # dev-shard-18-tracker-ip
+    elif [[ "$SHARD_INDEX" = 19 ]]; then
+        export TRACKER_WS_ADDR=ws://34.80.249.104:5000  # dev-shard-19-tracker-ip
+    elif [[ "$SHARD_INDEX" = 20 ]]; then
+        export TRACKER_WS_ADDR=ws://35.201.248.92:5000  # dev-shard-20-tracker-ip
+    else
+        printf "Invalid <Shard Index> argument: $SHARD_INDEX\n"
+        exit
+    fi
+    if [[ "$SHARD_INDEX" -gt 0 ]]; then
+        # Create a genesis_params.json
+        export GENESIS_CONFIGS_DIR="genesis-configs/shard_$SHARD_INDEX"
+        mkdir -p "./$GENESIS_CONFIGS_DIR"
+        node > "./$GENESIS_CONFIGS_DIR/genesis_params.json" <<EOF
+        const data = require('./genesis-configs/testnet/genesis_params.json');
+        data.blockchain.TRACKER_WS_ADDR = '$TRACKER_WS_ADDR';
+        data.consensus.MIN_NUM_VALIDATORS = 3;
+        console.log(JSON.stringify(data, null, 2));
+EOF
+    fi
+else
+    printf "Invalid <Project/Season> argument: $SEASON\n"
+    exit
+fi
+
+printf "TRACKER_WS_ADDR=$TRACKER_WS_ADDR\n"
+printf "GENESIS_CONFIGS_DIR=$GENESIS_CONFIGS_DIR\n"
+printf "KEYSTORE_DIR=$KEYSTORE_DIR\n"
+
+if [[ "$NODE_INDEX" -lt 0 ]] || [[ "$NODE_INDEX" -gt 6 ]]; then
+    printf "Invalid <Node Index> argument: $NODE_INDEX\n"
+    exit
+fi
 
 if [[ $FULL_SYNC_OPTION = "" ]]; then
   export SYNC_MODE=fast
@@ -225,18 +233,18 @@ fi
 printf "\n#### [Step 6] Start new node server ####\n\n"
 
 # NOTE(liayoo): Currently this script supports [--keystore|--mnemonic] option only for the parent chain.
-if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$2" -gt 0 ]]; then
-    export ACCOUNT_INDEX="$3"
+if [[ $ACCOUNT_INJECTION_OPTION = "" ]] || [[ "$SHARD_INDEX" -gt 0 ]]; then
+    export ACCOUNT_INDEX="$NODE_INDEX"
     printf "ACCOUNT_INDEX=$ACCOUNT_INDEX\n"
     COMMAND_PREFIX=""
 elif [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
-    if [[ "$3" = 0 ]]; then
+    if [[ "$NODE_INDEX" = 0 ]]; then
         KEYSTORE_FILENAME="keystore_node_0.json"
-    elif [[ "$3" = 1 ]]; then
+    elif [[ "$NODE_INDEX" = 1 ]]; then
         KEYSTORE_FILENAME="keystore_node_1.json"
-    elif [[ "$3" = 2 ]]; then
+    elif [[ "$NODE_INDEX" = 2 ]]; then
         KEYSTORE_FILENAME="keystore_node_2.json"
-    elif [[ "$3" = 3 ]]; then
+    elif [[ "$NODE_INDEX" = 3 ]]; then
         KEYSTORE_FILENAME="keystore_node_3.json"
     else
         KEYSTORE_FILENAME="keystore_node_4.json"
@@ -261,4 +269,4 @@ eval $START_CMD
 
 # NOTE(platfowner): deploy_blockchain_incremental_gcp.sh waits until the new server gets healthy.
 
-printf "\n* << Node server [$1 $2 $3] successfully deployed! ***************************************\n\n"
+printf "\n* << Node server [$SEASON $SHARD_INDEX $NODE_INDEX] successfully deployed! ***************************************\n\n"

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -3,8 +3,10 @@
 if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
     printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|spring|summer] <Shard Index> <Node Index> [--keep-code] [--full-sync] [--keystore|--mnemonic] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_incremental_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
 
 function parse_options() {
     local option="$1"
@@ -213,9 +215,9 @@ if [[ $KEEP_CODE_OPTION = "" ]]; then
     sudo chmod -R 777 $BLOCKCHAIN_DATA_DIR
 
     printf '\n'
-    printf 'Installing modules..\n'
+    printf 'Installing node modules..\n'
     cd $NEW_DIR_PATH
-    npm install
+    yarn install
 else
     printf '\n'
     printf 'Using old working directory..\n'

--- a/start_servers_afan_local.sh
+++ b/start_servers_afan_local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+printf "\n[[[[[ start_servers_afan_local.sh ]]]]]\n\n"
+
 # PARENT CHAIN
 CONSOLE_LOG=true BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5

--- a/start_servers_local.sh
+++ b/start_servers_local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+printf "\n[[[[[ start_servers_local.sh ]]]]]\n\n"
+
 # PARENT CHAIN
 BLOCKCHAIN_DATA_DIR=~/ain_blockchain_data node ./tracker-server/index.js &
 sleep 5

--- a/start_tracker_genesis_gcp.sh
+++ b/start_tracker_genesis_gcp.sh
@@ -3,8 +3,10 @@
 if [[ $# -gt 1 ]]; then
     printf "Usage: bash start_tracker_genesis_gcp.sh [--keep-code]\n"
     printf "Example: bash start_tracker_genesis_gcp.sh --keep-code\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ start_tracker_genesis_gcp.sh ]]]]]\n\n"
 
 KEEP_CODE_OPTION=""
 
@@ -39,7 +41,7 @@ if [[ $KEEP_CODE_OPTION = "" ]]; then
 
     printf '\n'
     printf 'Installing node modules..\n'
-    npm install
+    yarn install
 else
     printf '\n'
     printf 'Using old directory..\n'

--- a/start_tracker_incremental_gcp.sh
+++ b/start_tracker_incremental_gcp.sh
@@ -3,8 +3,10 @@
 if [[ "$#" -lt 1 ]] || [[ "$#" -gt 2 ]]; then
     printf "Usage: bash start_tracker_incremental_gcp.sh <Number of Nodes> [--keep-code]\n"
     printf "Example: bash start_tracker_incremental_gcp.sh 5 --keep-code\n"
+    printf "\n"
     exit
 fi
+printf "\n[[[[[ start_tracker_incremental_gcp.sh ]]]]]\n\n"
 
 # 1. Configure env vars
 printf "\n#### [Step 1] Configure env vars ####\n\n"
@@ -48,9 +50,9 @@ if [[ $KEEP_CODE_OPTION = "" ]]; then
     mv * $NEW_DIR_PATH
 
     printf '\n'
-    printf 'Installing modules..\n'
+    printf 'Installing node modules..\n'
     cd $NEW_DIR_PATH
-    npm install
+    yarn install
 else
     printf '\n'
     printf 'Using old working directory..\n'

--- a/stop_servers_local.sh
+++ b/stop_servers_local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+printf "\n[[[[[ stop_servers_local.sh ]]]]]\n\n"
+
 killall -9 node # SIGKILL
 rm -rf ~/ain_blockchain_data/
 BASEDIR=$(dirname "$0")

--- a/wait_until_node_sync_gcp.sh
+++ b/wait_until_node_sync_gcp.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+printf "\n[[[[[ wait_until_node_sync_gcp.sh ]]]]]\n\n"
+
 printf "\n#### Wait until the new node server catches up ####\n\n"
 
 SECONDS=0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,17 @@
 # yarn lockfile v1
 
 
-"@ainblockchain/ain-util@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-util/-/ain-util-1.1.6.tgz#f8dc8506e5f4560ab4f81bd0664e3b6606ba70b4"
-  integrity sha512-1QbPfHGE5PV/AmWPZ5VD2gW5t2bagFCn1xZPpVnpfPiNCc45RnNS0D6scRzMwBsTo1kJpNciJXIyUpCabaEplA==
+"@ainblockchain/ain-util@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@ainblockchain/ain-util/-/ain-util-1.1.8.tgz#f8d693490121f0eff70e9ca75b8ee1187582c605"
+  integrity sha512-yh4/+DHAUa/qM9mTMQzRc2j4zcgx+7TUG+UIaormKlpyYhKQblbWtuiiCWpH1Ib87lzx1A3s/Xtp5FPgZgJbfw==
   dependencies:
+    bip39 "^3.0.4"
     bn.js "^4.11.8"
     browserify-cipher "^1.0.1"
-    eccrypto "^1.1.5"
+    eccrypto "^1.1.6"
     fast-json-stable-stringify "^2.0.0"
+    hdkey "^2.0.1"
     keccak "^2.0.0"
     pbkdf2 "^3.0.17"
     randombytes "^2.1.0"
@@ -728,7 +730,7 @@ bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@^4.11.1, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.4.0:
+bn.js@^4.11.1, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
@@ -764,7 +766,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1, brorand@^1.1.0:
+brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -1578,13 +1580,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-eccrypto@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/eccrypto/-/eccrypto-1.1.5.tgz#8e97a82009bd4a37a8ebf919e47590edc1e121b3"
-  integrity sha512-iGu2lqaSFEX7jmYQayOzSIB52PdXguUeR17V7ilfmd5nVdt683HvYB0DwuGK1Y3srNp/zl6D05JfEdFY+SC5MQ==
+eccrypto@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/eccrypto/-/eccrypto-1.1.6.tgz#846bd1222323036f7a3515613704386399702bd3"
+  integrity sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==
   dependencies:
     acorn "7.1.1"
-    elliptic "6.5.3"
+    elliptic "6.5.4"
     es6-promise "4.2.8"
     nan "2.14.0"
   optionalDependencies:
@@ -1609,20 +1611,7 @@ ejs@^3.1.6:
   dependencies:
     jake "^10.6.1"
 
-elliptic@6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
-
-elliptic@^6.4.1, elliptic@^6.5.2:
+elliptic@6.5.4, elliptic@^6.4.1, elliptic@^6.5.2:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -2100,6 +2089,11 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+express-rate-limit@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-5.5.1.tgz#110c23f6a65dfa96ab468eda95e71697bc6987a2"
+  integrity sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==
 
 express@^4.17.1:
   version "4.17.1"
@@ -2829,7 +2823,7 @@ hex2dec@^1.0.1:
   resolved "https://registry.yarnpkg.com/hex2dec/-/hex2dec-1.1.2.tgz#8e1ce4bef36a74f7d5723c3fb3090c2860077338"
   integrity sha512-Yu+q/XWr2fFQ11tHxPq4p4EiNkb2y+lAacJNhAdRXVfRIcDH6gi7htWFnnlIzvqHMHoWeIsfXlNAjZInpAOJDA==
 
-hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
+hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -3677,7 +3671,7 @@ minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=


### PR DESCRIPTION
Change summary:
- Add express rate limit config for ddos protection with ENABLE_EXPRESS_RATE_LIMIT flag
- Turn off ENABLE_EXPRESS_RATE_LIMIT flag in staging for performance test pipeline
- Use 'yarn' instead of 'npm' on gcp
- Tweak deployment scripts 

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/690 