### PR TITLE
Add 'all' option to deploy_test_gcp.sh

### DIFF
--- a/deploy_test_gcp.sh
+++ b/deploy_test_gcp.sh
@@ -152,15 +152,29 @@ function deploy_test() {
 }
 
 if [[ $INSTANCE_INDEX = "all" ]]; then
-    deploy_test 0 test_unit 
-    deploy_test 1 test_integration_function 
-    deploy_test 2 test_integration_node 
-    deploy_test 3 test_integration_sharding 
-    deploy_test 4 test_integration_blockchain 
-    deploy_test 5 test_integration_consensus 
-    deploy_test 6 test_integration_dapp 
-    deploy_test 7 test_integration_he_protocol 
-    deploy_test 8 test_integration_he_sharding 
+    if [[ $BACKGROUND_OPTION = "--bg" ]] || [[ $STOP_ONLY_OPTION = "--stop-only" ]]; then
+        # parallelized function calls
+        deploy_test 0 test_unit &
+        deploy_test 1 test_integration_function &
+        deploy_test 2 test_integration_node &
+        deploy_test 3 test_integration_sharding &
+        deploy_test 4 test_integration_blockchain &
+        deploy_test 5 test_integration_consensus &
+        deploy_test 6 test_integration_dapp &
+        deploy_test 7 test_integration_he_protocol &
+        deploy_test 8 test_integration_he_sharding
+    else
+        # serialized function calls
+        deploy_test 0 test_unit 
+        deploy_test 1 test_integration_function 
+        deploy_test 2 test_integration_node 
+        deploy_test 3 test_integration_sharding 
+        deploy_test 4 test_integration_blockchain 
+        deploy_test 5 test_integration_consensus 
+        deploy_test 6 test_integration_dapp 
+        deploy_test 7 test_integration_he_protocol 
+        deploy_test 8 test_integration_he_sharding 
+    fi
 else
     deploy_test "$INSTANCE_INDEX" "$TESTING_OPTION"
 fi


### PR DESCRIPTION
Change summary:
- Add 'all' option to deploy_test_gcp.sh

Background:
With 'all' option, the scripts runs all tests (unit + integration) on cloud instances (dev-test-0 ~ 8).

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/762