### PR TITLE
Fix bandwidth budget updates not applying

### DIFF
--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -181,15 +181,15 @@ class TransactionPool {
     return appStakesTotal > 0 ? appsBandwidthBudgetPerBlock * appStake / appStakesTotal : 0;
   }
 
-  getBandwidthBudgets(blockNumber, stateVersion) {
+  getBandwidthBudgets(stateVersion) {
     const bandwidthBudgetPerBlock = this.node.getBlockchainParam(
-        'resource/bandwidth_budget_per_block', blockNumber, stateVersion);
+        'resource/bandwidth_budget_per_block', null, stateVersion);
     const serviceBandwidthBudgetRatio = this.node.getBlockchainParam(
-        'resource/service_bandwidth_budget_ratio', blockNumber, stateVersion);
+        'resource/service_bandwidth_budget_ratio', null, stateVersion);
     const appsBandwidthBudgetRatio = this.node.getBlockchainParam(
-        'resource/apps_bandwidth_budget_ratio', blockNumber, stateVersion);
+        'resource/apps_bandwidth_budget_ratio', null, stateVersion);
     const freeBandwidthBudgetRatio = this.node.getBlockchainParam(
-        'resource/free_bandwidth_budget_ratio', blockNumber, stateVersion);
+        'resource/free_bandwidth_budget_ratio', null, stateVersion);
     const serviceBandwidthBudgetPerBlock = bandwidthBudgetPerBlock * serviceBandwidthBudgetRatio;
     const appsBandwidthBudgetPerBlock = bandwidthBudgetPerBlock * appsBandwidthBudgetRatio;
     const freeBandwidthBudgetPerBlock = bandwidthBudgetPerBlock * freeBandwidthBudgetRatio;
@@ -218,7 +218,7 @@ class TransactionPool {
       serviceBandwidthBudgetPerBlock,
       appsBandwidthBudgetPerBlock,
       freeBandwidthBudgetPerBlock,
-    } = this.getBandwidthBudgets(db.blockNumberSnapshot, db.stateVersion);
+    } = this.getBandwidthBudgets(db.stateVersion);
     for (const tx of txList) {
       const nonce = tx.tx_body.nonce;
       if (addrToDiscardedNoncedTx[tx.address] && nonce >= 0) {


### PR DESCRIPTION
In getBandwidthBudgets(), the db.blockNumberSnapshot was always set to -2, meaning it always uses the original blockchain params (See https://github.com/ainblockchain/ain-blockchain/blob/master/db/index.js#L588). 
Updated to use the default block number (node.bc.lastBlockNumber()) instead, by setting it to null.

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/927