### PR TITLE
Do not call winstonLogger.debug() if DEBUG=false.

### DIFF
--- a/logger/index.js
+++ b/logger/index.js
@@ -1,6 +1,7 @@
 /* eslint new-cap: "off" */
 const winston = require('winston');
 const { getWinstonLevels, getWinstonColors, getWinstonTransports } = require('./winston-util');
+const { NodeConfigs } = require('../common/constants');
 
 const winstonLogger = new winston.createLogger({
   levels: getWinstonLevels(),
@@ -30,7 +31,7 @@ class Logger {
   }
 
   debug(text) {
-    if (!isFinished) {
+    if (!isFinished && NodeConfigs.DEBUG) {
       winstonLogger.debug(`[${this.prefix}] ${text}`)
     }
   }


### PR DESCRIPTION
It seems the winston library has some issues with garbage collecting when a log function with a level lower than the current level is called. Fixed this by not calling winstonLogger.debug() if DEBUG env var is not true.

Without the changes:
<img width="676" alt="Screen Shot 2021-12-09 at 2 14 11 PM" src="https://user-images.githubusercontent.com/14267554/145526675-6e869fb1-5cb2-49ca-97cf-d56f2521021d.png">


With the changes:
<img width="673" alt="Screen Shot 2021-12-09 at 6 08 20 PM" src="https://user-images.githubusercontent.com/14267554/145526717-7a37460d-d0aa-4798-b7dc-63c91f35e391.png">



\+ It also seems that bunyan, on the other hand, doesn't have this issue. I'll conduct some quick research on it & share it in the next meeting. We can compare & discuss which library to use!

Related: https://github.com/ainblockchain/ain-blockchain/issues/745