### PR TITLE
Feature/liayoo/update bandwidth budget params

### DIFF
--- a/blockchain-configs/base/timer_flags.json
+++ b/blockchain-configs/base/timer_flags.json
@@ -22,5 +22,9 @@
   "update_max_state_tree_size_per_byte2": {
     "enabled_block": 2,
     "has_bandage": true
+  },
+  "update_bandwidth_budget_params": {
+    "enabled_block": 2,
+    "has_bandage": true
   }
 }

--- a/blockchain-configs/mainnet-prod/timer_flags.json
+++ b/blockchain-configs/mainnet-prod/timer_flags.json
@@ -24,7 +24,7 @@
     "has_bandage": true
   },
   "update_bandwidth_budget_params": {
-    "enabled_block": -1,
+    "enabled_block": null,
     "has_bandage": true
   }
 }

--- a/blockchain-configs/mainnet-prod/timer_flags.json
+++ b/blockchain-configs/mainnet-prod/timer_flags.json
@@ -22,5 +22,9 @@
   "update_max_state_tree_size_per_byte2": {
     "enabled_block": 58300,
     "has_bandage": true
+  },
+  "update_bandwidth_budget_params": {
+    "enabled_block": -1,
+    "has_bandage": true
   }
 }

--- a/blockchain-configs/testnet-prod/timer_flags.json
+++ b/blockchain-configs/testnet-prod/timer_flags.json
@@ -26,5 +26,9 @@
   "update_max_state_tree_size_per_byte2": {
     "enabled_block": 56300,
     "has_bandage": true
+  },
+  "update_bandwidth_budget_params": {
+    "enabled_block": -1,
+    "has_bandage": true
   }
 }

--- a/blockchain-configs/testnet-prod/timer_flags.json
+++ b/blockchain-configs/testnet-prod/timer_flags.json
@@ -28,7 +28,7 @@
     "has_bandage": true
   },
   "update_bandwidth_budget_params": {
-    "enabled_block": -1,
+    "enabled_block": null,
     "has_bandage": true
   }
 }

--- a/db/bandage-files/update_bandwidth_budget_params.js
+++ b/db/bandage-files/update_bandwidth_budget_params.js
@@ -1,0 +1,24 @@
+module.exports = {
+  data: [
+    {
+      path: ['values', 'blockchain_params', 'resource', 'bandwidth_budget_per_block'],
+      value: 1000000,
+      prevValue: 10000
+    },
+    {
+      path: ['values', 'blockchain_params', 'resource', 'service_bandwidth_budget_ratio'],
+      value: 0.05,
+      prevValue: 0.5
+    },
+    {
+      path: ['values', 'blockchain_params', 'resource', 'apps_bandwidth_budget_ratio'],
+      value: 0.9495,
+      prevValue: 0.495
+    },
+    {
+      path: ['values', 'blockchain_params', 'resource', 'free_bandwidth_budget_ratio'],
+      value: 0.0005,
+      prevValue: 0.005
+    }
+  ]
+};


### PR DESCRIPTION
Updated `bandwidth_budget_per_block`, `service_bandwidth_budget_ratio`, `apps_bandwidth_budget_ratio` and `free_bandwidth_budget_ratio` blockchain params with bandage files and timer flags.

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/927 