### PR TITLE
Use enabled_block = 2 for additional timer flags in base configs

### DIFF
--- a/blockchain-configs/base/timer_flags.json
+++ b/blockchain-configs/base/timer_flags.json
@@ -20,7 +20,7 @@
     "has_bandage": true
   },
   "update_max_state_tree_size_per_byte2": {
-    "enabled_block": 3,
+    "enabled_block": 2,
     "has_bandage": true
   }
 }


### PR DESCRIPTION
Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/914