### PR TITLE
Ignore minimalNTPLatencyDelta that's too big/small

### DIFF
--- a/consensus/index.js
+++ b/consensus/index.js
@@ -161,8 +161,11 @@ class Consensus {
           try {
             const iNTPData = await ntpsync.ntpLocalClockDeltaPromise();
             logger.debug(`(Local Time - NTP Time) Delta = ${iNTPData.minimalNTPLatencyDelta} ms`);
-            this.timeAdjustment = iNTPData.minimalNTPLatencyDelta;
-            this.ntpData = { ...iNTPData, syncedAt: Date.now() };
+            if (Math.abs(iNTPData.minimalNTPLatencyDelta) < 10000) {
+              // Ignore if the value is too big/small.
+              this.timeAdjustment = iNTPData.minimalNTPLatencyDelta;
+              this.ntpData = { ...iNTPData, syncedAt: Date.now() };
+            }
           } catch (err) {
             logger.error(`ntpsync error: ${err} ${err.stack}`);
           }


### PR DESCRIPTION
Sandbox node 14 stopped because of minimalNTPLatencyDelta that's too big, causing currentTime to be less than startingTime. Updated to ignore minimalNTPLatencyDelta values that are too small/big.

Following is the last ntpsync result from node 14 before it stopped.
```
{
    "averageNTPDelta": 962443388956.375,
    "averageNTPLatency": 9.75,
    "minimalNTPLatencyDelta": 3849773555827,
    "minimalNTPLatency": 8,
    "totalSampleCount": 4,
    "syncedAt": 1640784755831
}
```