### PR TITLE
[bugfix] Set P2P_PEER_CANDIDATE_URL when deploying gcp

### DIFF
--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -241,6 +241,7 @@ export BLOCKCHAIN_DATA_DIR="/home/ain_blockchain_data"
 # NOTE(liayoo): This is a temporary setting. Remove once domain is set up for afan metaverse related services.
 export CORS_WHITELIST=*
 printf "CORS_WHITELIST=$CORS_WHITELIST\n"
+export P2P_PEER_CANDIDATE_URL="https://$SEASON-api.ainetwork.ai/json-rpc"
 
 MAX_OLD_SPACE_SIZE_MB=11000
 


### PR DESCRIPTION
Specify P2P_PEER_CANDIDATE_URL for deploying an individual gcp cluster.