### PR TITLE
Support incremental deploy w/ code updates

### DIFF
--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
+if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
     printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code] [--keep-data] [--kill-only|--skip-kill]\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev lia 0 --setup --keystore\n"
     printf "\n"

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
-    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--restart|--reset] [--kill-only|--skip-kill]\n"
+    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code] [--keep-data] [--kill-only|--skip-kill]\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev lia 0 --setup --keystore\n"
     printf "\n"
     exit
@@ -58,18 +58,10 @@ function parse_options() {
             exit
         fi
         ACCOUNT_INJECTION_OPTION="$option"
-    elif [[ $option = '--restart' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
-    elif [[ $option = '--reset' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
+    elif [[ $option = '--keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
     elif [[ $option = '--kill-only' ]]; then
         if [[ "$KILL_OPTION" ]]; then
             printf "You cannot use both --skip-kill and --kill-only\n"
@@ -91,7 +83,8 @@ function parse_options() {
 # Parse options.
 SETUP_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
-RESET_RESTART_OPTION=""
+KEEP_CODE_OPTION=""
+KEEP_DATA_OPTION=""
 KILL_OPTION=""
 
 ARG_INDEX=4
@@ -102,7 +95,8 @@ do
 done
 printf "SETUP_OPTION=$SETUP_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
-printf "RESET_RESTART_OPTION=$RESET_RESTART_OPTION\n"
+printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "KILL_OPTION=$KILL_OPTION\n"
 
 if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
@@ -235,7 +229,7 @@ if [[ $KILL_OPTION = "--kill-only" ]]; then
 fi
 
 # deploy files to GCP instances
-if [[ $RESET_RESTART_OPTION = "" ]]; then
+if [[ $KEEP_CODE_OPTION = "" ]]; then
     printf "\nDeploying parent blockchain...\n\n"
     printf "\nDeploying files to parent tracker (${TRACKER_TARGET_ADDR})...\n\n"
     gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ --project $PROJECT_ID --zone $TRACKER_ZONE
@@ -288,33 +282,32 @@ if [[ $SETUP_OPTION = "--setup" ]]; then
 fi
 
 printf "\nStarting blockchain servers...\n\n"
-if [[ $RESET_RESTART_OPTION = "--reset" ]]; then
-    # restart after removing chains, snapshots, and log files
+if [[ $KEEP_CODE_OPTION = "" ]]; then
+    GO_TO_PROJECT_ROOT_CMD="cd ."
+else
+    GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d)"
+fi
+if [[ $KEEP_DATA_OPTION = "" ]]; then
+    # restart after removing chains, snapshots, and log files (but keep the keys)
     CHAINS_DIR=/home/ain_blockchain_data/chains
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
-    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_tracker_genesis_gcp.sh"
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR && cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
-elif [[ $RESET_RESTART_OPTION = "--restart" ]]; then
-    # restart
-    START_TRACKER_CMD_BASE="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_tracker_genesis_gcp.sh"
-    START_NODE_CMD_BASE="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
+    LOGS_DIR=/home/ain_blockchain_data/logs
+    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_genesis_gcp.sh"
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_genesis_gcp.sh"
 else
-    # start
-    START_TRACKER_CMD_BASE=". start_tracker_genesis_gcp.sh"
-    START_NODE_CMD_BASE=". start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION=""
+    # restart with existing chains, snapshots, and log files
+    START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_genesis_gcp.sh"
+    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_genesis_gcp.sh"
 fi
 printf "\n"
 printf "START_TRACKER_CMD_BASE=$START_TRACKER_CMD_BASE\n"
 printf "START_NODE_CMD_BASE=$START_NODE_CMD_BASE\n"
-printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 
 printf "\n\n###########################\n# Starting parent tracker #\n###########################\n\n"
 
 printf "\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
 printf "START_TRACKER_CMD=$START_TRACKER_CMD\n"
 eval $START_TRACKER_CMD
@@ -335,12 +328,13 @@ do
     NODE_ZONE=NODE_${node_index}_ZONE
 
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+    printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
     printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD
     inject_account "$node_index"
@@ -365,7 +359,7 @@ if [[ $NUM_SHARDS -gt 0 ]]; then
             SHARD_NODE_2_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-2-singapore"
 
             # deploy files to GCP instances
-            if [[ $RESET_RESTART_OPTION = "" ]]; then
+            if [[ $KEEP_CODE_OPTION = "" ]]; then
                 printf "\nDeploying files to shard_$i tracker (${SHARD_TRACKER_TARGET_ADDR})...\n\n"
                 gcloud compute scp --recurse $FILES_FOR_TRACKER ${SHARD_TRACKER_TARGET_ADDR}:~/ --project $PROJECT_ID --zone $TRACKER_ZONE
                 printf "\nDeploying files to shard_$i node 0 (${SHARD_NODE_0_TARGET_ADDR})...\n\n"
@@ -394,15 +388,15 @@ if [[ $NUM_SHARDS -gt 0 ]]; then
             printf "START_TRACKER_CMD=$START_TRACKER_CMD\n"
             eval $START_TRACKER_CMD
             printf "\n\n##########################\n# Starting shard_$i node 0 #\n##########################\n\n"
-            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $NODE_0_ZONE"
+            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_0_ZONE"
             printf "START_NODE_CMD=$START_NODE_CMD\n"
             eval $START_NODE_CMD
             printf "\n\n##########################\n# Starting shard_$i node 1 #\n##########################\n\n"
-            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $NODE_1_ZONE"
+            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_1_ZONE"
             printf "START_NODE_CMD=$START_NODE_CMD\n"
             eval $START_NODE_CMD
             printf "\n\n##########################\n# Starting shard_$i node 2 #\n##########################\n\n"
-            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $NODE_2_ZONE"
+            START_NODE_CMD="gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_2_ZONE"
             printf "START_NODE_CMD=$START_NODE_CMD\n"
             eval $START_NODE_CMD
         done

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 3 ]] || [[ $# -gt 9 ]]; then
-    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--canary] [--full-sync] [--keystore|--mnemonic|--private-key] [--restart|--reset]\n"
+    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--canary] [--full-sync] [--keystore|--mnemonic|--private-key] [--keep-code] [--keep-data]\n"
     printf "Example: bash deploy_blockchain_incremental_gcp.sh dev lia 0 --setup --canary --full-sync --keystore\n"
     printf "\n"
     exit
@@ -61,18 +61,10 @@ function parse_options() {
             exit
         fi
         ACCOUNT_INJECTION_OPTION="$option"
-    elif [[ $option = '--restart' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
-    elif [[ $option = '--reset' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
+    elif [[ $option = '--keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
     else
         printf "Invalid option: $option\n"
         exit
@@ -84,7 +76,8 @@ SETUP_OPTION=""
 RUN_MODE_OPTION=""
 FULL_SYNC_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
-RESET_RESTART_OPTION=""
+KEEP_CODE_OPTION=""
+KEEP_DATA_OPTION=""
 
 ARG_INDEX=4
 while [ $ARG_INDEX -le $# ]
@@ -97,7 +90,8 @@ printf "SETUP_OPTION=$SETUP_OPTION\n"
 printf "RUN_MODE_OPTION=$RUN_MODE_OPTION\n"
 printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
-printf "RESET_RESTART_OPTION=$RESET_RESTART_OPTION\n"
+printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 
 if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
     printf "Must provide an ACCOUNT_INJECTION_OPTION\n"
@@ -158,7 +152,7 @@ function deploy_tracker() {
     printf "TRACKER_TARGET_ADDR='$TRACKER_TARGET_ADDR'\n"
     printf "TRACKER_ZONE='$TRACKER_ZONE'\n"
 
-    if [[ $RESET_RESTART_OPTION = "" ]]; then
+    if [[ $KEEP_CODE_OPTION = "" ]]; then
         # 1. Copy files for tracker
         printf "\n\n[[[ Copying files for tracker ]]]\n\n"
         SCP_CMD="gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ --project $PROJECT_ID --zone $TRACKER_ZONE"
@@ -196,7 +190,7 @@ function deploy_node() {
     printf "node_target_addr='$node_target_addr'\n"
     printf "node_zone='$node_zone'\n"
 
-    if [[ $RESET_RESTART_OPTION = "" ]]; then
+    if [[ $KEEP_CODE_OPTION = "" ]]; then
         # 1. Copy files for node
         printf "\n\n<<< Copying files for node $node_index >>>\n\n"
         SCP_CMD="gcloud compute scp --recurse $FILES_FOR_NODE ${node_target_addr}:~/ --project $PROJECT_ID --zone $node_zone"
@@ -224,13 +218,14 @@ function deploy_node() {
     fi
 
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+    printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
     printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
     printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $FULL_SYNC_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION' --project $PROJECT_ID --zone $node_zone"
+    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $FULL_SYNC_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION' --project $PROJECT_ID --zone $node_zone"
     printf "START_NODE_CMD=$START_NODE_CMD\n\n"
     eval $START_NODE_CMD
 
@@ -289,23 +284,22 @@ NODE_TARGET_ADDR_LIST=(
 )
 
 printf "\nStarting blockchain servers...\n\n"
-if [[ $RESET_RESTART_OPTION = "--reset" ]]; then
-    # restart after removing chains, snapshots, and log files
+if [[ $KEEP_CODE_OPTION = "" ]]; then
+    GO_TO_PROJECT_ROOT_CMD="cd ."
+else
+    GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d)"
+fi
+if [[ $KEEP_DATA_OPTION = "" ]]; then
+    # restart after removing chains, snapshots, and log files (but keep the keys)
     CHAINS_DIR=/home/ain_blockchain_data/chains
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
-    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR && cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_incremental_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
-elif [[ $RESET_RESTART_OPTION = "--restart" ]]; then
-    # restart
-    START_TRACKER_CMD_BASE="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_incremental_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
+    LOGS_DIR=/home/ain_blockchain_data/logs
+    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && cd $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
 else
-    # start
-    START_TRACKER_CMD_BASE=". start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE=". start_node_incremental_gcp.sh"
-    KEEP_CODE_OPTION=""
+    # restart with existing chains, snapshots, and log files
+    START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
 fi
 
 if [[ $RUN_MODE_OPTION = "--canary" ]]; then

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -295,7 +295,7 @@ if [[ $KEEP_DATA_OPTION = "" ]]; then
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
     LOGS_DIR=/home/ain_blockchain_data/logs
     START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && cd $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
 else
     # restart with existing chains, snapshots, and log files
     START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -248,6 +248,7 @@ function deploy_node() {
             echo 0
         } | node inject_account_gcp.js $node_ip_addr $ACCOUNT_INJECTION_OPTION
     else
+        local node_ip_addr=${IP_ADDR_LIST[${node_index}]}
         printf "\n* >> Injecting an account for node $node_index ********************\n\n"
         printf "node_ip_addr='$node_ip_addr'\n"
         local GENESIS_ACCOUNTS_PATH="blockchain-configs/base/genesis_accounts.json"

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 6 ]]; then
+if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
     printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--keep-code] [--keep-data] [--kill-only|--skip-kill]\n"
     printf "Example: bash deploy_blockchain_sandbox_gcp.sh lia 10 99 --setup\n"
     printf "\n"

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 3 ]] || [[ $# -gt 6 ]]; then
-    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--restart|--reset] [--kill-only|--skip-kill]\n"
+    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--keep-code] [--keep-data] [--kill-only|--skip-kill]\n"
     printf "Example: bash deploy_blockchain_sandbox_gcp.sh lia 10 99 --setup\n"
     printf "\n"
     exit
@@ -31,18 +31,10 @@ function parse_options() {
     local option="$1"
     if [[ $option = '--setup' ]]; then
         SETUP_OPTION="$option"
-    elif [[ $option = '--restart' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
-    elif [[ $option = '--reset' ]]; then
-        if [[ "$RESET_RESTART_OPTION" ]]; then
-            printf "You cannot use both restart and reset\n"
-            exit
-        fi
-        RESET_RESTART_OPTION="$option"
+    elif [[ $option = '--keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
     elif [[ $option = '--kill-only' ]]; then
         if [[ "$KILL_OPTION" ]]; then
             printf "You cannot use both --skip-kill and --kill-only\n"
@@ -63,7 +55,8 @@ function parse_options() {
 
 # Parse options.
 SETUP_OPTION=""
-RESET_RESTART_OPTION=""
+KEEP_CODE_OPTION=""
+KEEP_DATA_OPTION=""
 KILL_OPTION=""
 
 ARG_INDEX=4
@@ -73,7 +66,8 @@ do
   ((ARG_INDEX++))
 done
 printf "SETUP_OPTION=$SETUP_OPTION\n"
-printf "RESET_RESTART_OPTION=$RESET_RESTART_OPTION\n"
+printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "KILL_OPTION=$KILL_OPTION\n"
 
 
@@ -347,7 +341,7 @@ if [[ $KILL_OPTION = "--kill-only" ]]; then
 fi
 
 # deploy files to GCP instances
-if [[ $RESET_RESTART_OPTION = "" ]]; then
+if [[ $KEEP_CODE_OPTION = "" ]]; then
     printf "\nDeploying parent blockchain...\n"
     index=$START_NODE_IDX
     while [ $index -le $END_NODE_IDX ]
@@ -393,24 +387,25 @@ if [[ $SETUP_OPTION = "--setup" ]]; then
 fi
 
 printf "\nStarting blockchain servers...\n\n"
-if [[ $RESET_RESTART_OPTION = "--reset" ]]; then
-    # restart after removing chains, snapshots, and log files
+if [[ $KEEP_CODE_OPTION = "" ]]; then
+    GO_TO_PROJECT_ROOT_CMD="cd ."
+else
+    GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d)"
+fi
+if [[ $KEEP_DATA_OPTION = "" ]]; then
+    # restart after removing chains, snapshots, and log files (but keep the keys)
     CHAINS_DIR=/home/ain_blockchain_data/chains
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR && cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
-elif [[ $RESET_RESTART_OPTION = "--restart" ]]; then
-    # restart
-    START_NODE_CMD_BASE="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d) && . start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION="--keep-code"
+    LOGS_DIR=/home/ain_blockchain_data/logs
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_genesis_gcp.sh"
 else
-    # start
-    START_NODE_CMD_BASE=". start_node_genesis_gcp.sh"
-    KEEP_CODE_OPTION=""
+    # restart with existing chains, snapshots, and log files
+    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_genesis_gcp.sh"
 fi
 printf "\n"
 printf "START_NODE_CMD_BASE=$START_NODE_CMD_BASE\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 
 node_index=$START_NODE_IDX
 while [ $node_index -le $END_NODE_IDX ]
@@ -427,11 +422,12 @@ do
     NODE_ZONE=NODE_${node_index}_ZONE
 
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+    printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $JSON_RPC_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
     # printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD

--- a/node/index.js
+++ b/node/index.js
@@ -519,8 +519,8 @@ class BlockchainNode {
   }
 
   getRewards() {
-    return this.db.getValue(CommonUtil.formatPath(
-        [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_REWARDS, this.account.address]));
+    return this.account ? this.db.getValue(CommonUtil.formatPath(
+        [PredefinedDbPaths.CONSENSUS, PredefinedDbPaths.CONSENSUS_REWARDS, this.account.address])) : null;
   }
 
   // TODO(liayoo): Rename lastBlockNumber to finalBlockNumber.
@@ -571,6 +571,7 @@ class BlockchainNode {
   }
 
   createSingleTransaction(txBody) {
+    if (!this.account) return null;
     if (txBody.nonce === undefined) {
       txBody.nonce = this.getNonce();
     }

--- a/p2p/index.js
+++ b/p2p/index.js
@@ -367,6 +367,7 @@ class P2pClient {
         return;
       }
       logger.info(`[${LOG_HEADER}] Trying to initializing shard..`);
+      // TODO(liayoo): Move this to after node account is injected.
       if (await this.server.tryInitializeShard()) {
         logger.info(`[${LOG_HEADER}] Shard initialization done!`);
       } else {

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # NOTE(minsulee2): Since exit really exits terminals, those are replaced to return 1.
-if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
+if [[ $# -lt 3 ]] || [[ $# -gt 9 ]]; then
     printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--keep-data] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_genesis_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
     printf "\n"

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -2,7 +2,7 @@
 
 # NOTE(minsulee2): Since exit really exits terminals, those are replaced to return 1.
 if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
-    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
+    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--keep-data] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_genesis_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
     printf "\n"
     return 1
@@ -13,6 +13,8 @@ function parse_options() {
     local option="$1"
     if [[ $option = '--keep-code' ]]; then
         KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
     elif [[ $option = '--full-sync' ]]; then
         FULL_SYNC_OPTION="$option"
     elif [[ $option = '--keystore' ]]; then
@@ -63,6 +65,7 @@ fi
 NODE_INDEX="$3"
 
 KEEP_CODE_OPTION=""
+KEEP_DATA_OPTION=""
 FULL_SYNC_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
 JSON_RPC_OPTION=""
@@ -80,6 +83,7 @@ printf "SHARD_INDEX=$SHARD_INDEX\n"
 printf "NODE_INDEX=$NODE_INDEX\n"
 
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
@@ -122,15 +126,22 @@ fi
 printf '\n'
 printf 'Killing old jobs..\n'
 sudo killall node
-
+if [[ $KEEP_DATA_OPTION = "" ]]; then
+    printf '\n'
+    printf 'Removing old data..\n'
+    sudo rm -rf /home/ain_blockchain_data/chains
+    sudo rm -rf /home/ain_blockchain_data/snapshots
+    sudo rm -rf /home/ain_blockchain_data/logs
+    sudo mkdir -p /home/ain_blockchain_data
+    sudo chmod -R 777 /home/ain_blockchain_data
+else
+    sudo mkdir -p /home/ain_blockchain_data
+    sudo chmod -R 777 /home/ain_blockchain_data
+fi
 if [[ $KEEP_CODE_OPTION = "" ]]; then
     printf '\n'
     printf 'Setting up working directory..\n'
     cd
-    sudo rm -rf /home/ain_blockchain_data
-    sudo mkdir /home/ain_blockchain_data
-    sudo chmod -R 777 /home/ain_blockchain_data
-
     sudo rm -rf ../ain-blockchain*
     sudo mkdir ../ain-blockchain
     sudo chmod -R 777 ../ain-blockchain
@@ -146,7 +157,6 @@ else
     OLD_DIR_PATH=$(find ../ain-blockchain* -maxdepth 0 -type d)
     printf "OLD_DIR_PATH=$OLD_DIR_PATH\n"
     sudo chmod -R 777 $OLD_DIR_PATH
-    sudo chmod -R 777 /home/ain_blockchain_data
 fi
 
 

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
-    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--keep-data] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_incremental_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
     printf "\n"
     exit
@@ -12,6 +12,8 @@ function parse_options() {
     local option="$1"
     if [[ $option = '--keep-code' ]]; then
         KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
     elif [[ $option = '--full-sync' ]]; then
         FULL_SYNC_OPTION="$option"
     elif [[ $option = '--keystore' ]]; then
@@ -61,6 +63,7 @@ fi
 NODE_INDEX="$3"
 
 KEEP_CODE_OPTION=""
+KEEP_DATA_OPTION=""
 FULL_SYNC_OPTION=""
 ACCOUNT_INJECTION_OPTION=""
 JSON_RPC_OPTION=""
@@ -78,6 +81,7 @@ printf "SHARD_INDEX=$SHARD_INDEX\n"
 printf "NODE_INDEX=$NODE_INDEX\n"
 
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "FULL_SYNC_OPTION=$FULL_SYNC_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
@@ -258,6 +262,18 @@ printf "NEW_DIR_PATH=$NEW_DIR_PATH\n"
 
 # 3. Set up working directory & install modules
 printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
+if [[ $KEEP_DATA_OPTION = "" ]]; then
+    printf '\n'
+    printf 'Removing old data..\n'
+    sudo rm -rf /home/ain_blockchain_data/chains
+    sudo rm -rf /home/ain_blockchain_data/snapshots
+    sudo rm -rf /home/ain_blockchain_data/logs
+    sudo mkdir -p /home/ain_blockchain_data
+    sudo chmod -R 777 /home/ain_blockchain_data
+else
+    sudo mkdir -p /home/ain_blockchain_data
+    sudo chmod -R 777 /home/ain_blockchain_data
+fi
 if [[ $KEEP_CODE_OPTION = "" ]]; then
     printf '\n'
     printf 'Creating new working directory..\n'
@@ -267,9 +283,6 @@ if [[ $KEEP_CODE_OPTION = "" ]]; then
 
     sudo chmod -R 777 $NEW_DIR_PATH
     mv * $NEW_DIR_PATH
-
-    sudo mkdir -p /home/ain_blockchain_data
-    sudo chmod -R 777 /home/ain_blockchain_data
 
     printf '\n'
     printf 'Installing node modules..\n'

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
+if [[ $# -lt 3 ]] || [[ $# -gt 9 ]]; then
     printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|spring|summer|mainnet] <Shard Index> <Node Index> [--keep-code] [--keep-data] [--full-sync] [--keystore|--mnemonic|--private-key] [--json-rpc] [--rest-func]\n"
     printf "Example: bash start_node_incremental_gcp.sh spring 0 0 --keep-code --full-sync --keystore\n"
     printf "\n"


### PR DESCRIPTION
Added options to deploy & start node scripts that allow full control of code & data
- --keep-code (was previously automatically determined by --restart or --reset)
- --keep-data (was previously --restart, which also controlled code deployment)
