### PR TITLE
Test for multiple node and os

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -14,15 +14,19 @@ on:
     types: [opened, synchronize, reopened, closed]
 jobs:
   build_and_test:
-    if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited') }}
-    runs-on: macos-latest
+    if: ${{ github.event_name == 'pull_request' }} # && (github.event.action == 'opened' || github.event.action == 'edited') }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [ '12.x', '14.x', '16.x' ]
+    runs-on: ${{ matrix.os }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       # Setup node environment for testing
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - name: yarn install
         run: yarn install

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -14,7 +14,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 jobs:
   build_and_test:
-    if: ${{ github.event_name == 'pull_request' }} # && (github.event.action == 'opened' || github.event.action == 'edited') }}
+    if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-            node-version: '12.x'
+            node-version: '16.x'
             registry-url: 'https://registry.npmjs.org'
       - name: setup key
         env:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 ### [AI Network](https://ainetwork.ai) | [Whitepaper](https://c9ede755-23ca-410d-8a9d-e5b895cd95bb.filesusr.com/ugd/4f6eb2_482a2386addb4c3283ee6e26f8ad42e6.pdf) | [Documentation](https://docs.ainetwork.ai/)
 Official Javascript implementation of AI Network Blockchain.
 
+## Install Environment (Last update at 6th of Dec 2021)
+### OS
+
+- macOS 10.15 (macos-latest)
+- Ubuntu 20.04 (ubuntu-latest)
+
+### Node version
+
+- v16.x
+- v14.x
+- v12.x (will be deprecated)
+
 ## Tracker
 
 Tracker server is required by new peers who wish to join the AIN network. Each peer is sent the ipaddress of 2 other nodes in the network. These nodes then gossip information through the network of all transactions and blocks.
@@ -14,7 +26,6 @@ NOTE: Tracker Server must be started first before starting any blockchain node i
 #### Local
 
 - Clone this repository and install yarn packages
-- Highly recommend to use node version >= 12
 ```
 git clone https://github.com/ainblockchain/ain-blockchain.git
 cd ain-blockchain/tracker-server/
@@ -89,7 +100,6 @@ Operates a single peer node instance of the AIN blockchain. A single blockchain 
 #### Local
 
 - Clone this repository and install yarn packages
-- Highly recommend to use node version >= 12
 ```
 git clone https://github.com/ainblockchain/ain-blockchain.git
 cd ain-blockchain/
@@ -171,8 +181,6 @@ cat logger/logs/8080/<log_file>
 -->
 
 ### How to run tests
-
-Please check your node version before running the below tests. Tests has passed node version 12.*
 
 How to run unit test and integration test all around.
 ```


### PR DESCRIPTION
Test multiple OSs and Node versions.

<img width="839" alt="스크린샷 2021-12-06 오후 5 20 07" src="https://user-images.githubusercontent.com/56950836/144862480-9aec61f7-6c30-4ba0-9870-cf8958b1f894.png">

We've discussed to upgrade node versions and support latest OSs and we finally made it!

The blockchain client is now running under node v12, v14 and v16. It also be run on macos-latest and ubuntu-latest.

Support:
- OS: macos-latest, ubuntu-latest
- Node-version: 12, 14, 16