### PR TITLE
Correctly get GPT2 version compatibility

### DIFF
--- a/tools/cicd/deployment.js
+++ b/tools/cicd/deployment.js
@@ -97,7 +97,7 @@ const main = async () => {
 
   // Get versions
   const ainJsVersion = getVersion(`${AINJS}/src`, 'constants.ts', 'BLOCKCHAIN_PROTOCOL_VERSION', 4);
-  const GPT2Version = getVersion(`${GPT2}/functions`, 'util.js', 'CURRENT_PROTOCOL_VERSION', 3);
+  const GPT2Version = getVersionFromAinJs(ainJsVersion, `${GPT2}/functions`);
   const insightVersion = getVersion(`${INSIGHT}/src/data/constants`, 'const.js', 'VERSION', 1);
   const faucetVersion = getVersionFromAinJs(ainJsVersion, FAUCET);
   const connectVersion = faucetVersion;


### PR DESCRIPTION
As release/v0.9.4 has declined. This fix has been missing.