### PR TITLE
Feature/liayoo/get state free tier usage optimization

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -23,12 +23,16 @@ const DevFlags = {
   // Enables p2p message tags checking.
   // TODO(liayoo): Add some security measures before turning this flag on.
   enableP2pMessageTagsChecking: false,
+
+  // NOTE(liayoo): Below flags are added for performance optimization testing purposes.
   // Enables tx receipt recording.
   enableTxReceiptRecording: true,
   // Enables gas fee collection.
   enableGasFeeCollection: true,
   // Enables gas fee distribution.
   enableGasFeeDistribution: true,
+  // Enables getStateFreeTierUsage() optimization.
+  enableGetStateFreeTierUsageOptimization: true,
 };
 
 // ** Blockchain configs **

--- a/db/index.js
+++ b/db/index.js
@@ -1389,13 +1389,15 @@ class DB {
       `${this.getProofHash(CommonUtil.appendPath(PredefinedDbPaths.VALUES_ROOT, appsPrefix))}`
     );
     if (!cachedHash || cachedHash !== currentHash) {
-      this.appStateUsageCache.hash = currentHash;
       const newValue = {};
       const apps = DB.getValueFromStateRoot(this.stateRoot, appsPrefix, true) || {};
       for (const appName of Object.keys(apps)) {
         newValue[appName] = this.getStateUsageAtPath(`${appsPrefix}/${appName}`);
       }
-      this.appStateUsageCache.value = newValue;
+      this.appStateUsageCache = {
+        hash: currentHash,
+        value: newValue
+      };
       return true;
     }
     return false;
@@ -1406,7 +1408,6 @@ class DB {
     const currentHash = this.getProofHash(
         CommonUtil.appendPath(PredefinedDbPaths.VALUES_ROOT, PredefinedDbPaths.STAKING));
     if (!cachedHash || cachedHash !== currentHash) {
-      this.appStakeCache.hash = currentHash;
       const newValue = new Set();
       const apps = DB.getValueFromStateRoot(this.stateRoot, PredefinedDbPaths.STAKING, true) || {};
       for (const appName of Object.keys(apps)) {
@@ -1415,7 +1416,10 @@ class DB {
           `/${PredefinedDbPaths.STAKING}/${appName}/${PredefinedDbPaths.STAKING_BALANCE_TOTAL}`);
         if (stake) newValue.add(appName);
       }
-      this.appStakeCache.value = newValue;
+      this.appStakeCache = {
+        hash: currentHash,
+        value: newValue
+      };
       return true;
     }
     return false;

--- a/db/index.js
+++ b/db/index.js
@@ -67,7 +67,7 @@ class DB {
     this.eh = eventHandler;
     this.restFunctionsUrlWhitelistCache = { hash: null, whitelist: [] };
     this.appStateUsageCache = { hash: null, value: null };
-    this.appStakeCache = { hash: null, value: new Set() };
+    this.stakedAppSetCache = { hash: null, value: new Set() };
     this.stateFreeTierUsageCache = null;
     this.updateRestFunctionsUrlWhitelistCache();
     this.updateStateFreeTierUsageCache();
@@ -1404,7 +1404,7 @@ class DB {
   }
 
   updateAppStakeCache() {
-    const cachedHash = this.appStakeCache.hash;
+    const cachedHash = this.stakedAppSetCache.hash;
     const currentHash = this.getProofHash(
         CommonUtil.appendPath(PredefinedDbPaths.VALUES_ROOT, PredefinedDbPaths.STAKING));
     if (!cachedHash || cachedHash !== currentHash) {
@@ -1417,7 +1417,7 @@ class DB {
           newValue.add(appName);
         }
       }
-      this.appStakeCache = {
+      this.stakedAppSetCache = {
         hash: currentHash,
         value: newValue
       };
@@ -1432,7 +1432,7 @@ class DB {
     if (appStateUsageCached || freeTierAppCached) {
       const usage = {};
       for (const appName in this.appStateUsageCache.value) {
-        if (!this.appStakeCache.value.has(appName)) {
+        if (!this.stakedAppSetCache.value.has(appName)) {
           CommonUtil.mergeNumericJsObjects(usage, this.appStateUsageCache.value[appName]);
         }
       }

--- a/db/index.js
+++ b/db/index.js
@@ -1413,7 +1413,9 @@ class DB {
       for (const appName of Object.keys(apps)) {
         const stake = DB.getValueFromStateRoot(
             this.stateRoot, PathUtil.getStakingBalanceTotalPath(appName));
-        if (stake) newValue.add(appName);
+        if (CommonUtil.isNumber(stake) && stake > 0) {
+          newValue.add(appName);
+        }
       }
       this.appStakeCache = {
         hash: currentHash,

--- a/db/index.js
+++ b/db/index.js
@@ -1412,8 +1412,7 @@ class DB {
       const apps = DB.getValueFromStateRoot(this.stateRoot, PredefinedDbPaths.STAKING, true) || {};
       for (const appName of Object.keys(apps)) {
         const stake = DB.getValueFromStateRoot(
-          this.stateRoot,
-          `/${PredefinedDbPaths.STAKING}/${appName}/${PredefinedDbPaths.STAKING_BALANCE_TOTAL}`);
+            this.stateRoot, PathUtil.getStakingBalanceTotalPath(appName));
         if (stake) newValue.add(appName);
       }
       this.appStakeCache = {
@@ -1449,8 +1448,7 @@ class DB {
     const apps = DB.getValueFromStateRoot(this.stateRoot, PredefinedDbPaths.APPS, true) || {};
     for (const appName of Object.keys(apps)) {
       if (!DB.getValueFromStateRoot(
-          this.stateRoot,
-          `/${PredefinedDbPaths.STAKING}/${appName}/${PredefinedDbPaths.STAKING_BALANCE_TOTAL}`)) {
+          this.stateRoot, PathUtil.getStakingBalanceTotalPath(appName))) {
         CommonUtil.mergeNumericJsObjects(
             usage, this.getStateUsageAtPath(`${PredefinedDbPaths.APPS}/${appName}`));
       }


### PR DESCRIPTION
- Added stateFreeTierUsageCache along with appStateUsageCache and appStakeCache
- Added enableGetStateFreeTierUsageOptimization dev flag to switch between the legacy logic
- I've checked that during integration & unit tests, the legacy & new logic always returned the same usage values.
- Related issue: https://github.com/ainblockchain/ain-blockchain/issues/915