### PR TITLE
Feature/liayoo/p2p msg tags

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -802,6 +802,21 @@ class CommonUtil {
   static getWhitelistFromString(value) {
     return CommonUtil.isWildcard(value) ? value : value.split(',');
   }
+
+  static countMaxOccurrences(list) {
+    if (!CommonUtil.isArray(list)) {
+      return 0;
+    }
+    let maxOccurrences = 0;
+    const counts = {};
+    for (const item of list) {
+      counts[item] = (counts[item] || 0) + 1;
+      if (maxOccurrences < counts[item]) {
+        maxOccurrences = counts[item];
+      }
+    }
+    return maxOccurrences;
+  }
 }
 
 module.exports = CommonUtil;

--- a/common/constants.js
+++ b/common/constants.js
@@ -557,8 +557,10 @@ const TrafficEventTypes = {
   // P2P messages
   P2P_MESSAGE_CLIENT: 'p2p_message_client',
   P2P_MESSAGE_SERVER: 'p2p_message_server',
-  P2P_TAG_LENGTH: 'p2p_tag_length',
-  P2P_TAG_MAX_OCCUR: 'p2p_tag_max_occur',
+  P2P_TAG_CONSENSUS_LENGTH: 'p2p_tag_consensus_length',
+  P2P_TAG_CONSENSUS_MAX_OCCUR: 'p2p_tag_consensus_max_occur',
+  P2P_TAG_TX_LENGTH: 'p2p_tag_tx_length',
+  P2P_TAG_TX_MAX_OCCUR: 'p2p_tag_tx_max_occur',
   // Client APIs
   CLIENT_API_GET: 'client_api_get',
   CLIENT_API_SET: 'client_api_set',

--- a/common/constants.js
+++ b/common/constants.js
@@ -24,6 +24,8 @@ const DevFlags = {
   enableTrafficMonitoring: true,
   // Enables winston logger. (default = bunyan)
   enableWinstonLogger: false,
+  // Enables p2p message tagging.
+  enableP2pMessageTags: true,
 };
 
 // ** Blockchain configs **
@@ -555,6 +557,8 @@ const TrafficEventTypes = {
   // P2P messages
   P2P_MESSAGE_CLIENT: 'p2p_message_client',
   P2P_MESSAGE_SERVER: 'p2p_message_server',
+  P2P_TAG_LENGTH: 'p2p_tag_length',
+  P2P_TAG_MAX_DUPLICATE: 'p2p_tag_max_duplicate',
   // Client APIs
   CLIENT_API_GET: 'client_api_get',
   CLIENT_API_SET: 'client_api_set',

--- a/common/constants.js
+++ b/common/constants.js
@@ -558,7 +558,7 @@ const TrafficEventTypes = {
   P2P_MESSAGE_CLIENT: 'p2p_message_client',
   P2P_MESSAGE_SERVER: 'p2p_message_server',
   P2P_TAG_LENGTH: 'p2p_tag_length',
-  P2P_TAG_MAX_DUPLICATE: 'p2p_tag_max_duplicate',
+  P2P_TAG_MAX_OCCURRENCES: 'p2p_tag_max_occurrences',
   // Client APIs
   CLIENT_API_GET: 'client_api_get',
   CLIENT_API_SET: 'client_api_set',

--- a/common/constants.js
+++ b/common/constants.js
@@ -558,7 +558,7 @@ const TrafficEventTypes = {
   P2P_MESSAGE_CLIENT: 'p2p_message_client',
   P2P_MESSAGE_SERVER: 'p2p_message_server',
   P2P_TAG_LENGTH: 'p2p_tag_length',
-  P2P_TAG_MAX_OCCURRENCES: 'p2p_tag_max_occurrences',
+  P2P_TAG_MAX_OCCUR: 'p2p_tag_max_occur',
   // Client APIs
   CLIENT_API_GET: 'client_api_get',
   CLIENT_API_SET: 'client_api_set',

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -225,7 +225,7 @@ class Consensus {
   // Types of consensus messages:
   //  1. Proposal { value: { proposalBlock, proposalTx }, type = 'PROPOSE' }
   //  2. Vote { value: <voting tx>, type = 'VOTE' }
-  handleConsensusMessage(msg) {
+  handleConsensusMessage(msg, tags = []) {
     const LOG_HEADER = 'handleConsensusMessage';
 
     if (!this.checkConsensusProtocolVersion(msg)) {
@@ -284,7 +284,7 @@ class Consensus {
           e.log();
           if (ConsensusUtil.isVoteAgainstBlockError(e.code)) {
             this.node.bp.addSeenBlock(proposalBlock, proposalTx, false);
-            this.server.client.broadcastConsensusMessage(msg);
+            this.server.client.broadcastConsensusMessage(msg, tags);
             this.tryVoteAgainstInvalidBlock(proposalBlock);
           }
         } else {
@@ -292,7 +292,7 @@ class Consensus {
         }
         return;
       }
-      this.server.client.broadcastConsensusMessage(msg);
+      this.server.client.broadcastConsensusMessage(msg, tags);
       this.tryVoteForValidBlock(proposalBlock);
     } else if (msg.type === ConsensusMessageTypes.VOTE) {
       if (this.node.tp.transactionTracker[msg.value.hash]) {
@@ -312,7 +312,7 @@ class Consensus {
         logger.error(`[${LOG_HEADER}] Cannot process the vote or it's invalid: ${JSON.stringify(msg.value)}`);
         return;
       }
-      this.server.client.broadcastConsensusMessage(msg);
+      this.server.client.broadcastConsensusMessage(msg, tags);
     }
   }
 

--- a/monitoring/grafana.json
+++ b/monitoring/grafana.json
@@ -1489,7 +1489,7 @@
         "y": 64
       },
       "hiddenSeries": false,
-      "id": 68,
+      "id": 98,
       "legend": {
         "avg": false,
         "current": false,
@@ -1516,23 +1516,35 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:block_txs:metric",
+          "expr": "client_status:traffic_stats:1_m:p_2_p_tag_consensus_length:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:block_txs:metric",
+          "expr": "client_status:traffic_stats:5_m:p_2_p_tag_consensus_length:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:block_txs:metric",
+          "expr": "client_status:traffic_stats:1_h:p_2_p_tag_consensus_length:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -1541,7 +1553,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "block_txs",
+      "title": "p_2_p_tag_consensus_length",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1651,12 +1663,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1666,7 +1672,7 @@
         "y": 72
       },
       "hiddenSeries": false,
-      "id": 66,
+      "id": 100,
       "legend": {
         "avg": false,
         "current": false,
@@ -1693,23 +1699,35 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:block_size:metric",
+          "expr": "client_status:traffic_stats:1_m:p_2_p_tag_consensus_max_occur:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:block_size:metric",
+          "expr": "client_status:traffic_stats:5_m:p_2_p_tag_consensus_max_occur:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:block_size:metric",
+          "expr": "client_status:traffic_stats:1_h:p_2_p_tag_consensus_max_occur:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -1718,7 +1736,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "block_size",
+      "title": "p_2_p_tag_consensus_max_occur",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1837,7 +1855,7 @@
         "y": 80
       },
       "hiddenSeries": false,
-      "id": 70,
+      "id": 102,
       "legend": {
         "avg": false,
         "current": false,
@@ -1864,23 +1882,35 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:block_gas_amount:metric",
+          "expr": "client_status:traffic_stats:1_m:p_2_p_tag_tx_length:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:block_gas_amount:metric",
+          "expr": "client_status:traffic_stats:5_m:p_2_p_tag_tx_length:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:block_gas_amount:metric",
+          "expr": "client_status:traffic_stats:1_h:p_2_p_tag_tx_length:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -1889,7 +1919,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "block_gas_amount",
+      "title": "p_2_p_tag_tx_length",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2015,7 +2045,7 @@
         "y": 88
       },
       "hiddenSeries": false,
-      "id": 74,
+      "id": 104,
       "legend": {
         "avg": false,
         "current": false,
@@ -2042,23 +2072,35 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:block_gas_cost:metric",
+          "expr": "client_status:traffic_stats:1_m:p_2_p_tag_tx_max_occur:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:block_gas_cost:metric",
+          "expr": "client_status:traffic_stats:5_m:p_2_p_tag_tx_max_occur:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "IpGY85sGk"
+          },
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:block_gas_cost:metric",
+          "expr": "client_status:traffic_stats:1_h:p_2_p_tag_tx_max_occur:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2067,7 +2109,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "block_gas_cost",
+      "title": "p_2_p_tag_tx_max_occur",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2193,7 +2235,7 @@
         "y": 96
       },
       "hiddenSeries": false,
-      "id": 80,
+      "id": 68,
       "legend": {
         "avg": false,
         "current": false,
@@ -2221,14 +2263,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:tx_bytes:metric",
+          "expr": "client_status:traffic_stats:1_m:block_txs:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:tx_bytes:metric",
+          "expr": "client_status:traffic_stats:5_m:block_txs:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2236,7 +2278,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:tx_bytes:metric",
+          "expr": "client_status:traffic_stats:1_h:block_txs:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2245,7 +2287,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "tx_bytes",
+      "title": "block_txs",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2355,6 +2397,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2364,7 +2412,7 @@
         "y": 104
       },
       "hiddenSeries": false,
-      "id": 82,
+      "id": 66,
       "legend": {
         "avg": false,
         "current": false,
@@ -2392,14 +2440,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:tx_op_size:metric",
+          "expr": "client_status:traffic_stats:1_m:block_size:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:tx_op_size:metric",
+          "expr": "client_status:traffic_stats:5_m:block_size:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2407,7 +2455,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:tx_op_size:metric",
+          "expr": "client_status:traffic_stats:1_h:block_size:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2416,7 +2464,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "tx_op_size",
+      "title": "block_size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2535,7 +2583,7 @@
         "y": 112
       },
       "hiddenSeries": false,
-      "id": 78,
+      "id": 70,
       "legend": {
         "avg": false,
         "current": false,
@@ -2563,14 +2611,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:tx_gas_amount:metric",
+          "expr": "client_status:traffic_stats:1_m:block_gas_amount:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:tx_gas_amount:metric",
+          "expr": "client_status:traffic_stats:5_m:block_gas_amount:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2578,7 +2626,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:tx_gas_amount:metric",
+          "expr": "client_status:traffic_stats:1_h:block_gas_amount:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2587,7 +2635,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "tx_gas_amount",
+      "title": "block_gas_amount",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2707,7 +2755,7 @@
         "y": 120
       },
       "hiddenSeries": false,
-      "id": 76,
+      "id": 74,
       "legend": {
         "avg": false,
         "current": false,
@@ -2735,14 +2783,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:tx_gas_cost:metric",
+          "expr": "client_status:traffic_stats:1_m:block_gas_cost:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:tx_gas_cost:metric",
+          "expr": "client_status:traffic_stats:5_m:block_gas_cost:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2750,7 +2798,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:tx_gas_cost:metric",
+          "expr": "client_status:traffic_stats:1_h:block_gas_cost:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -2759,7 +2807,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "tx_gas_cost",
+      "title": "block_gas_cost",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2885,7 +2933,7 @@
         "y": 128
       },
       "hiddenSeries": false,
-      "id": 42,
+      "id": 80,
       "legend": {
         "avg": false,
         "current": false,
@@ -2913,31 +2961,31 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:json_rpc_get:rate",
+          "expr": "client_status:traffic_stats:1_m:tx_bytes:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:json_rpc_get:rate",
+          "expr": "client_status:traffic_stats:5_m:tx_bytes:metric",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:tx_bytes:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:json_rpc_get:rate",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "G"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "json_rpc_get:rate",
+      "title": "tx_bytes",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3047,12 +3095,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3062,7 +3104,7 @@
         "y": 136
       },
       "hiddenSeries": false,
-      "id": 64,
+      "id": 82,
       "legend": {
         "avg": false,
         "current": false,
@@ -3090,14 +3132,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:json_rpc_get:metric",
+          "expr": "client_status:traffic_stats:1_m:tx_op_size:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:json_rpc_get:metric",
+          "expr": "client_status:traffic_stats:5_m:tx_op_size:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3105,7 +3147,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:json_rpc_get:metric",
+          "expr": "client_status:traffic_stats:1_h:tx_op_size:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3114,7 +3156,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "json_rpc_get:metric (latency)",
+      "title": "tx_op_size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3225,12 +3267,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3240,7 +3276,7 @@
         "y": 144
       },
       "hiddenSeries": false,
-      "id": 52,
+      "id": 78,
       "legend": {
         "avg": false,
         "current": false,
@@ -3268,14 +3304,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:json_rpc_set:rate",
+          "expr": "client_status:traffic_stats:1_m:tx_gas_amount:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:json_rpc_set:rate",
+          "expr": "client_status:traffic_stats:5_m:tx_gas_amount:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3283,7 +3319,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:json_rpc_set:rate",
+          "expr": "client_status:traffic_stats:1_h:tx_gas_amount:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3292,7 +3328,195 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "json_rpc_set:rate",
+      "title": "tx_gas_amount",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 145
+      },
+      "hiddenSeries": false,
+      "id": 42,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_m:json_rpc_get:rate",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:5_m:json_rpc_get:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:json_rpc_get:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "json_rpc_get:rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 152
+      },
+      "hiddenSeries": false,
+      "id": 76,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_m:tx_gas_cost:metric",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:5_m:tx_gas_cost:metric",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:tx_gas_cost:metric",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "tx_gas_cost",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3336,11 +3560,11 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 152
+        "x": 0,
+        "y": 153
       },
       "hiddenSeries": false,
-      "id": 62,
+      "id": 64,
       "legend": {
         "avg": false,
         "current": false,
@@ -3368,14 +3592,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:json_rpc_set:metric",
+          "expr": "client_status:traffic_stats:1_m:json_rpc_get:metric",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:json_rpc_set:metric",
+          "expr": "client_status:traffic_stats:5_m:json_rpc_get:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3383,7 +3607,7 @@
         },
         {
           "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:json_rpc_set:metric",
+          "expr": "client_status:traffic_stats:1_h:json_rpc_get:metric",
           "hide": false,
           "interval": "",
           "legendFormat": "",
@@ -3392,7 +3616,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "json_rpc_set:metric (latency)",
+      "title": "json_rpc_get:metric (latency)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3536,6 +3760,106 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 161
+      },
+      "hiddenSeries": false,
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_m:json_rpc_set:rate",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:5_m:json_rpc_set:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:json_rpc_set:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "json_rpc_set:rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
         "x": 12,
         "y": 168
       },
@@ -3594,6 +3918,106 @@
       "thresholds": [],
       "timeRegions": [],
       "title": "p_2_p_message_server:metric (latency)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 169
+      },
+      "hiddenSeries": false,
+      "id": 62,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_m:json_rpc_set:metric",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:5_m:json_rpc_set:metric",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:json_rpc_set:metric",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "json_rpc_set:metric (latency)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3688,6 +4112,100 @@
       "thresholds": [],
       "timeRegions": [],
       "title": "p_2_p_message_client:rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "hiddenSeries": false,
+      "id": 44,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_m:client_api_get:rate",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:5_m:client_api_get:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "client_status:traffic_stats:1_h:client_api_get:rate",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "client_api_get:rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3820,100 +4338,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 192
-      },
-      "hiddenSeries": false,
-      "id": 44,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "client_status:traffic_stats:1_m:client_api_get:rate",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "client_status:traffic_stats:5_m:client_api_get:rate",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "client_status:traffic_stats:1_h:client_api_get:rate",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "G"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "client_api_get:rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "fieldConfig": {
         "defaults": {
           "unit": "short"
@@ -3925,8 +4349,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 200
+        "x": 0,
+        "y": 185
       },
       "hiddenSeries": false,
       "id": 60,
@@ -4025,8 +4449,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 208
+        "x": 0,
+        "y": 193
       },
       "hiddenSeries": false,
       "id": 50,
@@ -4125,8 +4549,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 216
+        "x": 0,
+        "y": 201
       },
       "hiddenSeries": false,
       "id": 58,
@@ -4218,13 +4642,13 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Blockchain Servers",
   "uid": "M6YpMSyMz",
-  "version": 21,
+  "version": 23,
   "weekStart": ""
 }

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -297,8 +297,11 @@ class P2pClient {
     }
   }
 
-  broadcastConsensusMessage(consensusMessage) {
-    const payload = encapsulateMessage(MessageTypes.CONSENSUS, { message: consensusMessage });
+  broadcastConsensusMessage(consensusMessage, tags = []) {
+    if (DevFlags.enableP2pMessageTags) {
+      tags.push(this.server.node.account.address);
+    }
+    const payload = encapsulateMessage(MessageTypes.CONSENSUS, { message: consensusMessage, tags });
     if (!payload) {
       logger.error('The consensus msg cannot be broadcasted because of msg encapsulation failure.');
       return;
@@ -345,8 +348,11 @@ class P2pClient {
     socket.send(JSON.stringify(payload));
   }
 
-  broadcastTransaction(transaction) {
-    const payload = encapsulateMessage(MessageTypes.TRANSACTION, { transaction: transaction });
+  broadcastTransaction(transaction, tags = []) {
+    if (DevFlags.enableP2pMessageTags) {
+      tags.push(this.server.node.account.address);
+    }
+    const payload = encapsulateMessage(MessageTypes.TRANSACTION, { transaction, tags });
     if (!payload) {
       logger.error('The transaction cannot be broadcasted because of msg encapsulation failure.');
       return;

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -515,9 +515,11 @@ class P2pServer {
                 `${JSON.stringify(consensusMessage)}`);
             if (DevFlags.enableP2pMessageTags) {
               logger.debug(`[${LOG_HEADER}] Tags attached to a consensus message: ${JSON.stringify(consensusTags)}`);
-              trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, consensusTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_OCCUR, CommonUtil.countMaxOccurrences(consensusTags));
+                    TrafficEventTypes.P2P_TAG_CONSENSUS_LENGTH, consensusTags.length);
+              trafficStatsManager.addEvent(
+                  TrafficEventTypes.P2P_TAG_CONSENSUS_MAX_OCCUR,
+                  CommonUtil.countMaxOccurrences(consensusTags));
             }
             if (this.node.state === BlockchainNodeStates.SERVING) {
               this.consensus.handleConsensusMessage(consensusMessage, consensusTags);
@@ -544,9 +546,9 @@ class P2pServer {
             logger.debug(`[${LOG_HEADER}] Receiving a transaction: ${JSON.stringify(tx)}`);
             if (DevFlags.enableP2pMessageTags) {
               logger.debug(`[${LOG_HEADER}] Tags attached to a tx message: ${JSON.stringify(txTags)}`);
-              trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, txTags.length);
+              trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_TX_LENGTH, txTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_OCCUR, CommonUtil.countMaxOccurrences(txTags));
+                  TrafficEventTypes.P2P_TAG_TX_MAX_OCCUR, CommonUtil.countMaxOccurrences(txTags));
             }
             if (this.node.tp.transactionTracker[tx.hash]) {
               logger.debug(`[${LOG_HEADER}] Already have the transaction in my tx tracker`);

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -510,10 +510,17 @@ class P2pServer {
               return;
             }
             const consensusMessage = _.get(parsedMessage, 'data.message');
+            const consensusTags = _.get(parsedMessage, 'data.tags', []);
             logger.debug(`[${LOG_HEADER}] Receiving a consensus message: ` +
                 `${JSON.stringify(consensusMessage)}`);
+            if (DevFlags.enableP2pMessageTags) {
+              logger.debug(`[${LOG_HEADER}] Tags attached to a consensus message: ${JSON.stringify(consensusTags)}`);
+              trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, consensusTags.length);
+              trafficStatsManager.addEvent(
+                  TrafficEventTypes.P2P_TAG_MAX_DUPLICATE, CommonUtil.countMaxOccurrences(consensusTags));
+            }
             if (this.node.state === BlockchainNodeStates.SERVING) {
-              this.consensus.handleConsensusMessage(consensusMessage);
+              this.consensus.handleConsensusMessage(consensusMessage, consensusTags);
             } else {
               logger.info(`\n [${LOG_HEADER}] Needs syncing...\n`);
               this.client.requestChainSegment();
@@ -533,7 +540,14 @@ class P2pServer {
               // this.convertTransactionMessage();
             }
             const tx = _.get(parsedMessage, 'data.transaction');
+            const txTags = _.get(parsedMessage, 'data.tags', []);
             logger.debug(`[${LOG_HEADER}] Receiving a transaction: ${JSON.stringify(tx)}`);
+            if (DevFlags.enableP2pMessageTags) {
+              logger.debug(`[${LOG_HEADER}] Tags attached to a tx message: ${JSON.stringify(txTags)}`);
+              trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, txTags.length);
+              trafficStatsManager.addEvent(
+                  TrafficEventTypes.P2P_TAG_MAX_DUPLICATE, CommonUtil.countMaxOccurrences(txTags));
+            }
             if (this.node.tp.transactionTracker[tx.hash]) {
               logger.debug(`[${LOG_HEADER}] Already have the transaction in my tx tracker`);
               const latency = Date.now() - beginTime;
@@ -559,7 +573,7 @@ class P2pServer {
                 newTxList.push(createdTx);
               }
               if (newTxList.length > 0) {
-                this.executeAndBroadcastTransaction({ tx_list: newTxList });
+                this.executeAndBroadcastTransaction({ tx_list: newTxList }, txTags);
               }
             } else {
               const createdTx = Transaction.create(tx.tx_body, tx.signature);
@@ -567,7 +581,7 @@ class P2pServer {
                 logger.info(`[${LOG_HEADER}] Failed to create a transaction for tx: ` +
                   `${JSON.stringify(tx, null, 2)}`);
               } else {
-                this.executeAndBroadcastTransaction(createdTx);
+                this.executeAndBroadcastTransaction(createdTx, txTags);
               }
             }
             break;
@@ -659,7 +673,7 @@ class P2pServer {
     socket.send(JSON.stringify(payload));
   }
 
-  executeAndBroadcastTransaction(tx) {
+  executeAndBroadcastTransaction(tx, tags = []) {
     const LOG_HEADER = 'executeAndBroadcastTransaction';
     if (!tx) {
       return {
@@ -695,7 +709,7 @@ class P2pServer {
       }
       logger.debug(`\n BATCH TX RESULT: ` + JSON.stringify(resultList));
       if (txListSucceeded.length > 0) {
-        this.client.broadcastTransaction({ tx_list: txListSucceeded });
+        this.client.broadcastTransaction({ tx_list: txListSucceeded }, tags);
       }
 
       return resultList;
@@ -703,7 +717,7 @@ class P2pServer {
       const result = this.node.executeTransactionAndAddToPool(tx);
       logger.debug(`\n TX RESULT: ` + JSON.stringify(result));
       if (!CommonUtil.isFailedTx(result)) {
-        this.client.broadcastTransaction(tx);
+        this.client.broadcastTransaction(tx, tags);
       }
 
       return {

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -517,7 +517,7 @@ class P2pServer {
               logger.debug(`[${LOG_HEADER}] Tags attached to a consensus message: ${JSON.stringify(consensusTags)}`);
               trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, consensusTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_OCCURRENCES, CommonUtil.countMaxOccurrences(consensusTags));
+                  TrafficEventTypes.P2P_TAG_MAX_OCCUR, CommonUtil.countMaxOccurrences(consensusTags));
             }
             if (this.node.state === BlockchainNodeStates.SERVING) {
               this.consensus.handleConsensusMessage(consensusMessage, consensusTags);
@@ -546,7 +546,7 @@ class P2pServer {
               logger.debug(`[${LOG_HEADER}] Tags attached to a tx message: ${JSON.stringify(txTags)}`);
               trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, txTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_OCCURRENCES, CommonUtil.countMaxOccurrences(txTags));
+                  TrafficEventTypes.P2P_TAG_MAX_OCCUR, CommonUtil.countMaxOccurrences(txTags));
             }
             if (this.node.tp.transactionTracker[tx.hash]) {
               logger.debug(`[${LOG_HEADER}] Already have the transaction in my tx tracker`);

--- a/p2p/server.js
+++ b/p2p/server.js
@@ -517,7 +517,7 @@ class P2pServer {
               logger.debug(`[${LOG_HEADER}] Tags attached to a consensus message: ${JSON.stringify(consensusTags)}`);
               trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, consensusTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_DUPLICATE, CommonUtil.countMaxOccurrences(consensusTags));
+                  TrafficEventTypes.P2P_TAG_MAX_OCCURRENCES, CommonUtil.countMaxOccurrences(consensusTags));
             }
             if (this.node.state === BlockchainNodeStates.SERVING) {
               this.consensus.handleConsensusMessage(consensusMessage, consensusTags);
@@ -546,7 +546,7 @@ class P2pServer {
               logger.debug(`[${LOG_HEADER}] Tags attached to a tx message: ${JSON.stringify(txTags)}`);
               trafficStatsManager.addEvent(TrafficEventTypes.P2P_TAG_LENGTH, txTags.length);
               trafficStatsManager.addEvent(
-                  TrafficEventTypes.P2P_TAG_MAX_DUPLICATE, CommonUtil.countMaxOccurrences(txTags));
+                  TrafficEventTypes.P2P_TAG_MAX_OCCURRENCES, CommonUtil.countMaxOccurrences(txTags));
             }
             if (this.node.tp.transactionTracker[tx.hash]) {
               logger.debug(`[${LOG_HEADER}] Already have the transaction in my tx tracker`);


### PR DESCRIPTION
- Added tags to know how many nodes has a broadcasted message (tx, consensus) visited before reaching me
- Added related traffic events (p2p_tag_length, p2p_tag_max_occurrences)
- Added enableP2pMessageTags to DevFlags to control the feature