### PR TITLE
Support TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER env variable

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -963,6 +963,10 @@ class CommonUtil {
     if (!CommonUtil.isNumber(enabledBlockNumber)) {
       return null;
     }
+    const earlyAppliedBlockNumber = process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER ? Number(process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER) : null;
+    if (CommonUtil.isNumber(earlyAppliedBlockNumber) && enabledBlockNumber <= earlyAppliedBlockNumber) {
+      return 2;
+    }
     return enabledBlockNumber;
   }
 
@@ -970,6 +974,10 @@ class CommonUtil {
     const disabledBlockNumber = timerFlag['disabled_block'];
     if (!CommonUtil.isNumber(disabledBlockNumber)) {
       return null;
+    }
+    const earlyAppliedBlockNumber = process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER ? Number(process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER) : null;
+    if (CommonUtil.isNumber(earlyAppliedBlockNumber) && disabledBlockNumber <= earlyAppliedBlockNumber) {
+      return 2;
     }
     return disabledBlockNumber;
   }

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -998,6 +998,8 @@ class CommonUtil {
     return CommonUtil.getDisabledBlockNumberFromTimerFlag(flag);
   }
 
+  // NOTE(platfowner): Bandage files are applied on 'enabled_block' number but not reverted on
+  // 'disabled_block' number.
   static createTimerFlagEnabledBandageMap(timerFlags) {
     const LOG_HEADER = 'createTimerFlagEnabledBandageMap';
     const map = new Map();

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -941,35 +941,53 @@ class CommonUtil {
 
   static hasTimerFlagEnabled(timerFlags, flagName, blockNumber) {
     const flag = timerFlags[flagName];
-    if (!flag) {
+    if (!CommonUtil.isDict(flag)) {
       return false;
     }
     if (!CommonUtil.isNumber(blockNumber)) {
       return false;
     }
-    const enabledBlock = flag['enabled_block'];
-    if (enabledBlock === undefined || !CommonUtil.isNumber(enabledBlock) ||
-        blockNumber < enabledBlock) {
+    const enabledBlockNumber = CommonUtil.getEnabledBlockNumberFromTimerFlag(flag);
+    if (!CommonUtil.isNumber(enabledBlockNumber) || blockNumber < enabledBlockNumber) {
       return false;
     }
-    const disabledBlock = flag['disabled_block'];
-    if (disabledBlock === undefined || !CommonUtil.isNumber(disabledBlock) ||
-        blockNumber < disabledBlock) {
+    const disabledBlockNumber = CommonUtil.getDisabledBlockNumberFromTimerFlag(flag);
+    if (!CommonUtil.isNumber(disabledBlockNumber) || blockNumber < disabledBlockNumber) {
       return true;
     }
     return false;
   }
 
-  static getTimerFlagEnabledBlock(timerFlags, flagName) {
+  static getEnabledBlockNumberFromTimerFlag(timerFlag) {
+    const enabledBlockNumber = timerFlag['enabled_block'];
+    if (!CommonUtil.isNumber(enabledBlockNumber)) {
+      return null;
+    }
+    return enabledBlockNumber;
+  }
+
+  static getDisabledBlockNumberFromTimerFlag(timerFlag) {
+    const disabledBlockNumber = timerFlag['disabled_block'];
+    if (!CommonUtil.isNumber(disabledBlockNumber)) {
+      return null;
+    }
+    return disabledBlockNumber;
+  }
+
+  static getTimerFlagEnabledBlockNumber(timerFlags, flagName) {
     const flag = timerFlags[flagName];
-    if (!flag) {
+    if (!CommonUtil.isDict(flag)) {
       return null;
     }
-    const enabledBlock = flag['enabled_block'];
-    if (enabledBlock === undefined || !CommonUtil.isNumber(enabledBlock)) {
+    return CommonUtil.getEnabledBlockNumberFromTimerFlag(flag);
+  }
+
+  static getTimerFlagDisabledBlockNumber(timerFlags, flagName) {
+    const flag = timerFlags[flagName];
+    if (!CommonUtil.isDict(flag)) {
       return null;
     }
-    return enabledBlock;
+    return CommonUtil.getDisabledBlockNumberFromTimerFlag(flag);
   }
 
   static createTimerFlagEnabledBandageMap(timerFlags) {
@@ -980,7 +998,7 @@ class CommonUtil {
     for (let i = 0; i < flagNameList.length; i++) {
       const flagName = flagNameList[i];
       const flag = timerFlags[flagName];
-      const enabledBlockNumber = flag['enabled_block'];
+      const enabledBlockNumber = CommonUtil.getEnabledBlockNumberFromTimerFlag(flag);
       if (CommonUtil.isNumber(enabledBlockNumber) && flag['has_bandage'] === true) {
         const bandageFilePath = path.resolve(__dirname, '../db/bandage-files', `${flagName}.js`);
         console.log(`[${LOG_HEADER}] [${i}] Registering ${bandageFilePath}`);

--- a/common/constants.js
+++ b/common/constants.js
@@ -63,7 +63,11 @@ function isEnabledTimerFlag(flagName, blockNumber) {
 }
 
 function isTimerFlagEnabledAt(flagName, blockNumber) {
-  return CommonUtil.getTimerFlagEnabledBlock(TimerFlags, flagName) === blockNumber;
+  return CommonUtil.getTimerFlagEnabledBlockNumber(TimerFlags, flagName) === blockNumber;
+}
+
+function isTimerFlagDisabledAt(flagName, blockNumber) {
+  return CommonUtil.getTimerFlagDisabledBlockNumber(TimerFlags, flagName) === blockNumber;
 }
 
 const TimerFlagEnabledBandageMap = CommonUtil.createTimerFlagEnabledBandageMap(TimerFlags);
@@ -763,6 +767,7 @@ module.exports = {
   TimerFlags,
   isEnabledTimerFlag,
   isTimerFlagEnabledAt,
+  isTimerFlagDisabledAt,
   TimerFlagEnabledBandageMap,
   BlockchainParams,
   NodeConfigs,

--- a/deploy_test_gcp.sh
+++ b/deploy_test_gcp.sh
@@ -82,7 +82,7 @@ function stop_servers() {
 }
 
 # deploy files
-FILES_FOR_TEST="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ test/ tools/ tracker-server/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh stop_servers_local.sh"
+FILES_FOR_TEST="afan_client/ blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ test/ tools/ tracker-server/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu.sh stop_servers_local.sh"
 
 printf "\n"
 SEASON="dev"

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -279,6 +279,9 @@ fi
 
 export STAKE=100000
 printf "STAKE=$STAKE\n"
+# uncomment and set value when necessary
+#export TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER=124440  # summer
+#printf "TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER=$TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER\n"
 
 if [[ "$SEASON" = "sandbox" ]]; then
     MAX_OLD_SPACE_SIZE_MB=11000

--- a/test/unit/common-util.test.js
+++ b/test/unit/common-util.test.js
@@ -2338,6 +2338,137 @@ describe("CommonUtil", () => {
     });
   })
 
+  describe('hasTimerFlagEnabled with TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER', () => { 
+    before(() => {
+      process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER = '430';
+    });
+
+    after(() => {
+      delete process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER;
+    });
+
+    it("when invalid input", () => {
+      expect(CommonUtil.hasTimerFlagEnabled({}, 'some_flag', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({}, 'some_flag', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({}, 'some_flag', 100)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({
+        'some_flag': null
+      }, 'some_flag', 100)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({
+        'some_flag': {
+          'enabled_block': true,
+        }
+      }, 'some_flag', 100)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({
+        'some_flag': {
+          'enabled_block': true,
+          'disabled_block': true,
+        }
+      }, 'some_flag', 100)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled({
+        'some_flag': {
+          'enabled_block': '0',
+          'disabled_block': '200',
+        }
+      }, 'some_flag', 100)).to.equal(false);
+    });
+
+    it("when valid input", () => {
+      const timerFlags = {
+        'flag_a': {
+        },
+        'flag_b': {
+          'enabled_block': null,
+        },
+        'flag_c': {
+          'enabled_block': null,
+          'disabled_block': null,
+        },
+        'flag_d': {
+          'enabled_block': 100,
+        },
+        'flag_e': {
+          'enabled_block': 200,
+          'disabled_block': null,
+        },
+        'flag_f': {
+          'enabled_block': 300,
+          'disabled_block': 350,
+        },
+        'flag_g': {
+          'enabled_block': 400,
+          'disabled_block': 450,
+        },
+        'flag_h': {
+          'enabled_block': 500,
+          'disabled_block': 550,
+        },
+      };
+
+      // without enabled_block nor disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', 1)).to.equal(false);
+      // with null enabled_block and without disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_b', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_b', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_b', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_b', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_b', 1)).to.equal(false);
+      // with null enabled_block and disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_c', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_c', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_c', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_c', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_c', 1)).to.equal(false);
+      // without disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', 1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', 2)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_d', 3)).to.equal(true);
+      // with null disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', 1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', 2)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_e', 3)).to.equal(true);
+      // with disabled_block < TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', 1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', 2)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_f', 3)).to.equal(false);
+      // with enabled_block < TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER < disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 2)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 430)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 449)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_g', 450)).to.equal(false);
+      // with TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER < enabled_block < disabled_block
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', undefined)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', null)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', -1)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', 0)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', 499)).to.equal(false);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', 500)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', 549)).to.equal(true);
+      expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_h', 550)).to.equal(false);
+    });
+  })
+
   describe('getTimerFlagEnabledBlockNumber / getTimerFlagDisabledBlockNumber', () => { 
     it("when invalid input", () => {
       expect(CommonUtil.getTimerFlagEnabledBlockNumber({}, 'some_flag')).to.equal(null);
@@ -2451,6 +2582,123 @@ describe("CommonUtil", () => {
       // with smaller disabled_block
       expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_i')).to.equal(600);
       expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_i')).to.equal(550);
+    });
+  })
+
+  describe('getTimerFlagEnabledBlockNumber / getTimerFlagDisabledBlockNumber with TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER', () => { 
+    before(() => {
+      process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER = '430';
+    });
+
+    after(() => {
+      delete process.env.TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER;
+    });
+
+    it("when invalid input", () => {
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({}, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({}, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': null
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': null
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+          'disabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+          'disabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': '0',
+          'disabled_block': '200',
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': '0',
+          'disabled_block': '200',
+        }
+      }, 'some_flag')).to.equal(null);
+    });
+
+    it("when valid input", () => {
+      const timerFlags = {
+        'flag_a': {
+        },
+        'flag_b': {
+          'enabled_block': null,
+        },
+        'flag_c': {
+          'enabled_block': null,
+          'disabled_block': null,
+        },
+        'flag_d': {
+          'enabled_block': 100,
+        },
+        'flag_e': {
+          'enabled_block': 200,
+          'disabled_block': null,
+        },
+        'flag_f': {
+          'enabled_block': 300,
+          'disabled_block': 350,
+        },
+        'flag_g': {
+          'enabled_block': 400,
+          'disabled_block': 450,
+        },
+        'flag_h': {
+          'enabled_block': 500,
+          'disabled_block': 550,
+        },
+      };
+
+      // without enabled_block nor disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_a')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_a')).to.equal(null);
+      // with null enabled_block and without disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_b')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_b')).to.equal(null);
+      // with null enabled_block and disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_c')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_c')).to.equal(null);
+      // without disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_d')).to.equal(2);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_d')).to.equal(null);
+      // with null disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_e')).to.equal(2);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_e')).to.equal(null);
+      // with disabled_block < TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_f')).to.equal(2);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_f')).to.equal(2);
+      // with enabled_block < TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER < disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_g')).to.equal(2);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_g')).to.equal(450);
+      // with TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER < enabled_block < disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_h')).to.equal(500);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_h')).to.equal(550);
     });
   })
 })

--- a/test/unit/common-util.test.js
+++ b/test/unit/common-util.test.js
@@ -2250,7 +2250,7 @@ describe("CommonUtil", () => {
         },
       };
 
-      // without enabled_block no disabled_block
+      // without enabled_block nor disabled_block
       expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', undefined)).to.equal(false);
       expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', null)).to.equal(false);
       expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_a', -1)).to.equal(false);
@@ -2335,6 +2335,122 @@ describe("CommonUtil", () => {
       expect(CommonUtil.hasTimerFlagEnabled(timerFlags, 'flag_i', 601)).to.equal(false);
       expect(CommonUtil.hasTimerFlagEnabled(
           timerFlags, 'flag_i', Number.MAX_SAFE_INTEGER)).to.equal(false);
+    });
+  })
+
+  describe('getTimerFlagEnabledBlockNumber / getTimerFlagDisabledBlockNumber', () => { 
+    it("when invalid input", () => {
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({}, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({}, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': null
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': null
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+          'disabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': true,
+          'disabled_block': true,
+        }
+      }, 'some_flag')).to.equal(null);
+
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber({
+        'some_flag': {
+          'enabled_block': '0',
+          'disabled_block': '200',
+        }
+      }, 'some_flag')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber({
+        'some_flag': {
+          'enabled_block': '0',
+          'disabled_block': '200',
+        }
+      }, 'some_flag')).to.equal(null);
+    });
+
+    it("when valid input", () => {
+      const timerFlags = {
+        'flag_a': {
+        },
+        'flag_b': {
+          'enabled_block': null,
+        },
+        'flag_c': {
+          'enabled_block': null,
+          'disabled_block': null,
+        },
+        'flag_d': {
+          'enabled_block': 100,
+        },
+        'flag_e': {
+          'enabled_block': 200,
+          'disabled_block': null,
+        },
+        'flag_f': {
+          'enabled_block': 300,
+          'disabled_block': 350,
+        },
+        'flag_g': {
+          'enabled_block': 400,
+          'disabled_block': 401,
+        },
+        'flag_h': {
+          'enabled_block': 500,
+          'disabled_block': 500,
+        },
+        'flag_i': {
+          'enabled_block': 600,
+          'disabled_block': 550,
+        },
+      };
+
+      // without enabled_block nor disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_a')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_a')).to.equal(null);
+      // with null enabled_block and without disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_b')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_b')).to.equal(null);
+      // with null enabled_block and disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_c')).to.equal(null);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_c')).to.equal(null);
+      // without disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_d')).to.equal(100);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_d')).to.equal(null);
+      // with null disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_e')).to.equal(200);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_e')).to.equal(null);
+      // with numeric disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_f')).to.equal(300);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_f')).to.equal(350);
+      // with tight disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_g')).to.equal(400);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_g')).to.equal(401);
+      // with equal disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_h')).to.equal(500);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_h')).to.equal(500);
+      // with smaller disabled_block
+      expect(CommonUtil.getTimerFlagEnabledBlockNumber(timerFlags, 'flag_i')).to.equal(600);
+      expect(CommonUtil.getTimerFlagDisabledBlockNumber(timerFlags, 'flag_i')).to.equal(550);
     });
   })
 })


### PR DESCRIPTION
Change summary:
- Support TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER env variable
- Fix deploy_test_gcp.sh for integration/dapp test

Background:
- When genesis deploy is necessary, TIMER_FLAG_EARLY_APPLIED_BLOCK_NUMBER env variable allows to apply timer flags of which enabled block numbers are less than the env variable value early (i.e. at block number '2' instead of at 'enabled_block' block number).