### PR TITLE
Allow writing with subtree owners in partial set cases (with isPartialSet = true)

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -255,8 +255,8 @@ class CommonUtil {
     if (args.is_global !== undefined) {
       options.isGlobal = CommonUtil.toBool(args.is_global);
     }
-    if (args.is_partial_set !== undefined) {
-      options.isPartialSet = CommonUtil.toBool(args.is_partial_set);
+    if (args.is_merge !== undefined) {
+      options.isMerge = CommonUtil.toBool(args.is_merge);
     }
     return options;
   }

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -247,6 +247,9 @@ class CommonUtil {
     if (args.include_proof !== undefined) {
       options.includeProof = CommonUtil.toBool(args.include_proof);
     }
+    if (args.is_partial_set !== undefined) {
+      options.isPartialSet = CommonUtil.toBool(args.is_partial_set);
+    }
     return options;
   }
 

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -247,9 +247,6 @@ class CommonUtil {
     if (args.include_proof !== undefined) {
       options.includeProof = CommonUtil.toBool(args.include_proof);
     }
-    if (args.is_partial_set !== undefined) {
-      options.isPartialSet = CommonUtil.toBool(args.is_partial_set);
-    }
     return options;
   }
 
@@ -257,6 +254,9 @@ class CommonUtil {
     const options = {};
     if (args.is_global !== undefined) {
       options.isGlobal = CommonUtil.toBool(args.is_global);
+    }
+    if (args.is_partial_set !== undefined) {
+      options.isPartialSet = CommonUtil.toBool(args.is_partial_set);
     }
     return options;
   }

--- a/db/index.js
+++ b/db/index.js
@@ -1795,8 +1795,8 @@ class DB {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_RULE,
-        error_message: `Non-empty (${matched.subtreeOwners.length}) subtree owners ` +
-            `for rule path '${CommonUtil.formatPath(parsedRulePath)}': ` +
+        error_message: `Non-empty (${matched.subtreeOwners.length}) ` +
+            `subtree owners for rule path '${CommonUtil.formatPath(parsedRulePath)}': ` +
             `${JSON.stringify(subtreeOwnerPathList)}`,
         matched,
       };
@@ -1827,8 +1827,8 @@ class DB {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_FUNCTION,
-        error_message: `Non-empty (${matched.subtreeOwners.length}) subtree owners ` +
-            `for function path '${CommonUtil.formatPath(parsedFuncPath)}': ` +
+        error_message: `Non-empty (${matched.subtreeOwners.length}) ` +
+            `subtree owners for function path '${CommonUtil.formatPath(parsedFuncPath)}': ` +
             `${JSON.stringify(subtreeOwnerPathList)}`,
         matched,
       };
@@ -1859,8 +1859,8 @@ class DB {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_OWNER,
-        error_message: `Non-empty (${matched.subtreeOwners.length}) subtree owners ` +
-            `for owner path '${CommonUtil.formatPath(parsedOwnerPath)}': ` +
+        error_message: `Non-empty (${matched.subtreeOwners.length}) ` +
+            `subtree owners for owner path '${CommonUtil.formatPath(parsedOwnerPath)}': ` +
             `${JSON.stringify(subtreeOwnerPathList)}`,
         matched,
       };

--- a/db/index.js
+++ b/db/index.js
@@ -626,12 +626,12 @@ class DB {
       return null;
     }
     if (permission === OwnerProperties.WRITE_RULE) {
-      return this.getPermissionForRule(localPath, auth, options.isPartialSet);
+      return this.getPermissionForRule(localPath, auth, options && options.isPartialSet);
     } else if (permission === OwnerProperties.WRITE_FUNCTION) {
-      return this.getPermissionForFunction(localPath, auth, options.isPartialSet);
+      return this.getPermissionForFunction(localPath, auth, options && options.isPartialSet);
     } else if (permission === OwnerProperties.WRITE_OWNER ||
         permission === OwnerProperties.BRANCH_OWNER) {
-      return this.getPermissionForOwner(localPath, auth, options.isPartialSet);
+      return this.getPermissionForOwner(localPath, auth, options && options.isPartialSet);
     } else {
       return {
         code: TxResultCode.EVAL_OWNER_INVALID_PERMISSION,

--- a/db/index.js
+++ b/db/index.js
@@ -925,9 +925,9 @@ class DB {
           unitWriteGasLimit);
     }
     const curFunction = this.getFunction(functionPath, { isShallow: false, isGlobal });
-    const newFunction = applyFunctionChange(curFunction, func);
+    const applyRes = applyFunctionChange(curFunction, func);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.FUNCTIONS_ROOT);
-    this.writeDatabase(fullPath, newFunction);
+    this.writeDatabase(fullPath, applyRes.funcConfig);
     return CommonUtil.returnTxResult(
         TxResultCode.SUCCESS,
         null,
@@ -981,9 +981,9 @@ class DB {
           unitWriteGasLimit);
     }
     const curRule = this.getRule(rulePath, { isShallow: false, isGlobal });
-    const newRule = applyRuleChange(curRule, rule);
+    const applyRes = applyRuleChange(curRule, rule);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.RULES_ROOT);
-    this.writeDatabase(fullPath, newRule);
+    this.writeDatabase(fullPath, applyRes.ruleConfig);
     return CommonUtil.returnTxResult(
         TxResultCode.SUCCESS,
         null,
@@ -1035,9 +1035,9 @@ class DB {
           unitWriteGasLimit);
     }
     const curOwner = this.getOwner(ownerPath, { isShallow: false, isGlobal });
-    const newOwner = applyOwnerChange(curOwner, owner);
+    const applyRes = applyOwnerChange(curOwner, owner);
     const fullPath = DB.getFullPath(localPath, PredefinedDbPaths.OWNERS_ROOT);
-    this.writeDatabase(fullPath, newOwner);
+    this.writeDatabase(fullPath, applyRes.ownerConfig);
     return CommonUtil.returnTxResult(
         TxResultCode.SUCCESS,
         null,

--- a/db/index.js
+++ b/db/index.js
@@ -617,6 +617,7 @@ class DB {
     return this.getPermissionForValue(localPath, value, auth, timestamp);
   }
 
+  // TODO(platfowner): Consider allowing the callers to specify target config.
   evalOwner(refPath, permission, auth, options) {
     const isGlobal = options && options.isGlobal;
     const parsedPath = CommonUtil.parsePath(refPath);

--- a/db/index.js
+++ b/db/index.js
@@ -1784,7 +1784,6 @@ class DB {
     }
     return {
       code: TxResultCode.SUCCESS,
-      error_message: '',
       matched,
     };
   }
@@ -1816,7 +1815,6 @@ class DB {
     }
     return {
       code: TxResultCode.SUCCESS,
-      error_message: '',
       matched,
     };
   }
@@ -1848,7 +1846,6 @@ class DB {
     }
     return {
       code: TxResultCode.SUCCESS,
-      error_message: '',
       matched,
     };
   }
@@ -1881,7 +1878,6 @@ class DB {
     }
     return {
       code: TxResultCode.SUCCESS,
-      error_message: '',
       matched,
     };
   }

--- a/db/index.js
+++ b/db/index.js
@@ -627,12 +627,12 @@ class DB {
       return null;
     }
     if (permission === OwnerProperties.WRITE_RULE) {
-      return this.getPermissionForRule(localPath, auth, options && options.isPartialSet);
+      return this.getPermissionForRule(localPath, auth, options && options.isMerge);
     } else if (permission === OwnerProperties.WRITE_FUNCTION) {
-      return this.getPermissionForFunction(localPath, auth, options && options.isPartialSet);
+      return this.getPermissionForFunction(localPath, auth, options && options.isMerge);
     } else if (permission === OwnerProperties.WRITE_OWNER ||
         permission === OwnerProperties.BRANCH_OWNER) {
-      return this.getPermissionForOwner(localPath, auth, options && options.isPartialSet);
+      return this.getPermissionForOwner(localPath, auth, options && options.isMerge);
     } else {
       return {
         code: TxResultCode.EVAL_OWNER_INVALID_PERMISSION,
@@ -920,7 +920,7 @@ class DB {
     }
     const curFunction = this.getFunction(functionPath, { isShallow: false, isGlobal });
     const applyRes = applyFunctionChange(curFunction, func);
-    const permCheckRes = this.getPermissionForFunction(localPath, auth, applyRes.isPartialSet);
+    const permCheckRes = this.getPermissionForFunction(localPath, auth, applyRes.isMerge);
     if (CommonUtil.isFailedTxResultCode(permCheckRes.code)) {
       return CommonUtil.returnTxResult(
           permCheckRes.code,
@@ -976,7 +976,7 @@ class DB {
     }
     const curRule = this.getRule(rulePath, { isShallow: false, isGlobal });
     const applyRes = applyRuleChange(curRule, rule);
-    const permCheckRes = this.getPermissionForRule(localPath, auth, applyRes.isPartialSet);
+    const permCheckRes = this.getPermissionForRule(localPath, auth, applyRes.isMerge);
     if (CommonUtil.isFailedTxResultCode(permCheckRes.code)) {
       return CommonUtil.returnTxResult(
           permCheckRes.code,
@@ -1030,7 +1030,7 @@ class DB {
     }
     const curOwner = this.getOwner(ownerPath, { isShallow: false, isGlobal });
     const applyRes = applyOwnerChange(curOwner, owner);
-    const permCheckRes = this.getPermissionForOwner(localPath, auth, applyRes.isPartialSet);
+    const permCheckRes = this.getPermissionForOwner(localPath, auth, applyRes.isMerge);
     if (CommonUtil.isFailedTxResultCode(permCheckRes.code)) {
       return CommonUtil.returnTxResult(
           permCheckRes.code,
@@ -1789,9 +1789,9 @@ class DB {
     };
   }
 
-  getPermissionForRule(parsedRulePath, auth, isPartialSet) {
+  getPermissionForRule(parsedRulePath, auth, isMerge) {
     const matched = this.matchOwnerForParsedPath(parsedRulePath);
-    if (!isPartialSet && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
+    if (!isMerge && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_RULE,
@@ -1820,9 +1820,9 @@ class DB {
     };
   }
 
-  getPermissionForFunction(parsedFuncPath, auth, isPartialSet) {
+  getPermissionForFunction(parsedFuncPath, auth, isMerge) {
     const matched = this.matchOwnerForParsedPath(parsedFuncPath);
-    if (!isPartialSet && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
+    if (!isMerge && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_FUNCTION,
@@ -1851,9 +1851,9 @@ class DB {
     };
   }
 
-  getPermissionForOwner(parsedOwnerPath, auth, isPartialSet) {
+  getPermissionForOwner(parsedOwnerPath, auth, isMerge) {
     const matched = this.matchOwnerForParsedPath(parsedOwnerPath);
-    if (!isPartialSet && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
+    if (!isMerge && matched.subtreeOwners && matched.subtreeOwners.length > 0) {
       const subtreeOwnerPathList = this.getSubtreeConfigPathList(matched.subtreeOwners);
       return {
         code: TxResultCode.EVAL_OWNER_NON_EMPTY_SUBTREE_OWNERS_FOR_OWNER,

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -608,6 +608,16 @@ function hasConfigLabelOnly(stateTreeObj, configLabel) {
 }
 
 /**
+ * Returns a config at the given path if available, otherwise null.
+ */
+function getConfigAtPath(stateTreeObj, configPath) {
+  if (!CommonUtil.isDict(stateTreeObj)) {
+    return null;
+  }
+  return CommonUtil.getJsObject(stateTreeObj, configPath);
+}
+
+/**
  * Returns a new rule tree created by applying the rule change to
  * the current rule tree.
  * 
@@ -619,22 +629,29 @@ function hasConfigLabelOnly(stateTreeObj, configLabel) {
 function applyRuleChange(curRuleTree, ruleChange) {
   if (!hasConfigLabel(curRuleTree, PredefinedDbPaths.DOT_RULE) ||
       !hasConfigLabelOnly(ruleChange, PredefinedDbPaths.DOT_RULE)) {
-    return CommonUtil.isDict(ruleChange) ?
+    const newRuleConfig = CommonUtil.isDict(ruleChange) ?
         JSON.parse(JSON.stringify(ruleChange)) : ruleChange;
+    return {
+      isPartialSet: false,
+      ruleConfig: newRuleConfig,
+    };
   }
-  const ruleChangeMap = CommonUtil.getJsObject(ruleChange, [PredefinedDbPaths.DOT_RULE]);
+  const ruleChangeMap = getConfigAtPath(ruleChange, [PredefinedDbPaths.DOT_RULE]);
   if (!ruleChangeMap || Object.keys(ruleChangeMap).length === 0) {
-    return curRuleTree;
+    return {
+      isPartialSet: true,
+      ruleConfig: curRuleTree,
+    };
   }
   const newRuleConfig = {}
   if (CommonUtil.isDict(curRuleTree) && curRuleTree[PredefinedDbPaths.DOT_RULE]) {
     CommonUtil.setJsObject(newRuleConfig, [PredefinedDbPaths.DOT_RULE], curRuleTree[PredefinedDbPaths.DOT_RULE]);
   }
-  let newRuleMap = CommonUtil.getJsObject(newRuleConfig, [PredefinedDbPaths.DOT_RULE]);
+  let newRuleMap = getConfigAtPath(newRuleConfig, [PredefinedDbPaths.DOT_RULE]);
   if (!CommonUtil.isDict(newRuleMap)) {
     // Add a place holder.
     CommonUtil.setJsObject(newRuleConfig, [PredefinedDbPaths.DOT_RULE], {});
-    newRuleMap = CommonUtil.getJsObject(newRuleConfig, [PredefinedDbPaths.DOT_RULE]);
+    newRuleMap = getConfigAtPath(newRuleConfig, [PredefinedDbPaths.DOT_RULE]);
   }
   for (const ruleKey in ruleChangeMap) {
     const ruleInfo = ruleChangeMap[ruleKey];
@@ -645,7 +662,10 @@ function applyRuleChange(curRuleTree, ruleChange) {
     }
   }
 
-  return newRuleConfig;
+  return {
+    isPartialSet: true,
+    ruleConfig: newRuleConfig,
+  };
 }
 
 /**
@@ -660,20 +680,27 @@ function applyRuleChange(curRuleTree, ruleChange) {
 function applyFunctionChange(curFuncTree, functionChange) {
   if (!hasConfigLabel(curFuncTree, PredefinedDbPaths.DOT_FUNCTION) ||
       !hasConfigLabelOnly(functionChange, PredefinedDbPaths.DOT_FUNCTION)) {
-    return CommonUtil.isDict(functionChange) ?
+    const newFuncConfig = CommonUtil.isDict(functionChange) ?
         JSON.parse(JSON.stringify(functionChange)) : functionChange;
+    return {
+      isPartialSet: false,
+      funcConfig: newFuncConfig,
+    };
   }
-  const funcChangeMap = CommonUtil.getJsObject(functionChange, [PredefinedDbPaths.DOT_FUNCTION]);
+  const funcChangeMap = getConfigAtPath(functionChange, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!funcChangeMap || Object.keys(funcChangeMap).length === 0) {
-    return curFuncTree;
+    return {
+      isPartialSet: true,
+      funcConfig: curFuncTree,
+    };
   }
   const newFuncConfig =
       CommonUtil.isDict(curFuncTree) ? JSON.parse(JSON.stringify(curFuncTree)) : {};
-  let newFuncMap = CommonUtil.getJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
+  let newFuncMap = getConfigAtPath(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!CommonUtil.isDict(newFuncMap)) {
     // Add a place holder.
     CommonUtil.setJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION], {});
-    newFuncMap = CommonUtil.getJsObject(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
+    newFuncMap = getConfigAtPath(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
   }
   for (const functionKey in funcChangeMap) {
     const functionInfo = funcChangeMap[functionKey];
@@ -684,7 +711,10 @@ function applyFunctionChange(curFuncTree, functionChange) {
     }
   }
 
-  return newFuncConfig;
+  return {
+    isPartialSet: true,
+    funcConfig: newFuncConfig,
+  };
 }
 
 /**
@@ -699,21 +729,28 @@ function applyFunctionChange(curFuncTree, functionChange) {
 function applyOwnerChange(curOwnerTree, ownerChange) {
   if (!hasConfigLabel(curOwnerTree, PredefinedDbPaths.DOT_OWNER) ||
       !hasConfigLabelOnly(ownerChange, PredefinedDbPaths.DOT_OWNER)) {
-    return CommonUtil.isDict(ownerChange) ?
+    const newOwnerConfig = CommonUtil.isDict(ownerChange) ?
         JSON.parse(JSON.stringify(ownerChange)) : ownerChange;
+    return {
+      isPartialSet: false,
+      ownerConfig: newOwnerConfig,
+    };
   }
   const ownerMapPath = [PredefinedDbPaths.DOT_OWNER, OwnerProperties.OWNERS];
-  const ownerChangeMap = CommonUtil.getJsObject(ownerChange, ownerMapPath);
+  const ownerChangeMap = getConfigAtPath(ownerChange, ownerMapPath);
   if (!ownerChangeMap || Object.keys(ownerChangeMap).length === 0) {
-    return curOwnerTree;
+    return {
+      isPartialSet: true,
+      ownerConfig: curOwnerTree,
+    };
   }
   const newOwnerConfig =
       CommonUtil.isDict(curOwnerTree) ? JSON.parse(JSON.stringify(curOwnerTree)) : {};
-  let newOwnerMap = CommonUtil.getJsObject(newOwnerConfig, ownerMapPath);
+  let newOwnerMap = getConfigAtPath(newOwnerConfig, ownerMapPath);
   if (!CommonUtil.isDict(newOwnerMap)) {
     // Add a place holder.
     CommonUtil.setJsObject(newOwnerConfig, ownerMapPath, {});
-    newOwnerMap = CommonUtil.getJsObject(newOwnerConfig, ownerMapPath);
+    newOwnerMap = getConfigAtPath(newOwnerConfig, ownerMapPath);
   }
   for (const ownerKey in ownerChangeMap) {
     const ownerPermissions = ownerChangeMap[ownerKey];
@@ -724,7 +761,10 @@ function applyOwnerChange(curOwnerTree, ownerChange) {
     }
   }
 
-  return newOwnerConfig;
+  return {
+    isPartialSet: true,
+    ownerConfig: newOwnerConfig,
+  };
 }
 
 /**

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -627,7 +627,7 @@ function getConfigAtPath(stateTreeObj, configPath) {
 // NOTE(platfowner): Config merge is applied only when the current rule tree has
 // .rule property and the rule change has .rule property as the only property.
 function applyRuleChange(curRuleTree, ruleChange) {
-  // 1. Config overwriting case:
+  // 1. Config overwriting case (isMerge = false):
   if (!hasConfigLabel(curRuleTree, PredefinedDbPaths.DOT_RULE) ||
       !hasConfigLabelOnly(ruleChange, PredefinedDbPaths.DOT_RULE)) {
     const newRuleConfig = CommonUtil.isDict(ruleChange) ?
@@ -637,7 +637,7 @@ function applyRuleChange(curRuleTree, ruleChange) {
       ruleConfig: newRuleConfig,
     };
   }
-  // 2. Config merge case:
+  // 2. Config no changes case (isMerge = true):
   const ruleChangeMap = getConfigAtPath(ruleChange, [PredefinedDbPaths.DOT_RULE]);
   if (!ruleChangeMap || Object.keys(ruleChangeMap).length === 0) {
     return {
@@ -645,6 +645,7 @@ function applyRuleChange(curRuleTree, ruleChange) {
       ruleConfig: curRuleTree,
     };
   }
+  // 3. Config merge case (isMerge = true):
   const newRuleConfig = {}
   if (CommonUtil.isDict(curRuleTree) && curRuleTree[PredefinedDbPaths.DOT_RULE]) {
     CommonUtil.setJsObject(newRuleConfig, [PredefinedDbPaths.DOT_RULE], curRuleTree[PredefinedDbPaths.DOT_RULE]);
@@ -680,7 +681,7 @@ function applyRuleChange(curRuleTree, ruleChange) {
 // NOTE(platfowner): Config merge is applied only when the current function tree has
 // .function property and the function change has .function property as the only property.
 function applyFunctionChange(curFuncTree, functionChange) {
-  // 1. Config overwriting case:
+  // 1. Config overwriting case (isMerge = false):
   if (!hasConfigLabel(curFuncTree, PredefinedDbPaths.DOT_FUNCTION) ||
       !hasConfigLabelOnly(functionChange, PredefinedDbPaths.DOT_FUNCTION)) {
     const newFuncConfig = CommonUtil.isDict(functionChange) ?
@@ -690,7 +691,7 @@ function applyFunctionChange(curFuncTree, functionChange) {
       funcConfig: newFuncConfig,
     };
   }
-  // 2. Config merge case:
+  // 2. Config no changes case (isMerge = true):
   const funcChangeMap = getConfigAtPath(functionChange, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!funcChangeMap || Object.keys(funcChangeMap).length === 0) {
     return {
@@ -698,6 +699,7 @@ function applyFunctionChange(curFuncTree, functionChange) {
       funcConfig: curFuncTree,
     };
   }
+  // 3. Config merge case (isMerge = true):
   const newFuncConfig =
       CommonUtil.isDict(curFuncTree) ? JSON.parse(JSON.stringify(curFuncTree)) : {};
   let newFuncMap = getConfigAtPath(newFuncConfig, [PredefinedDbPaths.DOT_FUNCTION]);
@@ -731,7 +733,7 @@ function applyFunctionChange(curFuncTree, functionChange) {
 // NOTE(platfowner): Config merge is applied only when the current owner tree has
 // .owner property and the owner change has .owner property as the only property.
 function applyOwnerChange(curOwnerTree, ownerChange) {
-  // 1. Config overwriting case:
+  // 1. Config overwriting case (isMerge = false):
   if (!hasConfigLabel(curOwnerTree, PredefinedDbPaths.DOT_OWNER) ||
       !hasConfigLabelOnly(ownerChange, PredefinedDbPaths.DOT_OWNER)) {
     const newOwnerConfig = CommonUtil.isDict(ownerChange) ?
@@ -741,7 +743,7 @@ function applyOwnerChange(curOwnerTree, ownerChange) {
       ownerConfig: newOwnerConfig,
     };
   }
-  // 2. Config merge case:
+  // 2. Config no changes case (isMerge = true):
   const ownerMapPath = [PredefinedDbPaths.DOT_OWNER, OwnerProperties.OWNERS];
   const ownerChangeMap = getConfigAtPath(ownerChange, ownerMapPath);
   if (!ownerChangeMap || Object.keys(ownerChangeMap).length === 0) {
@@ -750,6 +752,7 @@ function applyOwnerChange(curOwnerTree, ownerChange) {
       ownerConfig: curOwnerTree,
     };
   }
+  // 3. Config merge case (isMerge = true):
   const newOwnerConfig =
       CommonUtil.isDict(curOwnerTree) ? JSON.parse(JSON.stringify(curOwnerTree)) : {};
   let newOwnerMap = getConfigAtPath(newOwnerConfig, ownerMapPath);

--- a/db/state-util.js
+++ b/db/state-util.js
@@ -624,22 +624,24 @@ function getConfigAtPath(stateTreeObj, configPath) {
  * @param {Object} curRuleTree current rule tree (to be modified by this rule)
  * @param {Object} ruleChange rule change
  */
-// NOTE(platfowner): Partial set is applied only when the current rule tree has
+// NOTE(platfowner): Config merge is applied only when the current rule tree has
 // .rule property and the rule change has .rule property as the only property.
 function applyRuleChange(curRuleTree, ruleChange) {
+  // 1. Config overwriting case:
   if (!hasConfigLabel(curRuleTree, PredefinedDbPaths.DOT_RULE) ||
       !hasConfigLabelOnly(ruleChange, PredefinedDbPaths.DOT_RULE)) {
     const newRuleConfig = CommonUtil.isDict(ruleChange) ?
         JSON.parse(JSON.stringify(ruleChange)) : ruleChange;
     return {
-      isPartialSet: false,
+      isMerge: false,
       ruleConfig: newRuleConfig,
     };
   }
+  // 2. Config merge case:
   const ruleChangeMap = getConfigAtPath(ruleChange, [PredefinedDbPaths.DOT_RULE]);
   if (!ruleChangeMap || Object.keys(ruleChangeMap).length === 0) {
     return {
-      isPartialSet: true,
+      isMerge: true,
       ruleConfig: curRuleTree,
     };
   }
@@ -663,7 +665,7 @@ function applyRuleChange(curRuleTree, ruleChange) {
   }
 
   return {
-    isPartialSet: true,
+    isMerge: true,
     ruleConfig: newRuleConfig,
   };
 }
@@ -675,22 +677,24 @@ function applyRuleChange(curRuleTree, ruleChange) {
  * @param {Object} curFuncTree current function tree (to be modified by this function)
  * @param {Object} functionChange function change
  */
-// NOTE(platfowner): Partial set is applied only when the current function tree has
+// NOTE(platfowner): Config merge is applied only when the current function tree has
 // .function property and the function change has .function property as the only property.
 function applyFunctionChange(curFuncTree, functionChange) {
+  // 1. Config overwriting case:
   if (!hasConfigLabel(curFuncTree, PredefinedDbPaths.DOT_FUNCTION) ||
       !hasConfigLabelOnly(functionChange, PredefinedDbPaths.DOT_FUNCTION)) {
     const newFuncConfig = CommonUtil.isDict(functionChange) ?
         JSON.parse(JSON.stringify(functionChange)) : functionChange;
     return {
-      isPartialSet: false,
+      isMerge: false,
       funcConfig: newFuncConfig,
     };
   }
+  // 2. Config merge case:
   const funcChangeMap = getConfigAtPath(functionChange, [PredefinedDbPaths.DOT_FUNCTION]);
   if (!funcChangeMap || Object.keys(funcChangeMap).length === 0) {
     return {
-      isPartialSet: true,
+      isMerge: true,
       funcConfig: curFuncTree,
     };
   }
@@ -712,7 +716,7 @@ function applyFunctionChange(curFuncTree, functionChange) {
   }
 
   return {
-    isPartialSet: true,
+    isMerge: true,
     funcConfig: newFuncConfig,
   };
 }
@@ -724,23 +728,25 @@ function applyFunctionChange(curFuncTree, functionChange) {
  * @param {Object} curOwnerTree current owner tree (to be modified by this function)
  * @param {Object} ownerChange owner change
  */
-// NOTE(platfowner): Partial set is applied only when the current owner tree has
+// NOTE(platfowner): Config merge is applied only when the current owner tree has
 // .owner property and the owner change has .owner property as the only property.
 function applyOwnerChange(curOwnerTree, ownerChange) {
+  // 1. Config overwriting case:
   if (!hasConfigLabel(curOwnerTree, PredefinedDbPaths.DOT_OWNER) ||
       !hasConfigLabelOnly(ownerChange, PredefinedDbPaths.DOT_OWNER)) {
     const newOwnerConfig = CommonUtil.isDict(ownerChange) ?
         JSON.parse(JSON.stringify(ownerChange)) : ownerChange;
     return {
-      isPartialSet: false,
+      isMerge: false,
       ownerConfig: newOwnerConfig,
     };
   }
+  // 2. Config merge case:
   const ownerMapPath = [PredefinedDbPaths.DOT_OWNER, OwnerProperties.OWNERS];
   const ownerChangeMap = getConfigAtPath(ownerChange, ownerMapPath);
   if (!ownerChangeMap || Object.keys(ownerChangeMap).length === 0) {
     return {
-      isPartialSet: true,
+      isMerge: true,
       ownerConfig: curOwnerTree,
     };
   }
@@ -762,7 +768,7 @@ function applyOwnerChange(curOwnerTree, ownerChange) {
   }
 
   return {
-    isPartialSet: true,
+    isMerge: true,
     ownerConfig: newOwnerConfig,
   };
 }

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -500,7 +500,6 @@ describe('Blockchain Node', () => {
         assert.deepEqual(body.code, 0);
         assert.deepEqual(eraseEvalResMatched(body.result), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -534,7 +533,6 @@ describe('Blockchain Node', () => {
           code: 0,
           result: {
             "code": 0,
-            "error_message": "",
             "matched": {
               "closestOwner": {
                 "config": {
@@ -637,7 +635,6 @@ describe('Blockchain Node', () => {
             },
             {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "state": {
                   "closestRule": {
@@ -694,7 +691,6 @@ describe('Blockchain Node', () => {
             },
             {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "closestOwner": {
                   "config": {
@@ -998,7 +994,6 @@ describe('Blockchain Node', () => {
         .then(res => {
           assert.deepEqual(eraseEvalResMatched(res.result.result), {
             "code": 0,
-            "error_message": "",
             "matched": "erased",
           });
         })
@@ -1031,7 +1026,6 @@ describe('Blockchain Node', () => {
         .then(res => {
           assert.deepEqual(res.result.result, {
             "code": 0,
-            "error_message": "",
             "matched": {
               "closestOwner": {
                 "config": {

--- a/test/integration/sharding.test.js
+++ b/test/integration/sharding.test.js
@@ -816,7 +816,6 @@ describe('Sharding', () => {
           assert.deepEqual(body.code, 0);
           assert.deepEqual(eraseEvalResMatched(body.result), {
             "code": 0,
-            "error_message": "",
             "matched": "erased",
           });
         })
@@ -832,7 +831,6 @@ describe('Sharding', () => {
           assert.deepEqual(body.code, 0);
           assert.deepEqual(eraseEvalResMatched(body.result), {
             "code": 0,
-            "error_message": "",
             "matched": "erased",
           });
         })
@@ -850,7 +848,6 @@ describe('Sharding', () => {
             "code": 0,
             "result": {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "closestOwner": {
                   "config": {
@@ -897,7 +894,6 @@ describe('Sharding', () => {
             "code": 0,
             "result": {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "closestOwner": {
                   "config": {
@@ -1000,7 +996,6 @@ describe('Sharding', () => {
               },
               {
                 "code": 0,
-                "error_message": "",
                 "matched": {
                   "state": {
                     "closestRule": {
@@ -1057,7 +1052,6 @@ describe('Sharding', () => {
               },
               {
                 "code": 0,
-                "error_message": "",
                 "matched": {
                   "closestOwner": {
                     "config": {
@@ -1165,7 +1159,6 @@ describe('Sharding', () => {
               },
               {
                 "code": 0,
-                "error_message": "",
                 "matched": {
                   "state": {
                     "closestRule": {
@@ -1222,7 +1215,6 @@ describe('Sharding', () => {
               },
               {
                 "code": 0,
-                "error_message": "",
                 "matched": {
                   "closestOwner": {
                     "config": {
@@ -1493,7 +1485,6 @@ describe('Sharding', () => {
           .then(res => {
             assert.deepEqual(eraseEvalResMatched(res.result.result), {
               "code": 0,
-              "error_message": "",
               "matched": "erased",
             });
           })
@@ -1509,7 +1500,6 @@ describe('Sharding', () => {
           .then(res => {
             assert.deepEqual(eraseEvalResMatched(res.result.result), {
               "code": 0,
-              "error_message": "",
               "matched": "erased",
             });
           })
@@ -1526,7 +1516,6 @@ describe('Sharding', () => {
           .then(res => {
             assert.deepEqual(res.result.result, {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "closestOwner": {
                   "config": {
@@ -1570,7 +1559,6 @@ describe('Sharding', () => {
           .then(res => {
             assert.deepEqual(res.result.result, {
               "code": 0,
-              "error_message": "",
               "matched": {
                 "closestOwner": {
                   "config": {

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -763,8 +763,8 @@ describe("DB operations", () => {
             child2: 2
           }, { addr: 'abcd' },
           null, { extra: { executed_at: 1234567890000 }}), {
-          "error_message": "State rule evaluated false: [{\"max_children\":1}] at '/apps/test/test_rule/some/path/more/than/max' for value path '/apps/test/test_rule/some/path/more/than/max' with newValue '{\"child1\":1,\"child2\":2}'",
           "code": 12104,
+          "error_message": "State rule evaluated false: [{\"max_children\":1}] at '/apps/test/test_rule/some/path/more/than/max' for value path '/apps/test/test_rule/some/path/more/than/max' with newValue '{\"child1\":1,\"child2\":2}'",
           "bandwidth_gas_amount": 1
         });
       })
@@ -1386,7 +1386,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/var_path", 'value', { addr: 'other' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -1395,7 +1394,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/path", 'value', { addr: 'abcd' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
@@ -1407,7 +1405,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/upper/path/deeper/path", 'value', { addr: 'ijkl' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
@@ -1428,7 +1425,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/var_path/subpath", 'value', { addr: 'other' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -1437,7 +1433,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/path/subpath", 'value', { addr: 'abcd' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
@@ -1452,7 +1447,6 @@ describe("DB operations", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
             "/apps/test/test_rule/some/upper/path/subpath", 'value', { addr: 'abcd' }, timestamp)), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalRule(
@@ -1899,28 +1893,24 @@ describe("DB operations", () => {
             "/apps/test/test_owner/some/path", 'write_rule',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path", 'write_function',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path", 'write_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path", 'branch_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -1957,28 +1947,24 @@ describe("DB operations", () => {
             "/apps/test/test_owner/some/path/subpath", 'write_rule',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path/subpath", 'write_function',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path/subpath", 'write_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path/subpath", 'branch_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -2015,28 +2001,24 @@ describe("DB operations", () => {
             "/apps/test/test_owner/some/upper/path/subpath", 'write_rule',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/subpath", 'write_function',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/subpath", 'write_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/subpath", 'branch_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -2077,28 +2059,24 @@ describe("DB operations", () => {
             "/apps/test/test_owner/some/upper/path", 'write_rule',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_function',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'branch_owner',
             { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -2649,7 +2627,6 @@ describe("DB operations", () => {
           },
           {
             "code": 0,
-            "error_message": "",
             "matched": {
               "state": {
                 "closestRule": {
@@ -2706,7 +2683,6 @@ describe("DB operations", () => {
           },
           {
             "code": 0,
-            "error_message": "",
             "matched": {
               "closestOwner": {
                 "config": {
@@ -4028,7 +4004,6 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node2.db.evalRule(
         `/apps/test/users/${node2.account.address}/balance`, 0, null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node2.db.evalRule(
@@ -4040,7 +4015,6 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
         `/apps/test/users/${node1.account.address}/balance`, 1, null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4049,7 +4023,6 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
         `/apps/test/users/${node1.account.address}/info`, "something", null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node2.db.evalRule(
@@ -4062,7 +4035,6 @@ describe("DB rule config", () => {
         `/apps/test/users/${node2.account.address}/new_info`, "something",
         { addr: node2.account.address }, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4072,7 +4044,6 @@ describe("DB rule config", () => {
         `/apps/test/users/${node1.account.address}/child/grandson`, "something",
         { addr: node1.account.address }, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node2.db.evalRule(
@@ -4088,7 +4059,6 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node2.db.evalRule(
         `/apps/test/users/${node2.account.address}/balance_info`, "something", null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
@@ -4103,7 +4073,6 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
         `/apps/test/users/${node1.account.address}/next_counter`, 11, null,  null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
@@ -4119,7 +4088,6 @@ describe("DB rule config", () => {
         `/apps/test/second_users/${node2.account.address}/${node2.account.address}`,
         "some value", null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
@@ -4135,13 +4103,11 @@ describe("DB rule config", () => {
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
         '/apps/test/no_dup_key/aaa/bbb', "some value", null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node1.db.evalRule(
         '/apps/test/dup_key/aaa/bbb', "some value", null, null)), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4266,7 +4232,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true/branch', 'branch_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4280,14 +4245,12 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/false/true/branch', 'branch_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/branch', 'branch_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4297,14 +4260,12 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true', 'write_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4318,7 +4279,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/false', 'write_owner',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4328,21 +4288,18 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4359,21 +4316,18 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4390,21 +4344,18 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4421,21 +4372,18 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
         { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4460,7 +4408,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/false/true/true/branch', 'branch_owner',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4498,7 +4445,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/false/true', 'write_owner',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
@@ -4536,7 +4482,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/false', 'write_rule',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4567,7 +4512,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4598,7 +4542,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/false', 'write_function',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -4629,7 +4572,6 @@ describe("DB owner config", () => {
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
         { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
       "code": 0,
-      "error_message": "",
       "matched": "erased",
     });
   })
@@ -5293,7 +5235,6 @@ describe("DB sharding config", () => {
             "/apps/test/test_sharding/some/path/to", newValue,
             { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -5303,7 +5244,6 @@ describe("DB sharding config", () => {
             "/apps/afan/apps/test/test_sharding/some/path/to", newValue,
             { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" }, null, { isGlobal: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -5466,7 +5406,6 @@ describe("DB sharding config", () => {
             "/apps/test/test_sharding/some/path/to", "write_rule",
             { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })
@@ -5476,7 +5415,6 @@ describe("DB sharding config", () => {
             "/apps/afan/apps/test/test_sharding/some/path/to", "write_rule",
             { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" }, { isGlobal: true })), {
           "code": 0,
-          "error_message": "",
           "matched": "erased",
         });
       })

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -1834,27 +1834,27 @@ describe("DB operations", () => {
       it("evalOwner to evaluate existing owner with matching address", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path", 'write_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/path", 'write_rule',{ addr: '' })), {
+            "/apps/test/test_owner/some/path", 'write_rule',{ addr: '' }, {})), {
           "code": 12302,
           "error_message": "write_rule permission evaluated false: [null] at '/apps/test/test_owner/some/path' for rule path '/apps/test/test_owner/some/path' with permission 'write_rule', auth '{\"addr\":\"\"}'",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/deeper/path", 'write_owner',
-            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/deeper/path", 'write_rule',
-            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
           "code": 12302,
           "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_function\":false,\"write_owner\":true,\"write_rule\":false}] at '/apps/test/test_owner/some/upper/path/deeper/path' for rule path '/apps/test/test_owner/some/upper/path/deeper/path' with permission 'write_rule', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
           "matched": "erased",
@@ -1863,25 +1863,25 @@ describe("DB operations", () => {
 
       it("evalOwner to evaluate existing owner without matching address", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/path", 'write_owner', { addr: 'other' })), {
+            "/apps/test/test_owner/some/path", 'write_owner', { addr: 'other' }, {})), {
           "code": 12502,
           "error_message": "write_owner permission evaluated false: [{\"branch_owner\":false,\"write_function\":true,\"write_owner\":false,\"write_rule\":true}] at '/apps/test/test_owner/some/path' for owner path '/apps/test/test_owner/some/path' with permission 'write_owner', auth '{\"addr\":\"other\"}'",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/path", 'write_rule', { addr: 'other' })), {
+            "/apps/test/test_owner/some/path", 'write_rule', { addr: 'other' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/upper/path/deeper/path", 'write_owner', { addr: 'other' })), {
+            "/apps/test/test_owner/some/upper/path/deeper/path", 'write_owner', { addr: 'other' }, {})), {
           "code": 12502,
           "error_message": "write_owner permission evaluated false: [{\"branch_owner\":false,\"write_function\":true,\"write_owner\":false,\"write_rule\":true}] at '/apps/test/test_owner/some/upper/path/deeper/path' for owner path '/apps/test/test_owner/some/upper/path/deeper/path' with permission 'write_owner', auth '{\"addr\":\"other\"}'",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/upper/path/deeper/path", 'write_rule', { addr: 'other' })), {
+            "/apps/test/test_owner/some/upper/path/deeper/path", 'write_rule', { addr: 'other' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
@@ -1891,27 +1891,27 @@ describe("DB operations", () => {
       it("evalOwner to evaluate closest owner", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/path/subpath", 'write_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
-            "/apps/test/test_owner/some/path/subpath", 'write_rule',{ addr: '' })), {
+            "/apps/test/test_owner/some/path/subpath", 'write_rule',{ addr: '' }, {})), {
           "code": 12302,
           "error_message": "write_rule permission evaluated false: [null] at '/apps/test/test_owner/some/path' for rule path '/apps/test/test_owner/some/path/subpath' with permission 'write_rule', auth '{\"addr\":\"\"}'",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/deeper/path/subpath", 'write_owner',
-            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/deeper/path/subpath", 'write_rule',
-            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+            { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
           "code": 12302,
           "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_function\":false,\"write_owner\":true,\"write_rule\":false}] at '/apps/test/test_owner/some/upper/path/deeper/path' for rule path '/apps/test/test_owner/some/upper/path/deeper/path/subpath' with permission 'write_rule', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
           "matched": "erased",
@@ -1921,14 +1921,14 @@ describe("DB operations", () => {
       it("evalOwner to evaluate a owner without subtree owners", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/subpath", 'write_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path/subpath", 'write_rule',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 12302,
           "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_function\":false,\"write_owner\":true,\"write_rule\":false}] at '/apps/test/test_owner/some/upper/path' for rule path '/apps/test/test_owner/some/upper/path/subpath' with permission 'write_rule', auth '{\"addr\":\"0x09A0d53FDf1c36A131938eb379b98910e55EEfe1\"}'",
           "matched": "erased",
@@ -1938,28 +1938,28 @@ describe("DB operations", () => {
       it("evalOwner to evaluate a owner with subtree owners", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_rule',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 12301,
           "error_message": "Non-empty (1) subtree owners for rule path '/apps/test/test_owner/some/upper/path': [\"/deeper/path\"]",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_function',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 12401,
           "error_message": "Non-empty (1) subtree owners for function path '/apps/test/test_owner/some/upper/path': [\"/deeper/path\"]",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 12501,
           "error_message": "Non-empty (1) subtree owners for owner path '/apps/test/test_owner/some/upper/path': [\"/deeper/path\"]",
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'branch_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {})), {
           "code": 12501,
           "error_message": "Non-empty (1) subtree owners for owner path '/apps/test/test_owner/some/upper/path': [\"/deeper/path\"]",
           "matched": "erased",
@@ -1969,7 +1969,7 @@ describe("DB operations", () => {
       it("evalOwner to evaluate a owner with invalid permission", () => {
         assert.deepEqual(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'invalid permission',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, {}), {
           "code": 12201,
           "error_message": "Invalid permission 'invalid permission' for local path '/apps/test/test_owner/some/upper/path' with auth '{\"addr\":\"0x09A0d53FDf1c36A131938eb379b98910e55EEfe1\"}'",
           "matched": null,
@@ -4098,28 +4098,28 @@ describe("DB owner config", () => {
   it("branch_owner permission for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/branch', 'branch_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/branch', 'branch_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12502,
       "error_message": "branch_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":true,\"write_function\":true}] at '/apps/test/test_owner/mixed/false/true/true' for owner path '/apps/test/test_owner/mixed/false/true/true/branch' with permission 'branch_owner', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/branch', 'branch_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/branch', 'branch_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -4129,28 +4129,28 @@ describe("DB owner config", () => {
   it("write_owner permission for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12502,
       "error_message": "write_owner permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":true,\"write_function\":true}] at '/apps/test/test_owner/mixed/true/false/true' for owner path '/apps/test/test_owner/mixed/true/false/true' with permission 'write_owner', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_owner',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -4160,28 +4160,28 @@ describe("DB owner config", () => {
   it("write_rule permission for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/false' for rule path '/apps/test/test_owner/mixed/true/true/false' with permission 'write_rule', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
@@ -4191,28 +4191,28 @@ describe("DB owner config", () => {
   it("write_rule permission on deeper path for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/false' for rule path '/apps/test/test_owner/mixed/true/true/false/deeper_path' with permission 'write_rule', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
@@ -4222,28 +4222,28 @@ describe("DB owner config", () => {
   it("write_function permission for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":true,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/false' for function path '/apps/test/test_owner/mixed/true/true/false' with permission 'write_function', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
@@ -4253,28 +4253,28 @@ describe("DB owner config", () => {
   it("write_function permission on deeper path for known user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
-        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' })), {
+        { addr: '0x08Aed7AF9354435c38d52143EE50ac839D20696b' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":true,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/false' for function path '/apps/test/test_owner/mixed/true/true/false/deeper_path' with permission 'write_function', auth '{\"addr\":\"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"}'",
       "matched": "erased",
@@ -4285,28 +4285,28 @@ describe("DB owner config", () => {
   it("branch_owner permission for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/branch', 'branch_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "branch_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for owner path '/apps/test/test_owner/mixed/true/true/true/branch' with permission 'branch_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/branch', 'branch_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/branch', 'branch_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "branch_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/false/true' for owner path '/apps/test/test_owner/mixed/true/false/true/branch' with permission 'branch_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/branch', 'branch_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "branch_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":true,\"write_function\":true}] at '/apps/test/test_owner/mixed/true/true/false' for owner path '/apps/test/test_owner/mixed/true/true/false/branch' with permission 'branch_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
@@ -4316,28 +4316,28 @@ describe("DB owner config", () => {
   it("write_owner permission for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "write_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for owner path '/apps/test/test_owner/mixed/true/true/true' with permission 'write_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "write_owner permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/false/true/true' for owner path '/apps/test/test_owner/mixed/false/true/true' with permission 'write_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_owner',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12502,
       "error_message": "write_owner permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":true,\"write_function\":true}] at '/apps/test/test_owner/mixed/true/true/false' for owner path '/apps/test/test_owner/mixed/true/true/false' with permission 'write_owner', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
@@ -4347,28 +4347,28 @@ describe("DB owner config", () => {
   it("write_rule permission for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for rule path '/apps/test/test_owner/mixed/true/true/true' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/false/true/true' for rule path '/apps/test/test_owner/mixed/false/true/true' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/false/true' for rule path '/apps/test/test_owner/mixed/true/false/true' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -4378,28 +4378,28 @@ describe("DB owner config", () => {
   it("write_rule permission on deeper path for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for rule path '/apps/test/test_owner/mixed/true/true/true/deeper_path' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/false/true/true' for rule path '/apps/test/test_owner/mixed/false/true/true/deeper_path' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12302,
       "error_message": "write_rule permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/false/true' for rule path '/apps/test/test_owner/mixed/true/false/true/deeper_path' with permission 'write_rule', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_rule',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -4409,28 +4409,28 @@ describe("DB owner config", () => {
   it("write_function permission for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for function path '/apps/test/test_owner/mixed/true/true/true' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/false/true/true' for function path '/apps/test/test_owner/mixed/false/true/true' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/false/true' for function path '/apps/test/test_owner/mixed/true/false/true' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -4440,28 +4440,28 @@ describe("DB owner config", () => {
   it("write_function permission on deeper path for unknown user with mixed config", () => {
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/true/deeper_path', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":false,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/true/true' for function path '/apps/test/test_owner/mixed/true/true/true/deeper_path' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/false/true/true/deeper_path', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":true,\"write_owner\":false,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/false/true/true' for function path '/apps/test/test_owner/mixed/false/true/true/deeper_path' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/false/true/deeper_path', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 12402,
       "error_message": "write_function permission evaluated false: [{\"branch_owner\":false,\"write_owner\":true,\"write_rule\":false,\"write_function\":false}] at '/apps/test/test_owner/mixed/true/false/true' for function path '/apps/test/test_owner/mixed/true/false/true/deeper_path' with permission 'write_function', auth '{\"addr\":\"0x07A43138CC760C85A5B1F115aa60eADEaa0bf417\"}'",
       "matched": "erased",
     });
     assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
         '/apps/test/test_owner/mixed/true/true/false/deeper_path', 'write_function',
-        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' })), {
+        { addr: '0x07A43138CC760C85A5B1F115aa60eADEaa0bf417' }, {})), {
       "code": 0,
       "error_message": "",
       "matched": "erased",
@@ -5298,7 +5298,7 @@ describe("DB sharding config", () => {
       it("evalOwner with isGlobal = false", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_sharding/some/path/to", "write_rule",
-            { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" })), {
+            { addr: "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1" }, {})), {
           "code": 0,
           "error_message": "",
           "matched": "erased",

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -1077,7 +1077,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_function permission with subtree owners'.
-      it("setFunction to write with subtree owners with isPartialSet = false", () => {
+      it("setFunction to write with subtree owners with isMerge = false", () => {
         const functionConfig = {
           ".function": {
             "fid_other": {
@@ -1096,7 +1096,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_function permission with subtree owners'.
-      it("setFunction to write with subtree owners with isPartialSet = true", () => {
+      it("setFunction to write with subtree owners with isMerge = true", () => {
         const functionConfig = {
           ".function": {
             "fid_other": {
@@ -1592,7 +1592,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_rule permission with subtree owners'.
-      it("setRule to write with subtree owners with isPartialSet = false", () => {
+      it("setRule to write with subtree owners with isMerge = false", () => {
         assert.deepEqual(node.db.setRule("/apps/test/test_owner/some/upper/path/deeper",
             {
               ".rule": {
@@ -1606,7 +1606,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_rule permission with subtree owners'.
-      it("setRule to write with subtree owners with isPartialSet = true", () => {
+      it("setRule to write with subtree owners with isMerge = true", () => {
         assert.deepEqual(node.db.setRule("/apps/test/test_owner/some/upper/path", {
               ".rule": {
                 "write": "auth.addr === 'xyz'"
@@ -2054,28 +2054,28 @@ describe("DB operations", () => {
         });
       })
 
-      it("evalOwner to evaluate a owner with subtree owners and isPartialSet = true", () => {
+      it("evalOwner to evaluate a owner with subtree owners and isMerge = true", () => {
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_rule',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isMerge: true })), {
           "code": 0,
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_function',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isMerge: true })), {
           "code": 0,
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'write_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isMerge: true })), {
           "code": 0,
           "matched": "erased",
         });
         assert.deepEqual(eraseEvalResMatched(node.db.evalOwner(
             "/apps/test/test_owner/some/upper/path", 'branch_owner',
-            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isPartialSet: true })), {
+            { addr: '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1' }, { isMerge: true })), {
           "code": 0,
           "matched": "erased",
         });
@@ -2187,7 +2187,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_owner permission with subtree owners'.
-      it("setOwner to write with subtree owners with isPartialSet = false", () => {
+      it("setOwner to write with subtree owners with isMerge = false", () => {
         assert.deepEqual(node.db.setOwner("/apps/test/test_owner/some/upper/path/deeper", {
           ".owner": {
             "owners": {
@@ -2207,7 +2207,7 @@ describe("DB operations", () => {
       })
 
       // For details, see test case 'evalOwner to evaluate write_owner permission with subtree owners'.
-      it("setOwner to write with subtree owners with isPartialSet = true", () => {
+      it("setOwner to write with subtree owners with isMerge = true", () => {
         assert.deepEqual(node.db.setOwner(
             "/apps/test/test_owner/some/upper/path", {
           ".owner": {

--- a/test/unit/state-util.test.js
+++ b/test/unit/state-util.test.js
@@ -1462,7 +1462,10 @@ describe("state-util", () => {
     };
 
     it("add / delete / modify non-existing rule", () => {
-      assert.deepEqual(applyRuleChange(null, curRule), curRule); // the same as the given rule change.
+      assert.deepEqual(applyRuleChange(null, curRule), {
+        "isPartialSet": false,
+        "ruleConfig": curRule,
+      }); // the same as the given rule change.
     });
 
     it("delete / modify existing rule", () => {
@@ -1475,11 +1478,14 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".rule": {
-          // write: deleted
-          "state": {  // modified
-            "max_children": 100,
-            "ordering": "FIFO"
+        "isPartialSet": true,
+        "ruleConfig": {
+          ".rule": {
+            // write: deleted
+            "state": {  // modified
+              "max_children": 100,
+              "ordering": "FIFO"
+            }
           }
         }
         // deeper rule deleted
@@ -1497,11 +1503,14 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".rule": {
-          "write": true,
-          "state": { // added
-            "max_children": 10,
-            "ordering": "FIFO"
+        "isPartialSet": true,
+        "ruleConfig": {
+          ".rule": {
+            "write": true,
+            "state": { // added
+              "max_children": 10,
+              "ordering": "FIFO"
+            }
           }
         }
       });
@@ -1519,20 +1528,26 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".rule": {
-          "write": "auth.addr === 'efgh'", // modified
-          "state": null // deleted
-        },
-        "deeper": {
-          ".rule": { // replaced
-            "write": false
+        "isPartialSet": false,
+        "ruleConfig": {
+          ".rule": {
+            "write": "auth.addr === 'efgh'", // modified
+            "state": null // deleted
+          },
+          "deeper": {
+            ".rule": { // replaced
+              "write": false
+            }
           }
         }
       });
     });
 
     it("with null rule change", () => {
-      assert.deepEqual(applyRuleChange(curRule, null), null);
+      assert.deepEqual(applyRuleChange(curRule, null), {
+        "isPartialSet": false,
+        "ruleConfig": null,
+      });
     });
   })
 
@@ -1580,18 +1595,21 @@ describe("state-util", () => {
           }
         }
       }), {  // the same as the given function change.
-        ".function": {
-          "0x111": null,
-          "0x222": {
-            "function_type": "REST",
-            "function_id": "0x222"
-          },
-        },
-        "deeper": {
+        "isPartialSet": false,
+        "funcConfig": {
           ".function": {
-            "0x888": {
+            "0x111": null,
+            "0x222": {
               "function_type": "REST",
-              "function_id": "0x888"
+              "function_id": "0x222"
+            },
+          },
+          "deeper": {
+            ".function": {
+              "0x888": {
+                "function_type": "REST",
+                "function_id": "0x888"
+              }
             }
           }
         }
@@ -1612,25 +1630,28 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".function": {
-          "0x222": {  // modified
-            "function_type": "REST",
-            "function_id": "0x222",
-          },
-          "0x333": {  // untouched
-            "function_type": "REST",
-            "function_id": "0x333"
-          },
-          "0x444": {  // added
-            "function_type": "REST",
-            "function_id": "0x444"
-          }
-        },
-        "deeper": {
-          ".function": {  // deeper function
-            "0x999": {
+        "isPartialSet": true,
+        "funcConfig": {
+          ".function": {
+            "0x222": {  // modified
               "function_type": "REST",
-              "function_id": "0x999"
+              "function_id": "0x222",
+            },
+            "0x333": {  // untouched
+              "function_type": "REST",
+              "function_id": "0x333"
+            },
+            "0x444": {  // added
+              "function_type": "REST",
+              "function_id": "0x444"
+            }
+          },
+          "deeper": {
+            ".function": {  // deeper function
+              "0x999": {
+                "function_type": "REST",
+                "function_id": "0x999"
+              }
             }
           }
         }
@@ -1658,21 +1679,24 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".function": {  // replaced
-          "0x222": {
-            "function_type": "REST",
-            "function_id": "0x222",
-          },
-          "0x444": {
-            "function_type": "REST",
-            "function_id": "0x444"
-          }
-        },
-        "deeper": {  // replaced
-          ".function": {
-            "0x888": {
+        "isPartialSet": false,
+        "funcConfig": {
+          ".function": {  // replaced
+            "0x222": {
               "function_type": "REST",
-              "function_id": "0x888"
+              "function_id": "0x222",
+            },
+            "0x444": {
+              "function_type": "REST",
+              "function_id": "0x444"
+            }
+          },
+          "deeper": {  // replaced
+            ".function": {
+              "0x888": {
+                "function_type": "REST",
+                "function_id": "0x888"
+              }
             }
           }
         }
@@ -1680,7 +1704,10 @@ describe("state-util", () => {
     });
 
     it("with null function change", () => {
-      assert.deepEqual(applyFunctionChange(curFunction, null), null);
+      assert.deepEqual(applyFunctionChange(curFunction, null), {
+        "isPartialSet": false,
+        "funcConfig": null,
+      });
     });
   });
 
@@ -1747,18 +1774,9 @@ describe("state-util", () => {
           }
         }
       }), {  // the same as the given owner change.
-        ".owner": {  // owner
-          "owners": {
-            "*": {
-              "branch_owner": true,
-              "write_function": true,
-              "write_owner": true,
-              "write_rule": true,
-            },
-          }
-        },
-        "deeper": {
-          ".owner": {  // deeper owner
+        "isPartialSet": false,
+        "ownerConfig": {
+          ".owner": {  // owner
             "owners": {
               "*": {
                 "branch_owner": true,
@@ -1766,6 +1784,18 @@ describe("state-util", () => {
                 "write_owner": true,
                 "write_rule": true,
               },
+            }
+          },
+          "deeper": {
+            ".owner": {  // deeper owner
+              "owners": {
+                "*": {
+                  "branch_owner": true,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": true,
+                },
+              }
             }
           }
         }
@@ -1792,37 +1822,40 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".owner": {
-          "owners": {
-            "*": {  // modified
-              "branch_owner": true,
-              "write_function": false,
-              "write_owner": false,
-              "write_rule": false,
-            },
-            "bbbb": {  // untouched
-              "branch_owner": true,
-              "write_function": true,
-              "write_owner": true,
-              "write_rule": true,
-            },
-            "cccc": {  // added
-              "branch_owner": true,
-              "write_function": true,
-              "write_owner": true,
-              "write_rule": true,
-            }
-          }
-        },
-        "deeper": {
-          ".owner": {  // deeper owner
+        "isPartialSet": true,
+        "ownerConfig": {
+          ".owner": {
             "owners": {
-              "*": {
+              "*": {  // modified
+                "branch_owner": true,
+                "write_function": false,
+                "write_owner": false,
+                "write_rule": false,
+              },
+              "bbbb": {  // untouched
                 "branch_owner": true,
                 "write_function": true,
                 "write_owner": true,
                 "write_rule": true,
               },
+              "cccc": {  // added
+                "branch_owner": true,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": true,
+              }
+            }
+          },
+          "deeper": {
+            ".owner": {  // deeper owner
+              "owners": {
+                "*": {
+                  "branch_owner": true,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": true,
+                },
+              }
             }
           }
         }
@@ -1860,30 +1893,33 @@ describe("state-util", () => {
           }
         }
       }), {
-        ".owner": {  // replaced
-          "owners": {
-            "*": {  // modify
-              "branch_owner": true,
-              "write_function": false,
-              "write_owner": false,
-              "write_rule": false,
-            },
-            "cccc": {  // add
-              "branch_owner": true,
-              "write_function": true,
-              "write_owner": true,
-              "write_rule": true,
-            }
-          }
-        },
-        "deeper": {  // replaced
-          ".owner": {
+        "isPartialSet": false,
+        "ownerConfig": {
+          ".owner": {  // replaced
             "owners": {
-              "CCCC": {
+              "*": {  // modify
+                "branch_owner": true,
+                "write_function": false,
+                "write_owner": false,
+                "write_rule": false,
+              },
+              "cccc": {  // add
                 "branch_owner": true,
                 "write_function": true,
                 "write_owner": true,
                 "write_rule": true,
+              }
+            }
+          },
+          "deeper": {  // replaced
+            ".owner": {
+              "owners": {
+                "CCCC": {
+                  "branch_owner": true,
+                  "write_function": true,
+                  "write_owner": true,
+                  "write_rule": true,
+                }
               }
             }
           }
@@ -1892,7 +1928,10 @@ describe("state-util", () => {
     });
 
     it("with null owner change", () => {
-      assert.deepEqual(applyOwnerChange(curOwner, null), null);
+      assert.deepEqual(applyOwnerChange(curOwner, null), {
+        "isPartialSet": false,
+        "ownerConfig": null,
+      });
     });
   });
 

--- a/test/unit/state-util.test.js
+++ b/test/unit/state-util.test.js
@@ -1486,9 +1486,17 @@ describe("state-util", () => {
               "max_children": 100,
               "ordering": "FIFO"
             }
+          },
+          "deeper": {  // deeper rules preserved
+            ".rule": {
+              "state": {
+                "max_children": 10,
+                "ordering": "FIFO",
+              },
+              "write": true,
+            }
           }
         }
-        // deeper rule deleted
       });
 
       assert.deepEqual(applyRuleChange({

--- a/test/unit/state-util.test.js
+++ b/test/unit/state-util.test.js
@@ -1463,7 +1463,7 @@ describe("state-util", () => {
 
     it("add / delete / modify non-existing rule", () => {
       assert.deepEqual(applyRuleChange(null, curRule), {
-        "isPartialSet": false,
+        "isMerge": false,
         "ruleConfig": curRule,
       }); // the same as the given rule change.
     });
@@ -1478,7 +1478,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": true,
+        "isMerge": true,
         "ruleConfig": {
           ".rule": {
             // write: deleted
@@ -1503,7 +1503,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": true,
+        "isMerge": true,
         "ruleConfig": {
           ".rule": {
             "write": true,
@@ -1528,7 +1528,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": false,
+        "isMerge": false,
         "ruleConfig": {
           ".rule": {
             "write": "auth.addr === 'efgh'", // modified
@@ -1545,7 +1545,7 @@ describe("state-util", () => {
 
     it("with null rule change", () => {
       assert.deepEqual(applyRuleChange(curRule, null), {
-        "isPartialSet": false,
+        "isMerge": false,
         "ruleConfig": null,
       });
     });
@@ -1595,7 +1595,7 @@ describe("state-util", () => {
           }
         }
       }), {  // the same as the given function change.
-        "isPartialSet": false,
+        "isMerge": false,
         "funcConfig": {
           ".function": {
             "0x111": null,
@@ -1630,7 +1630,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": true,
+        "isMerge": true,
         "funcConfig": {
           ".function": {
             "0x222": {  // modified
@@ -1679,7 +1679,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": false,
+        "isMerge": false,
         "funcConfig": {
           ".function": {  // replaced
             "0x222": {
@@ -1705,7 +1705,7 @@ describe("state-util", () => {
 
     it("with null function change", () => {
       assert.deepEqual(applyFunctionChange(curFunction, null), {
-        "isPartialSet": false,
+        "isMerge": false,
         "funcConfig": null,
       });
     });
@@ -1774,7 +1774,7 @@ describe("state-util", () => {
           }
         }
       }), {  // the same as the given owner change.
-        "isPartialSet": false,
+        "isMerge": false,
         "ownerConfig": {
           ".owner": {  // owner
             "owners": {
@@ -1822,7 +1822,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": true,
+        "isMerge": true,
         "ownerConfig": {
           ".owner": {
             "owners": {
@@ -1893,7 +1893,7 @@ describe("state-util", () => {
           }
         }
       }), {
-        "isPartialSet": false,
+        "isMerge": false,
         "ownerConfig": {
           ".owner": {  // replaced
             "owners": {
@@ -1929,7 +1929,7 @@ describe("state-util", () => {
 
     it("with null owner change", () => {
       assert.deepEqual(applyOwnerChange(curOwner, null), {
-        "isPartialSet": false,
+        "isMerge": false,
         "ownerConfig": null,
       });
     });


### PR DESCRIPTION
Change summary:
- Allow writing rules / functions / owners with subtree owners in partial set cases (with isPartialSet = true)
- Do not return empty error_messages

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/779