### PR TITLE
fix unittest for tx pool

### DIFF
--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -626,7 +626,7 @@ describe('TransactionPool', () => {
       const receipts = txsToDummyReceipts(transactions);
       const block = Block.create(
           lastBlock.hash, [], {}, transactions, receipts, number, lastBlock.epoch + 1, '',
-          node.account.address, [], 0, 0);
+          node.account.address, {}, 0, 0);
       const newTransactions = {};
       newTransactions[node.account.address] = [];
       let initialNonce = node.getNonce() + 1;
@@ -642,6 +642,7 @@ describe('TransactionPool', () => {
         }));
         node.tp.addTransaction(newTransactions[node.account.address][i]);
       }
+      console.log(node.tp.transactions[node.account.address]);
       node.tp.cleanUpForNewBlock(block);
       assert.deepEqual(newTransactions, node.tp.transactions);
     });

--- a/unittest/tx-pool.test.js
+++ b/unittest/tx-pool.test.js
@@ -12,7 +12,7 @@ const {
   TransactionStates,
 } = require('../common/constants');
 
-describe('TransactionPool', async () => {
+describe('TransactionPool', () => {
   let node, transaction;
 
   beforeEach(async () => {
@@ -32,10 +32,10 @@ describe('TransactionPool', async () => {
   });
 
   describe('Transaction addition', () => {
-    let initialNonce = node.getNonce();
     let txToAdd;
 
     beforeEach(async () => {
+      let initialNonce = node.getNonce();
       txToAdd = getTransaction(node, {
         operation: {
           type: 'SET_VALUE',
@@ -149,7 +149,7 @@ describe('TransactionPool', async () => {
         }).map((tx) => {
           return tx.tx_body.nonce;
         });
-        assert.deepEqual(sortedNonces1, [...Array(11).keys()]);
+        assert.deepEqual(sortedNonces1, [...Array(10).keys()]);
         assert.deepEqual(sortedNonces2, [...Array(11).keys()]);
         assert.deepEqual(sortedNonces3, [...Array(11).keys()]);
         assert.deepEqual(sortedNonces4, [...Array(11).keys()]);
@@ -621,15 +621,15 @@ describe('TransactionPool', async () => {
   describe('Transaction pool clean-up', () => {
     it('cleanUpForNewBlock()', () => {
       const number = 1;
-      const lastBlock = node1.bc.genesisBlock;
-      const transactions = node1.tp.getValidTransactions();
+      const lastBlock = node.bc.genesisBlock;
+      const transactions = node.tp.getValidTransactions();
       const receipts = txsToDummyReceipts(transactions);
       const block = Block.create(
-          lastBlock.hash, [], transactions, receipts, number, lastBlock.epoch + 1, '',
-          node.account.address, []);
+          lastBlock.hash, [], {}, transactions, receipts, number, lastBlock.epoch + 1, '',
+          node.account.address, [], 0, 0);
       const newTransactions = {};
       newTransactions[node.account.address] = [];
-      let initialNonce = node.getNonce();
+      let initialNonce = node.getNonce() + 1;
       for (let i = 0; i < 10; i++) {
         newTransactions[node.account.address].push(getTransaction(node, {
           operation: {


### PR DESCRIPTION
FIX unit test for TX pool (#696)
* remove `async` from `describe`
* `node` has only 10 txs, but test wants 11 txs
  * see https://github.com/ainblockchain/ain-blockchain/blob/master/unittest/tx-pool.test.js#L73
* `node1` -> `node`
* `Block.create()` arguments mismatched
* `initialNonce` should be started from `node.getNonce() + 1`

Related issues: 
- https://github.com/ainblockchain/ain-blockchain/issues/696