### PR TITLE
Feature/minsulee2/keep more api nodes

### DIFF
--- a/p2p/index.js
+++ b/p2p/index.js
@@ -271,6 +271,9 @@ class P2pClient {
       return;
     }
     const randomPeerAddress = _.shuffle(addressArray)[0];
+    if (!this.outbound[randomPeerAddress]) {
+      return;
+    }
     this.closeSocketWithP2pStateUpdate(this.outbound[randomPeerAddress].socket);
   }
 

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -292,12 +292,10 @@ class P2pClient {
       const whitelist = this.server.node.db.getValue('/consensus/proposer_whitelist');
       const [whitelisted, notWhitelisted] =
           _.partition(bidirectedConnections, ((address) => whitelist[address]));
-      const whitelistDisconnectThreshold = Math.round(NodeConfigs.MAX_NUM_INBOUND_CONNECTION / 2);
-      if (whitelisted.length > whitelistDisconnectThreshold) {
-        const numDisconnectionCandidates = whitelisted.length - whitelistDisconnectThreshold;
-        const randomWhiteListed = _.shuffle(whitelisted).slice(0, numDisconnectionCandidates);
-        const disconnectionCandidates = _.concat(randomWhiteListed, notWhitelisted);
-        this.pickRandomPeerAndDisconnect(disconnectionCandidates);
+      const whitelistDisconnectThreshold = Math.floor(NodeConfigs.MAX_NUM_INBOUND_CONNECTION / 2);
+      // NOTE(minsulee2): Keep less than majority whitelisted.
+      if (whitelisted.length >= whitelistDisconnectThreshold) {
+        this.pickRandomPeerAndDisconnect(whitelisted);
       } else {
         this.pickRandomPeerAndDisconnect(notWhitelisted);
       }

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -286,6 +286,8 @@ class P2pClient {
     const bidirectedConnections = Object.keys(this.outbound).filter(address => {
       return Object.keys(this.server.inbound).includes(address);
     });
+    // NOTE(minsulee2): ENABLE_JSON_RPC_API === true means API server nodes for now.
+    // TODO(minsulee2): Need to introduce a new flag which marks a 'bridge node' role.
     if (NodeConfigs.ENABLE_JSON_RPC_API) {
       const whitelist = this.server.node.db.getValue('/consensus/proposer_whitelist');
       const [whitelisted, notWhitelisted] =

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -266,6 +266,14 @@ class P2pClient {
     this.updateP2pState();
   }
 
+  pickRandomPeerAndDisconnect(addressArray) {
+    if (addressArray.length === 0) {
+      return;
+    }
+    const randomPeerAddress = _.shuffle(addressArray)[0];
+    this.closeSocketWithP2pStateUpdate(this.outbound[randomPeerAddress].socket);
+  }
+
   disconnectRandomPeer() {
     if (Object.keys(this.outbound) === 0) {
       return;
@@ -275,8 +283,22 @@ class P2pClient {
     const bidirectedConnections = Object.keys(this.outbound).filter(address => {
       return Object.keys(this.server.inbound).includes(address);
     });
-    const randomPeerAddress = _.shuffle(bidirectedConnections)[0];
-    this.closeSocketWithP2pStateUpdate(this.outbound[randomPeerAddress].socket);
+    if (NodeConfigs.ENABLE_JSON_RPC_API) {
+      const whitelist = this.server.node.db.getValue('/consensus/proposer_whitelist');
+      const [whitelisted, notWhitelisted] =
+          _.partition(bidirectedConnections, ((address) => whitelist[address]));
+      const whitelistDisconnectThreshold = Math.round(NodeConfigs.MAX_NUM_INBOUND_CONNECTION / 2);
+      if (whitelisted.length > whitelistDisconnectThreshold) {
+        const numDisconnectionCandidates = whitelisted.length - whitelistDisconnectThreshold;
+        const randomWhiteListed = _.shuffle(whitelisted).slice(0, numDisconnectionCandidates);
+        const disconnectionCandidates = _.concat(randomWhiteListed, notWhitelisted);
+        this.pickRandomPeerAndDisconnect(disconnectionCandidates);
+      } else {
+        this.pickRandomPeerAndDisconnect(notWhitelisted);
+      }
+    } else {
+      this.pickRandomPeerAndDisconnect(bidirectedConnections);
+    }
   }
 
   async tryReorgPeerConnections() {


### PR DESCRIPTION
Keep a half of whitelisted(block generation) nodes when reorg.

- Disconnect any nodes if ENABLE_JSON_RPC_API is false
- Disconnect whitelisted if they are more than majority, do not disconnect otherwise.