### PR TITLE
Add child node pagination with is_partial option

### DIFF
--- a/common/common-util.js
+++ b/common/common-util.js
@@ -243,11 +243,15 @@ class CommonUtil {
     }
     if (args.is_shallow !== undefined) {
       options.isShallow = CommonUtil.toBool(args.is_shallow);
+    } else {
+      options.isShallow = false;
     }
     if (args.is_partial !== undefined) {
       options.isPartial = CommonUtil.toBool(args.is_partial);
       options.lastEndLabel = args.last_end_label !== undefined ?
           CommonUtil.toString(args.last_end_label) : null;
+    } else {
+      options.isPartial = false;
     }
     if (args.include_version !== undefined) {
       options.includeVersion = CommonUtil.toBool(args.include_version);
@@ -266,6 +270,9 @@ class CommonUtil {
 
   static toMatchOrEvalOptions(args, fromApi = false) {
     const options = {};
+    // NOTE: Not allowed true values of isShallow or isPartial options in match/eval requests.
+    options.isShallow = false;
+    options.isPartial = false;
     if (args.is_global !== undefined) {
       options.isGlobal = CommonUtil.toBool(args.is_global);
     }

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -246,6 +246,8 @@ class CommonUtil {
     }
     if (args.is_partial !== undefined) {
       options.isPartial = CommonUtil.toBool(args.is_partial);
+      options.lastEndLabel = args.last_end_label !== undefined ?
+          CommonUtil.toString(args.last_end_label) : null;
     }
     if (args.include_version !== undefined) {
       options.includeVersion = CommonUtil.toBool(args.include_version);

--- a/common/common-util.js
+++ b/common/common-util.js
@@ -244,6 +244,9 @@ class CommonUtil {
     if (args.is_shallow !== undefined) {
       options.isShallow = CommonUtil.toBool(args.is_shallow);
     }
+    if (args.is_partial !== undefined) {
+      options.isPartial = CommonUtil.toBool(args.is_partial);
+    }
     if (args.include_version !== undefined) {
       options.includeVersion = CommonUtil.toBool(args.include_version);
     }

--- a/common/constants.js
+++ b/common/constants.js
@@ -412,6 +412,7 @@ const FunctionTypes = {
  * @enum {string}
  */
 const StateLabelProperties = {
+  END_LABEL: '#end_label',
   HAS_PARENT_STATE_NODE: '#has_parent_state_node',
   HASH_DELIMITER: '#',  // Hash delimiter
   META_LABEL_PREFIX: '#',  // Prefix of all meta labels

--- a/db/index.js
+++ b/db/index.js
@@ -2270,6 +2270,7 @@ class DB {
     return funcs;
   }
 
+  // TODO(platfowner): Consider optimizing subtree function retrieval logic.
   getSubtreeFunctions(funcNode) {
     return this.getSubtreeFunctionsRecursive(0, funcNode);
   }
@@ -2417,6 +2418,7 @@ class DB {
     return rules;
   }
 
+  // TODO(platfowner): Consider optimizing subtree rule retrieval logic.
   getSubtreeRules(ruleNode, ruleProp) {
     return this.getSubtreeRulesRecursive(0, ruleNode, ruleProp);
   }
@@ -2682,6 +2684,7 @@ class DB {
     return owners;
   }
 
+  // TODO(platfowner): Consider optimizing subtree owner retrieval logic.
   getSubtreeOwners(ownerNode) {
     return this.getSubtreeOwnersRecursive(0, ownerNode);
   }

--- a/db/index.js
+++ b/db/index.js
@@ -720,7 +720,7 @@ class DB {
 
   checkRespTreeLimitsForEvalOrMatch(rootLabel, localPath, options) {
     if (options && options.fromApi) {
-    const targetStateRoot = options.isFinal ? this.stateManager.getFinalRoot() : this.stateRoot;
+      const targetStateRoot = options.isFinal ? this.stateManager.getFinalRoot() : this.stateRoot;
       const fullPath = DB.getFullPath(localPath, rootLabel);
       const stateNode = DB.getRefForReadingFromStateRoot(targetStateRoot, fullPath);
       if (stateNode !== null) {
@@ -753,19 +753,19 @@ class DB {
     const resultList = [];
     for (const op of opList) {
       if (op.type === undefined || op.type === ReadDbOperations.GET_VALUE) {
-        resultList.push(this.getValue(op.ref, CommonUtil.toGetOptions(op)));
+        resultList.push(this.getValue(op.ref, CommonUtil.toGetOptions(op, true)));
       } else if (op.type === ReadDbOperations.GET_RULE) {
-        resultList.push(this.getRule(op.ref, CommonUtil.toGetOptions(op)));
+        resultList.push(this.getRule(op.ref, CommonUtil.toGetOptions(op, true)));
       } else if (op.type === ReadDbOperations.GET_FUNCTION) {
-        resultList.push(this.getFunction(op.ref, CommonUtil.toGetOptions(op)));
+        resultList.push(this.getFunction(op.ref, CommonUtil.toGetOptions(op, true)));
       } else if (op.type === ReadDbOperations.GET_OWNER) {
-        resultList.push(this.getOwner(op.ref, CommonUtil.toGetOptions(op)));
+        resultList.push(this.getOwner(op.ref, CommonUtil.toGetOptions(op, true)));
       } else if (op.type === ReadDbOperations.MATCH_FUNCTION) {
-        resultList.push(this.matchFunction(op.ref, CommonUtil.toMatchOrEvalOptions(op)));
+        resultList.push(this.matchFunction(op.ref, CommonUtil.toMatchOrEvalOptions(op, true)));
       } else if (op.type === ReadDbOperations.MATCH_RULE) {
-        resultList.push(this.matchRule(op.ref, CommonUtil.toMatchOrEvalOptions(op)));
+        resultList.push(this.matchRule(op.ref, CommonUtil.toMatchOrEvalOptions(op, true)));
       } else if (op.type === ReadDbOperations.MATCH_OWNER) {
-        resultList.push(this.matchOwner(op.ref, CommonUtil.toMatchOrEvalOptions(op)));
+        resultList.push(this.matchOwner(op.ref, CommonUtil.toMatchOrEvalOptions(op, true)));
       } else if (op.type === ReadDbOperations.EVAL_RULE) {
         const auth = {};
         if (op.address) {
@@ -775,7 +775,7 @@ class DB {
           auth.fid = op.fid;
         }
         const timestamp = op.timestamp || Date.now();
-        const options = Object.assign(CommonUtil.toMatchOrEvalOptions(op), { timestamp });
+        const options = Object.assign(CommonUtil.toMatchOrEvalOptions(op, true), { timestamp });
         resultList.push(this.evalRule(op.ref, op.value, auth, options));
       } else if (op.type === ReadDbOperations.EVAL_OWNER) {
         const auth = {};
@@ -786,7 +786,7 @@ class DB {
           auth.fid = op.fid;
         }
         resultList.push(this.evalOwner(
-            op.ref, op.permission, auth, CommonUtil.toMatchOrEvalOptions(op)));
+            op.ref, op.permission, auth, CommonUtil.toMatchOrEvalOptions(op, true)));
       }
     }
     return resultList;

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -359,7 +359,7 @@ class RadixNode {
       });
       endLabel = this.getLabel();
     }
-    if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
+    if (CommonUtil.isNumber(maxListSize) && stateNodeList.length >= maxListSize) {
       return {
         list: stateNodeList,
         endLabel,
@@ -384,7 +384,7 @@ class RadixNode {
         endLabel = stateNodeListFromChild.endLabel !== null ?
             this.getLabel() + stateNodeListFromChild.endLabel : null;
       }
-      if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
+      if (CommonUtil.isNumber(maxListSize) && stateNodeList.length >= maxListSize) {
         return {
           list: stateNodeList,
           endLabel,

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -336,17 +336,27 @@ class RadixNode {
     return false;
   }
 
-  // TODO(platfowner): Get only partial child labels for isPartial = true.
-  getChildStateNodeList(isPartial = false) {
+  getChildStateNodeList(maxListSize = null) {
     const stateNodeList = [];
+    if (CommonUtil.isNumber(maxListSize) && maxListSize <= 0) {
+      return stateNodeList;
+    }
     if (this.hasChildStateNode()) {
       stateNodeList.push({
         serial: this.getSerial(),
         stateNode: this.getChildStateNode()
       });
     }
+    if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
+      return stateNodeList;
+    }
     for (const child of this.getChildNodes()) {
-      stateNodeList.push(...child.getChildStateNodeList());
+      const maxListSizeForChild = CommonUtil.isNumber(maxListSize) ?
+          maxListSize - stateNodeList.length : null;
+      stateNodeList.push(...child.getChildStateNodeList(maxListSizeForChild));
+      if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
+        return stateNodeList;
+      }
     }
     return stateNodeList;
   }

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -336,7 +336,8 @@ class RadixNode {
     return false;
   }
 
-  getChildStateNodeListWithEndLabel(maxListSize = null) {
+  // TODO(platfowner): Apply lastEndLabel.
+  getChildStateNodeListWithEndLabel(maxListSize = null, lastEndLabel = null) {
     const stateNodeList = [];
     let endLabel = null;
     if (CommonUtil.isNumber(maxListSize) && maxListSize <= 0) {
@@ -361,7 +362,8 @@ class RadixNode {
     for (const child of this.getChildNodes()) {
       const maxListSizeForChild = CommonUtil.isNumber(maxListSize) ?
           maxListSize - stateNodeList.length : null;
-      const stateNodeListFromChild = child.getChildStateNodeListWithEndLabel(maxListSizeForChild);
+      const stateNodeListFromChild =
+          child.getChildStateNodeListWithEndLabel(maxListSizeForChild, lastEndLabel);
       if (stateNodeListFromChild.list.length > 0) {
         stateNodeList.push(...stateNodeListFromChild.list);
         endLabel = stateNodeListFromChild.endLabel !== null ?

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -336,7 +336,8 @@ class RadixNode {
     return false;
   }
 
-  getChildStateNodeList() {
+  // TODO(platfowner): Get only partial child labels for isPartial = true.
+  getChildStateNodeList(isPartial = false) {
     const stateNodeList = [];
     if (this.hasChildStateNode()) {
       stateNodeList.push({

--- a/db/radix-node.js
+++ b/db/radix-node.js
@@ -336,29 +336,48 @@ class RadixNode {
     return false;
   }
 
-  getChildStateNodeList(maxListSize = null) {
+  getChildStateNodeListWithEndLabel(maxListSize = null) {
     const stateNodeList = [];
+    let endLabel = null;
     if (CommonUtil.isNumber(maxListSize) && maxListSize <= 0) {
-      return stateNodeList;
+      return {
+        list: stateNodeList,
+        endLabel,
+      };
     }
     if (this.hasChildStateNode()) {
       stateNodeList.push({
         serial: this.getSerial(),
         stateNode: this.getChildStateNode()
       });
+      endLabel = this.getLabel();
     }
     if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
-      return stateNodeList;
+      return {
+        list: stateNodeList,
+        endLabel,
+      };
     }
     for (const child of this.getChildNodes()) {
       const maxListSizeForChild = CommonUtil.isNumber(maxListSize) ?
           maxListSize - stateNodeList.length : null;
-      stateNodeList.push(...child.getChildStateNodeList(maxListSizeForChild));
+      const stateNodeListFromChild = child.getChildStateNodeListWithEndLabel(maxListSizeForChild);
+      if (stateNodeListFromChild.list.length > 0) {
+        stateNodeList.push(...stateNodeListFromChild.list);
+        endLabel = stateNodeListFromChild.endLabel !== null ?
+            this.getLabel() + stateNodeListFromChild.endLabel : null;
+      }
       if (CommonUtil.isNumber(maxListSize) && stateNodeList.length === maxListSize) {
-        return stateNodeList;
+        return {
+          list: stateNodeList,
+          endLabel,
+        };
       }
     }
-    return stateNodeList;
+    return {
+      list: stateNodeList,
+      endLabel,
+    };
   }
 
   getProofHash() {

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -380,10 +380,7 @@ class RadixTree {
 
   getChildStateLabelsWithEndLabel(isPartial = false, lastEndLabel = null) {
     const nodesWithEndLabel = this.getChildStateNodesWithEndLabel(isPartial, lastEndLabel);
-    const labelList = [];
-    for (const stateNode of nodesWithEndLabel.list) {
-      labelList.push(stateNode.getLabel());
-    }
+    const labelList = nodesWithEndLabel.list.map(entry => entry.getLabel());
     return {
       list: labelList,
       endLabel: nodesWithEndLabel.endLabel,

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -378,19 +378,29 @@ class RadixTree {
     this.numChildStateNodes--
   }
 
-  getChildStateLabels(isPartial = false, lastEndLabel = null) {
+  getChildStateLabelsWithEndLabel(isPartial = false, lastEndLabel = null) {
+    const nodesWithEndLabel = this.getChildStateNodesWithEndLabel(isPartial, lastEndLabel);
     const labelList = [];
-    for (const stateNode of this.getChildStateNodes(isPartial, lastEndLabel)) {
+    for (const stateNode of nodesWithEndLabel.list) {
       labelList.push(stateNode.getLabel());
     }
-    return labelList;
+    return {
+      list: labelList,
+      endLabel: nodesWithEndLabel.endLabel,
+    };
   }
 
-  // TODO(platfowner): Apply lastEndLabel and return endLabel.
-  getChildStateNodes(isPartial = false, lastEndLabel = null) {
+  // TODO(platfowner): Apply lastEndLabel.
+  getChildStateNodesWithEndLabel(isPartial = false, lastEndLabel = null) {
     const maxListSize = isPartial ? NodeConfigs.GET_RESP_MAX_SIBLINGS : null;
-    return this.root.getChildStateNodeList(maxListSize).sort((a, b) => a.serial - b.serial)
+    const nodeListWithEndLabel = this.root.getChildStateNodeListWithEndLabel(maxListSize);
+    const sortedNodeList = nodeListWithEndLabel.list
+        .sort((a, b) => a.serial - b.serial)
         .map(entry => entry.stateNode);
+    return {
+      list: sortedNodeList,
+      endLabel: nodeListWithEndLabel.endLabel,
+    };
   }
 
   hasChildStateNodes() {
@@ -483,7 +493,7 @@ class RadixTree {
     tree.setRoot(root);
     tree.setNextSerial(obj[StateLabelProperties.NEXT_SERIAL]);
     // NOTE(platfowner): Need to recompute and set numChildStateNodes.
-    const numChildStateNodes = tree.getChildStateLabels().length;
+    const numChildStateNodes = tree.getChildStateLabelsWithEndLabel().list.length;
     tree.setNumChildStateNodes(numChildStateNodes);
     return tree;
   }

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -2,6 +2,7 @@ const logger = new (require('../logger'))('RADIX_TREE');
 
 const CommonUtil = require('../common/common-util');
 const {
+  NodeConfigs,
   StateLabelProperties,
 } = require('../common/constants');
 const RadixNode = require('./radix-node');
@@ -377,16 +378,18 @@ class RadixTree {
     this.numChildStateNodes--
   }
 
-  getChildStateLabels(isPartial = false) {
+  getChildStateLabels(isPartial = false, lastEndLabel = null) {
     const labelList = [];
-    for (const stateNode of this.getChildStateNodes(isPartial)) {
+    for (const stateNode of this.getChildStateNodes(isPartial, lastEndLabel)) {
       labelList.push(stateNode.getLabel());
     }
     return labelList;
   }
 
-  getChildStateNodes(isPartial = false) {
-    return this.root.getChildStateNodeList(isPartial).sort((a, b) => a.serial - b.serial)
+  // TODO(platfowner): Apply lastEndLabel and return endLabel.
+  getChildStateNodes(isPartial = false, lastEndLabel = null) {
+    const maxListSize = isPartial ? NodeConfigs.GET_RESP_MAX_SIBLINGS : null;
+    return this.root.getChildStateNodeList(maxListSize).sort((a, b) => a.serial - b.serial)
         .map(entry => entry.stateNode);
   }
 

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -387,10 +387,10 @@ class RadixTree {
     };
   }
 
-  // TODO(platfowner): Apply lastEndLabel.
   getChildStateNodesWithEndLabel(isPartial = false, lastEndLabel = null) {
     const maxListSize = isPartial ? NodeConfigs.GET_RESP_MAX_SIBLINGS : null;
-    const nodeListWithEndLabel = this.root.getChildStateNodeListWithEndLabel(maxListSize);
+    const nodeListWithEndLabel =
+        this.root.getChildStateNodeListWithEndLabel(maxListSize, lastEndLabel);
     const sortedNodeList = nodeListWithEndLabel.list
         .sort((a, b) => a.serial - b.serial)
         .map(entry => entry.stateNode);

--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -377,16 +377,16 @@ class RadixTree {
     this.numChildStateNodes--
   }
 
-  getChildStateLabels() {
+  getChildStateLabels(isPartial = false) {
     const labelList = [];
-    for (const stateNode of this.getChildStateNodes()) {
+    for (const stateNode of this.getChildStateNodes(isPartial)) {
       labelList.push(stateNode.getLabel());
     }
     return labelList;
   }
 
-  getChildStateNodes() {
-    return this.root.getChildStateNodeList().sort((a, b) => a.serial - b.serial)
+  getChildStateNodes(isPartial = false) {
+    return this.root.getChildStateNodeList(isPartial).sort((a, b) => a.serial - b.serial)
         .map(entry => entry.stateNode);
   }
 

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -359,16 +359,16 @@ class StateNode {
     }
   }
 
-  getChildLabels(isPartial = false, lastEndLabel = null) {
-    return this.getChildLabelsWithEndLabel(isPartial, lastEndLabel).list;
+  getChildLabels() {
+    return this.getChildLabelsWithEndLabel().list;
   }
 
   getChildLabelsWithEndLabel(isPartial = false, lastEndLabel = null) {
     return this.radixTree.getChildStateLabelsWithEndLabel(isPartial, lastEndLabel);
   }
 
-  getChildNodes(isPartial = false, lastEndLabel = null) {
-    return this.getChildNodesWithEndLabel(isPartial, lastEndLabel).list;
+  getChildNodes() {
+    return this.getChildNodesWithEndLabel().list;
   }
 
   getChildNodesWithEndLabel(isPartial = false, lastEndLabel = null) {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -129,6 +129,8 @@ class StateNode {
   toStateSnapshot(options) {
     const isShallow = options && options.isShallow;
     const isPartial = options && options.isPartial;
+    const lastEndLabel = (options && options.lastEndLabel !== undefined) ?
+        options.lastEndLabel : null;
     const includeVersion = options && options.includeVersion;
     const includeTreeInfo = options && options.includeTreeInfo;
     const includeProof = options && options.includeProof;
@@ -136,7 +138,7 @@ class StateNode {
       return this.getValue();
     }
     const obj = {};
-    for (const label of this.getChildLabels(isPartial)) {
+    for (const label of this.getChildLabels(isPartial, lastEndLabel)) {
       const childNode = this.getChild(label);
       if (childNode.getIsLeaf()) {
         obj[label] = childNode.toStateSnapshot(options);
@@ -353,12 +355,12 @@ class StateNode {
     }
   }
 
-  getChildLabels(isPartial = false) {
-    return [...this.radixTree.getChildStateLabels(isPartial)];
+  getChildLabels(isPartial = false, lastEndLabel = null) {
+    return [...this.radixTree.getChildStateLabels(isPartial, lastEndLabel)];
   }
 
-  getChildNodes(isPartial = false) {
-    return [...this.radixTree.getChildStateNodes(isPartial)];
+  getChildNodes(isPartial = false, lastEndLabel = null) {
+    return [...this.radixTree.getChildStateNodes(isPartial, lastEndLabel)];
   }
 
   hasChildren() {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -355,12 +355,14 @@ class StateNode {
     }
   }
 
+  // TODO(platfowner): Return endLabel for isPartial = true.
   getChildLabels(isPartial = false, lastEndLabel = null) {
-    return [...this.radixTree.getChildStateLabels(isPartial, lastEndLabel)];
+    return [...this.radixTree.getChildStateLabelsWithEndLabel(isPartial, lastEndLabel).list];
   }
 
+  // TODO(platfowner): Return endLabel for isPartial = true.
   getChildNodes(isPartial = false, lastEndLabel = null) {
-    return [...this.radixTree.getChildStateNodes(isPartial, lastEndLabel)];
+    return [...this.radixTree.getChildStateNodesWithEndLabel(isPartial, lastEndLabel).list];
   }
 
   hasChildren() {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -128,6 +128,7 @@ class StateNode {
    */
   toStateSnapshot(options) {
     const isShallow = options && options.isShallow;
+    const isPartial = options && options.isPartial;
     const includeVersion = options && options.includeVersion;
     const includeTreeInfo = options && options.includeTreeInfo;
     const includeProof = options && options.includeProof;
@@ -135,6 +136,7 @@ class StateNode {
       return this.getValue();
     }
     const obj = {};
+    // TODO(platfowner): Get only partial child labels for isPartial = true.
     for (const label of this.getChildLabels()) {
       const childNode = this.getChild(label);
       if (childNode.getIsLeaf()) {
@@ -153,7 +155,7 @@ class StateNode {
           obj[`${StateLabelProperties.STATE_PROOF_HASH}:${label}`] = childNode.getProofHash();
         }
       } else {
-        obj[label] = isShallow ?
+        obj[label] = (isShallow || isPartial) ?
             { [`${StateLabelProperties.STATE_PROOF_HASH}`]: childNode.getProofHash() } :
             childNode.toStateSnapshot(options);
       }

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -138,7 +138,11 @@ class StateNode {
       return this.getValue();
     }
     const obj = {};
-    for (const label of this.getChildLabels(isPartial, lastEndLabel)) {
+    const childLabelsWithEndLabel = this.getChildLabelsWithEndLabel(isPartial, lastEndLabel);
+    if (isPartial) {
+      obj[`${StateLabelProperties.END_LABEL}`] = childLabelsWithEndLabel.endLabel;
+    }
+    for (const label of childLabelsWithEndLabel.list) {
       const childNode = this.getChild(label);
       if (childNode.getIsLeaf()) {
         obj[label] = childNode.toStateSnapshot(options);
@@ -355,14 +359,20 @@ class StateNode {
     }
   }
 
-  // TODO(platfowner): Return endLabel for isPartial = true.
   getChildLabels(isPartial = false, lastEndLabel = null) {
-    return [...this.radixTree.getChildStateLabelsWithEndLabel(isPartial, lastEndLabel).list];
+    return this.getChildLabelsWithEndLabel(isPartial, lastEndLabel).list;
   }
 
-  // TODO(platfowner): Return endLabel for isPartial = true.
+  getChildLabelsWithEndLabel(isPartial = false, lastEndLabel = null) {
+    return this.radixTree.getChildStateLabelsWithEndLabel(isPartial, lastEndLabel);
+  }
+
   getChildNodes(isPartial = false, lastEndLabel = null) {
-    return [...this.radixTree.getChildStateNodesWithEndLabel(isPartial, lastEndLabel).list];
+    return this.getChildNodesWithEndLabel(isPartial, lastEndLabel).list;
+  }
+
+  getChildNodesWithEndLabel(isPartial = false, lastEndLabel = null) {
+    return this.radixTree.getChildStateNodesWithEndLabel(isPartial, lastEndLabel);
   }
 
   hasChildren() {

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -126,6 +126,7 @@ class StateNode {
   /**
    * Converts this sub-tree to a js object.
    */
+  // TODO(platfowner): Return node serials with the end label for partial results merging.
   toStateSnapshot(options) {
     const isShallow = options && options.isShallow;
     const isPartial = options && options.isPartial;

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -136,8 +136,7 @@ class StateNode {
       return this.getValue();
     }
     const obj = {};
-    // TODO(platfowner): Get only partial child labels for isPartial = true.
-    for (const label of this.getChildLabels()) {
+    for (const label of this.getChildLabels(isPartial)) {
       const childNode = this.getChild(label);
       if (childNode.getIsLeaf()) {
         obj[label] = childNode.toStateSnapshot(options);
@@ -354,12 +353,12 @@ class StateNode {
     }
   }
 
-  getChildLabels() {
-    return [...this.radixTree.getChildStateLabels()];
+  getChildLabels(isPartial = false) {
+    return [...this.radixTree.getChildStateLabels(isPartial)];
   }
 
-  getChildNodes() {
-    return [...this.radixTree.getChildStateNodes()];
+  getChildNodes(isPartial = false) {
+    return [...this.radixTree.getChildStateNodes(isPartial)];
   }
 
   hasChildren() {

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -568,7 +568,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe('/get api', () => {
+    describe('get api', () => {
       it('get', () => {
         const request = {
           op_list: [
@@ -825,7 +825,7 @@ describe('Blockchain Node', () => {
       });
     });
 
-    describe(`${JSON_RPC_METHODS.AIN_GET} api`, () => {
+    describe('json-rpc: ain_get api', () => {
       it('returns the correct value', () => {
         const expected = 100;
         const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
@@ -908,7 +908,7 @@ describe('Blockchain Node', () => {
       });
     });
 
-    describe(`${JSON_RPC_METHODS.AIN_MATCH_FUNCTION} api`, () => {
+    describe('json-rpc: ain_matchFunction api', () => {
       it('returns correct value', () => {
         const ref = "/apps/test/test_function/some/path";
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -936,7 +936,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_MATCH_RULE} api`, () => {
+    describe('json-rpc: ain_matchRule api', () => {
       it('returns correct value (write)', () => {
         const ref = "/apps/test/test_rule/some/path";
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -1062,7 +1062,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_MATCH_OWNER} api`, () => {
+    describe('json-rpc api: ain_matchOwner', () => {
       it('returns correct value', () => {
         const ref = "/apps/test/test_owner/some/path";
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -1091,7 +1091,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_EVAL_RULE} api`, () => {
+    describe('json-rpc api: ain_evalRule', () => {
       it('returns true', () => {
         const ref = "/apps/test/test_rule/some/path";
         const value = "value";
@@ -1123,7 +1123,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_EVAL_OWNER} api`, () => {
+    describe('json-rpc api: ain_evalOwner', () => {
       it('returns correct value', () => {
         const ref = "/apps/test/test_owner/some/path";
         const address = "abcd";
@@ -1167,7 +1167,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_STATE_PROOF} api`, () => {
+    describe('json-rpc api: ain_getStateProof', () => {
       it('returns correct value', () => {
         const ref = '/values/blockchain_params/token/symbol';
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -1187,7 +1187,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_PROOF_HASH} api`, () => {
+    describe('json-rpc api: ain_getProofHash', () => {
       it('returns correct value', () => {
         const ref = '/values/blockchain_params/token/symbol';
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -1198,7 +1198,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_STATE_INFO} api`, () => {
+    describe('json-rpc api: ain_getStateInfo', () => {
       it('returns correct value', () => {
         const ref = '/values/apps/test/test_state_info/some/path';
         const request = { ref, protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
@@ -1221,7 +1221,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_STATE_USAGE} api`, () => {
+    describe('json-rpc api: ain_getStateUsage', () => {
       it('with existing app name', () => {
         const request = { app_name: 'test', protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
         return jayson.client.http(server1 + '/json-rpc').request(JSON_RPC_METHODS.AIN_GET_STATE_USAGE, request)
@@ -1273,7 +1273,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_PROTOCOL_VERSION} api`, () => {
+    describe('json-rpc api: ain_getProtocolVersion', () => {
       it('returns the correct version', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_GET_PROTOCOL_VERSION, {})
@@ -1283,7 +1283,7 @@ describe('Blockchain Node', () => {
       });
     });
 
-    describe(`${JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION} api`, () => {
+    describe('json-rpc api: ain_checkProtocolVersion', () => {
       it('returns success code', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, { protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION })
@@ -1330,7 +1330,7 @@ describe('Blockchain Node', () => {
       });
     })
 
-    describe(`${JSON_RPC_METHODS.AIN_GET_ADDRESS} api`, () => {
+    describe('json-rpc api: ain_getAddress', () => {
       it('returns the correct node address', () => {
         const expAddr = '0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204';
         const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
@@ -2977,7 +2977,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe('ain_sendSignedTransaction api', () => {
+    describe('json-rpc api: ain_sendSignedTransaction', () => {
       const account = {
         address: "0x9534bC7529961E5737a3Dd317BdEeD41AC08a52D",
         private_key: "e96292ef0676287908fc3461f747f106b7b9336f183b1766f83672fbe893664d",
@@ -3914,7 +3914,7 @@ describe('Blockchain Node', () => {
       })
     })
 
-    describe('ain_sendSignedTransactionBatch api', () => {
+    describe('json-rpc api: ain_sendSignedTransactionBatch', () => {
       const account = {
         address: "0x85a620A5A46d01cc1fCF49E73ab00710d4da943E",
         private_key: "b542fc2ca4a68081b3ba238888d3a8783354c3aa81711340fd69f6ff32798525",

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -319,7 +319,7 @@ describe("DB operations", () => {
         node.db.stateManager.finalizeVersion(backupFinalVersion);
       })
 
-      it('getValue to retrieve value near top of database with is_shallow', () => {
+      it('getValue to retrieve value near top of database with isShallow = true', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { isShallow: true }), {
           'ai': {
             "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
@@ -339,7 +339,7 @@ describe("DB operations", () => {
         })
       });
 
-      it('getValue to retrieve value near top of database with is_partial', () => {
+      it('getValue to retrieve value near top of database with isPartial = true', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
           'ai': {
             "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
@@ -356,6 +356,7 @@ describe("DB operations", () => {
           'shards': {
             "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
           },
+          "#end_label": "736861726473"
         })
       });
 
@@ -623,7 +624,7 @@ describe("DB operations", () => {
         expect(node.db.getValue("/apps/test/nested/far/down/to/nowhere")).to.equal(null)
       })
 
-      it("getValue to fail with value not present with is_shallow", () => {
+      it("getValue to fail with value not present with isShallow = true", () => {
         expect(node.db.getValue("/apps/test/nested/far/down/to/nowhere", true, false)).to.equal(null)
       })
     })
@@ -977,19 +978,20 @@ describe("DB operations", () => {
         });
       })
 
-      it("getFunction to retrieve existing function config with is_shallow", () => {
+      it("getFunction to retrieve existing function config with isShallow = true", () => {
         assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isShallow: true }), {
-          some: {
+          "some": {
             "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5"
           },
         });
       })
 
-      it("getFunction to retrieve existing function config with is_partial", () => {
+      it("getFunction to retrieve existing function config with isPartial = true", () => {
         assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true }), {
-          some: {
-            "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5"
+          "some": {
+            "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5",
           },
+          "#end_label": "736f6d65"
         });
       })
     })
@@ -1252,14 +1254,15 @@ describe("DB operations", () => {
         });
       })
 
-      it('getRule to retrieve existing rule config with is_partial', () => {
+      it('getRule to retrieve existing rule config with isPartial = true', () => {
         assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true }), {
           "some": {
             "#state_ph": "0x2be40be7d05dfe5a88319f6aa0f1a7eb61691f8f5fae8c7c993f10892cd29038"
           },
           "syntax": {
             "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732"
-          }
+          },
+          "#end_label": "73796e746178"
         });
       });
     })
@@ -1792,19 +1795,20 @@ describe("DB operations", () => {
         });
       })
 
-      it("getOwner to retrieve existing owner config with is_shallow", () => {
+      it("getOwner to retrieve existing owner config with isShallow = true", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isShallow: true }), {
-          some: {
+          "some": {
             "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80"
           },
         })
       })
 
-      it("getOwner to retrieve existing owner config with is_partial", () => {
+      it("getOwner to retrieve existing owner config with isPartial = true", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true }), {
-          some: {
-            "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80"
+          "some": {
+            "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80",
           },
+          "#end_label": "736f6d65"
         })
       })
     })

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -339,7 +339,7 @@ describe("DB operations", () => {
         })
       });
 
-      it('getValue to retrieve value near top of database with isPartial = true', () => {
+      it('getValue to retrieve value near top of database with isPartial = true and lastEndLabel', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
           'ai': {
             "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
@@ -358,6 +358,53 @@ describe("DB operations", () => {
           },
           "#end_label": "736861726473"
         })
+        // lastEndLabel = "736861726472" ("736861726473" - 1)
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "736861726472" }), {
+          'shards': {
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+          },
+          "#end_label": "736861726473"
+        })
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "736861726473" }), {
+          "#end_label": null
+        })
+      });
+
+      it('getValue to retrieve value near top of database with isPartial = true and lastEndLabel - chaining', () => {
+        // Change GET_RESP_MAX_SIBLINGS value for testing.
+        const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
+
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
+          "ai": {
+            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
+          },
+          "decrement": {
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+          },
+          "#end_label": "64656372656d656e74"
+        })
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "64656372656d656e74" }), {
+          "increment": {
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+          },
+          "nested": {
+            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f"
+          },
+          "#end_label": "6e6573746564"
+        })
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "6e6573746564" }), {
+          "shards": {
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+          },
+          "#end_label": "736861726473"
+        })
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "736861726473" }), {
+          "#end_label": null
+        })
+
+        // Restore GET_RESP_MAX_SIBLINGS value.
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
       });
 
       it('getValue to retrieve value with include_tree_info', () => {
@@ -986,12 +1033,22 @@ describe("DB operations", () => {
         });
       })
 
-      it("getFunction to retrieve existing function config with isPartial = true", () => {
+      it("getFunction to retrieve existing function config with isPartial = true and lastEndLabel", () => {
         assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true }), {
           "some": {
             "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5",
           },
           "#end_label": "736f6d65"
+        });
+        // lastEndLabel = "736f6d64" ("736f6d65" - 1)
+        assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true, lastEndLabel: "736f6d64" }), {
+          "some": {
+            "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5",
+          },
+          "#end_label": "736f6d65"
+        });
+        assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true, lastEndLabel: "736f6d65" }), {
+          "#end_label": null
         });
       })
     })
@@ -1254,7 +1311,7 @@ describe("DB operations", () => {
         });
       })
 
-      it('getRule to retrieve existing rule config with isPartial = true', () => {
+      it('getRule to retrieve existing rule config with isPartial = true and lastEndLabel', () => {
         assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true }), {
           "some": {
             "#state_ph": "0x2be40be7d05dfe5a88319f6aa0f1a7eb61691f8f5fae8c7c993f10892cd29038"
@@ -1263,6 +1320,16 @@ describe("DB operations", () => {
             "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732"
           },
           "#end_label": "73796e746178"
+        });
+        // lastEndLabel = "73796e746177" ("73796e746178" - 1)
+        assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true, lastEndLabel: "73796e746177" }), {
+          "syntax": {
+            "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732"
+          },
+          "#end_label": "73796e746178"
+        });
+        assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true, lastEndLabel: "73796e746178" }), {
+          "#end_label": null
         });
       });
     })
@@ -1803,12 +1870,22 @@ describe("DB operations", () => {
         })
       })
 
-      it("getOwner to retrieve existing owner config with isPartial = true", () => {
+      it("getOwner to retrieve existing owner config with isPartial = true and lastEndLabel", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true }), {
           "some": {
             "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80",
           },
           "#end_label": "736f6d65"
+        })
+        // lastEndLabel = "736f6d64" ("736f6d65" - 1)
+        assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true, lastEndLabel: "736f6d64" }), {
+          "some": {
+            "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80",
+          },
+          "#end_label": "736f6d65"
+        })
+        assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true, lastEndLabel: "736f6d65" }), {
+          "#end_label": null
         })
       })
     })

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -339,6 +339,26 @@ describe("DB operations", () => {
         })
       });
 
+      it('getValue to retrieve value near top of database with is_partial', () => {
+        assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
+          'ai': {
+            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
+          },
+          'increment': {
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+          },
+          'decrement': {
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+          },
+          'nested': {
+            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f"
+          },
+          'shards': {
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+          },
+        })
+      });
+
       it('getValue to retrieve value with include_tree_info', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { includeTreeInfo: true }), {
           "#num_children": 5,
@@ -964,6 +984,14 @@ describe("DB operations", () => {
           },
         });
       })
+
+      it("getFunction to retrieve existing function config with is_partial", () => {
+        assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true }), {
+          some: {
+            "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5"
+          },
+        });
+      })
     })
 
     describe("matchFunction:", () => {
@@ -1224,8 +1252,8 @@ describe("DB operations", () => {
         });
       })
 
-      it('getRule to retrieve existing rule config with is_shallow', () => {
-        assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isShallow: true }), {
+      it('getRule to retrieve existing rule config with is_partial', () => {
+        assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true }), {
           "some": {
             "#state_ph": "0x2be40be7d05dfe5a88319f6aa0f1a7eb61691f8f5fae8c7c993f10892cd29038"
           },
@@ -1766,6 +1794,14 @@ describe("DB operations", () => {
 
       it("getOwner to retrieve existing owner config with is_shallow", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isShallow: true }), {
+          some: {
+            "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80"
+          },
+        })
+      })
+
+      it("getOwner to retrieve existing owner config with is_partial", () => {
+        assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true }), {
           some: {
             "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80"
           },

--- a/test/unit/radix-node.test.js
+++ b/test/unit/radix-node.test.js
@@ -1304,6 +1304,110 @@ describe("radix-node", () => {
           ]);
     });
 
+    it("getChildStateNodeList with non-null maxListSize", () => {
+      // maxListSize = -1
+      const stateNodes1 = node.getChildStateNodeList(-1);
+      expect(stateNodes1.length).to.equal(0)
+      assert.deepEqual(
+          stateNodes1, []);
+
+      // maxListSize = 0
+      const stateNodes2 = node.getChildStateNodeList(0);
+      expect(stateNodes2.length).to.equal(0)
+      assert.deepEqual(
+          stateNodes2, []);
+
+      // maxListSize = 1
+      const stateNodes3 = node.getChildStateNodeList(1);
+      expect(stateNodes3.length).to.equal(1)
+      assert.deepEqual(
+          stateNodes3, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 4
+      const stateNodes4 = node.getChildStateNodeList(4);
+      expect(stateNodes4.length).to.equal(4)
+      assert.deepEqual(
+          stateNodes4, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            // skip the node of serial 1
+          ]);
+
+      // maxListSize = 5
+      const stateNodes5 = node.getChildStateNodeList(5);
+      expect(stateNodes5.length).to.equal(5)
+      assert.deepEqual(
+          stateNodes5, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+          ]);
+
+      // maxListSize = 6
+      const stateNodes6 = node.getChildStateNodeList(6);
+      expect(stateNodes6.length).to.equal(5)
+      assert.deepEqual(
+          stateNodes6, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+          ]);
+    });
+
     it("deleteRadixTreeVersion", () => {
       const versionAnother = 'ver_another';
       const versionYetAnother = 'ver_yet_another';

--- a/test/unit/radix-node.test.js
+++ b/test/unit/radix-node.test.js
@@ -1276,11 +1276,12 @@ describe("radix-node", () => {
       });
     });
 
-    it("getChildStateNodeList", () => {
-      const stateNodes = node.getChildStateNodeList();
-      expect(stateNodes.length).to.equal(5)
+    it("getChildStateNodeListWithEndLabel", () => {
+      const nodeListWithEndLabel = node.getChildStateNodeListWithEndLabel();
+      expect(nodeListWithEndLabel.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel.list.length).to.equal(5)
       assert.deepEqual(
-          stateNodes, [
+          nodeListWithEndLabel.list, [
             {
               serial: 0,
               stateNode: stateNode,
@@ -1306,22 +1307,23 @@ describe("radix-node", () => {
 
     it("getChildStateNodeList with non-null maxListSize", () => {
       // maxListSize = -1
-      const stateNodes1 = node.getChildStateNodeList(-1);
-      expect(stateNodes1.length).to.equal(0)
-      assert.deepEqual(
-          stateNodes1, []);
+      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(-1);
+      expect(nodeListWithEndLabel1.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel1.list.length).to.equal(0)
+      assert.deepEqual(nodeListWithEndLabel1.list, []);
 
       // maxListSize = 0
-      const stateNodes2 = node.getChildStateNodeList(0);
-      expect(stateNodes2.length).to.equal(0)
-      assert.deepEqual(
-          stateNodes2, []);
+      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(0);
+      expect(nodeListWithEndLabel2.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel2.list.length).to.equal(0)
+      assert.deepEqual(nodeListWithEndLabel2.list, []);
 
       // maxListSize = 1
-      const stateNodes3 = node.getChildStateNodeList(1);
-      expect(stateNodes3.length).to.equal(1)
+      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(1);
+      expect(nodeListWithEndLabel3.endLabel).to.equal('0000')
+      expect(nodeListWithEndLabel3.list.length).to.equal(1)
       assert.deepEqual(
-          stateNodes3, [
+          nodeListWithEndLabel3.list, [
             {
               serial: 0,
               stateNode: stateNode,
@@ -1329,11 +1331,50 @@ describe("radix-node", () => {
             // skip the other nodes
           ]);
 
-      // maxListSize = 4
-      const stateNodes4 = node.getChildStateNodeList(4);
-      expect(stateNodes4.length).to.equal(4)
+      // maxListSize = 2
+      const nodeListWithEndLabel4 = node.getChildStateNodeListWithEndLabel(2);
+      expect(nodeListWithEndLabel4.endLabel).to.equal('00001001')
+      expect(nodeListWithEndLabel4.list.length).to.equal(2)
       assert.deepEqual(
-          stateNodes4, [
+          nodeListWithEndLabel4.list, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+            // skip the node of serial 1
+          ]);
+
+      // maxListSize = 3
+      const nodeListWithEndLabel5 = node.getChildStateNodeListWithEndLabel(3);
+      expect(nodeListWithEndLabel5.endLabel).to.equal('00002002')
+      expect(nodeListWithEndLabel5.list.length).to.equal(3)
+      assert.deepEqual(
+          nodeListWithEndLabel5.list, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            // skip the node of serial 1
+          ]);
+
+      // maxListSize = 4
+      const nodeListWithEndLabel6 = node.getChildStateNodeListWithEndLabel(4);
+      expect(nodeListWithEndLabel6.endLabel).to.equal('000020021021')
+      expect(nodeListWithEndLabel6.list.length).to.equal(4)
+      assert.deepEqual(
+          nodeListWithEndLabel6.list, [
             {
               serial: 0,
               stateNode: stateNode,
@@ -1354,10 +1395,11 @@ describe("radix-node", () => {
           ]);
 
       // maxListSize = 5
-      const stateNodes5 = node.getChildStateNodeList(5);
-      expect(stateNodes5.length).to.equal(5)
+      const nodeListWithEndLabel7 = node.getChildStateNodeListWithEndLabel(5);
+      expect(nodeListWithEndLabel7.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel7.list.length).to.equal(5)
       assert.deepEqual(
-          stateNodes5, [
+          nodeListWithEndLabel7.list, [
             {
               serial: 0,
               stateNode: stateNode,
@@ -1381,10 +1423,11 @@ describe("radix-node", () => {
           ]);
 
       // maxListSize = 6
-      const stateNodes6 = node.getChildStateNodeList(6);
-      expect(stateNodes6.length).to.equal(5)
+      const nodeListWithEndLabel8 = node.getChildStateNodeListWithEndLabel(6);
+      expect(nodeListWithEndLabel8.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel8.list.length).to.equal(5)
       assert.deepEqual(
-          stateNodes6, [
+          nodeListWithEndLabel8.list, [
             {
               serial: 0,
               stateNode: stateNode,

--- a/test/unit/radix-node.test.js
+++ b/test/unit/radix-node.test.js
@@ -1559,10 +1559,10 @@ describe("radix-node", () => {
           ]);
     });
 
-    it("getChildStateNodeListWithLabel with various lastEndLabel", () => {
+    it("getChildStateNodeListWithLabel with non-existing lastEndLabel", () => {
       // maxListSize = 2
-      // lastEndLabel = '00002002' (childStateNode2) + '0'
-      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(2, '00002002' + '0');
+      // lastEndLabel = '000020020' (= '00002002' (childStateNode2) + '0')
+      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(2, '000020020');
       expect(nodeListWithEndLabel1.endLabel).to.equal('000020022022')
       expect(nodeListWithEndLabel1.list.length).to.equal(2)
       assert.deepEqual(
@@ -1580,8 +1580,8 @@ describe("radix-node", () => {
           ]);
 
       // maxListSize = 2
-      // lastEndLabel = '00002002' (childStateNode2) + '00'
-      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(2, '00002002' + '00');
+      // lastEndLabel = '0000200200' (= '00002002' (childStateNode2) + '00')
+      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(2, '0000200200');
       expect(nodeListWithEndLabel2.endLabel).to.equal('000020022022')
       expect(nodeListWithEndLabel2.list.length).to.equal(2)
       assert.deepEqual(
@@ -1599,12 +1599,50 @@ describe("radix-node", () => {
           ]);
 
       // maxListSize = 2
-      // lastEndLabel = '000022' (non-existing node)
-      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(2, '000022');
-      expect(nodeListWithEndLabel3.endLabel).to.equal(null)
-      expect(nodeListWithEndLabel3.list.length).to.equal(0)
+      // lastEndLabel = '000020' (= '00002002' (childStateNode2) - '02')
+      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(2, '000020');
+      expect(nodeListWithEndLabel3.endLabel).to.equal('000020021021')
+      expect(nodeListWithEndLabel3.list.length).to.equal(2)
       assert.deepEqual(
-          nodeListWithEndLabel3.list, []);
+          nodeListWithEndLabel3.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '00002' (= '00002002' (childStateNode2) - '002')
+      const nodeListWithEndLabel4 = node.getChildStateNodeListWithEndLabel(2, '00002');
+      expect(nodeListWithEndLabel4.endLabel).to.equal('000020021021')
+      expect(nodeListWithEndLabel4.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel4.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '000021' (= '00002002' (childStateNode2) - '002' + '1')
+      const nodeListWithEndLabel5 = node.getChildStateNodeListWithEndLabel(2, '000021');
+      expect(nodeListWithEndLabel5.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel5.list.length).to.equal(0)
+      assert.deepEqual(
+          nodeListWithEndLabel5.list, []);
     });
 
     it("getChildStateNodeListWithLabel chaining with endLabel and lastEndLabel", () => {

--- a/test/unit/radix-node.test.js
+++ b/test/unit/radix-node.test.js
@@ -1276,6 +1276,20 @@ describe("radix-node", () => {
       });
     });
 
+    it("compareRadixLabelWithPrefix", () => {
+      expect(RadixNode.compareRadixLabelWithPrefix('', '')).to.equal(0);
+      expect(RadixNode.compareRadixLabelWithPrefix('', 'aabbcc')).to.equal(0);
+      expect(RadixNode.compareRadixLabelWithPrefix('a', 'aabbcc')).to.equal(0);
+      expect(RadixNode.compareRadixLabelWithPrefix('aa', 'aabbcc')).to.equal(0);
+      expect(RadixNode.compareRadixLabelWithPrefix('aab', 'aabbcc')).to.equal(0);
+      expect(RadixNode.compareRadixLabelWithPrefix('aab9', 'aabbcc')).to.equal(-1);
+      expect(RadixNode.compareRadixLabelWithPrefix('aab9c', 'aabbcc')).to.equal(-1);
+      expect(RadixNode.compareRadixLabelWithPrefix('aabc', 'aabbcc')).to.equal(1);
+      expect(RadixNode.compareRadixLabelWithPrefix('aabcc', 'aabbcc')).to.equal(1);
+      expect(RadixNode.compareRadixLabelWithPrefix('ab', 'aabbcc')).to.equal(1);
+      expect(RadixNode.compareRadixLabelWithPrefix('aabbcc', 'aabbcc')).to.equal(0);
+    });
+
     it("getChildStateNodeListWithEndLabel", () => {
       const nodeListWithEndLabel = node.getChildStateNodeListWithEndLabel();
       expect(nodeListWithEndLabel.endLabel).to.equal('000020022022')
@@ -1305,7 +1319,7 @@ describe("radix-node", () => {
           ]);
     });
 
-    it("getChildStateNodeList with non-null maxListSize", () => {
+    it("getChildStateNodeListWithLabel with non-null maxListSize", () => {
       // maxListSize = -1
       const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(-1);
       expect(nodeListWithEndLabel1.endLabel).to.equal(null)
@@ -1345,7 +1359,7 @@ describe("radix-node", () => {
               serial: 3,
               stateNode: childStateNode1,
             },
-            // skip the node of serial 1
+            // skip the other nodes
           ]);
 
       // maxListSize = 3
@@ -1366,7 +1380,7 @@ describe("radix-node", () => {
               serial: 4,
               stateNode: childStateNode2,
             },
-            // skip the node of serial 1
+            // skip the other nodes
           ]);
 
       // maxListSize = 4
@@ -1391,7 +1405,7 @@ describe("radix-node", () => {
               serial: 2,
               stateNode: childStateNode21,
             },
-            // skip the node of serial 1
+            // skip the other nodes
           ]);
 
       // maxListSize = 5
@@ -1449,6 +1463,204 @@ describe("radix-node", () => {
               stateNode: childStateNode22,
             },
           ]);
+    });
+
+    it("getChildStateNodeListWithLabel with non-null maxListSize and lastEndLabel", () => {
+      // maxListSize = -1
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(-1, '00001001');
+      expect(nodeListWithEndLabel1.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel1.list.length).to.equal(0)
+      assert.deepEqual(nodeListWithEndLabel1.list, []);
+
+      // maxListSize = 0
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(0, '00001001');
+      expect(nodeListWithEndLabel2.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel2.list.length).to.equal(0)
+      assert.deepEqual(nodeListWithEndLabel2.list, []);
+
+      // maxListSize = 1
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(1, '00001001');
+      expect(nodeListWithEndLabel3.endLabel).to.equal('00002002')
+      expect(nodeListWithEndLabel3.list.length).to.equal(1)
+      assert.deepEqual(
+          nodeListWithEndLabel3.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel4 = node.getChildStateNodeListWithEndLabel(2, '00001001');
+      expect(nodeListWithEndLabel4.endLabel).to.equal('000020021021')
+      expect(nodeListWithEndLabel4.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel4.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 5
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel5 = node.getChildStateNodeListWithEndLabel(5, '00001001');
+      expect(nodeListWithEndLabel5.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel5.list.length).to.equal(3)
+      assert.deepEqual(
+          nodeListWithEndLabel5.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+          ]);
+
+      // maxListSize = 6
+      // lastEndLabel = '00001001' (childStateNode1)
+      const nodeListWithEndLabel6 = node.getChildStateNodeListWithEndLabel(6, '00001001');
+      expect(nodeListWithEndLabel6.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel6.list.length).to.equal(3)
+      assert.deepEqual(
+          nodeListWithEndLabel6.list, [
+            // skip previous nodes
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+          ]);
+    });
+
+    it("getChildStateNodeListWithLabel with various lastEndLabel", () => {
+      // maxListSize = 2
+      // lastEndLabel = '00002002' (childStateNode2) + '0'
+      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(2, '00002002' + '0');
+      expect(nodeListWithEndLabel1.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel1.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel1.list, [
+            // skip previous nodes
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '00002002' (childStateNode2) + '00'
+      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(2, '00002002' + '00');
+      expect(nodeListWithEndLabel2.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel2.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel2.list, [
+            // skip previous nodes
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+            // skip the other nodes
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '000022' (non-existing node)
+      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(2, '000022');
+      expect(nodeListWithEndLabel3.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel3.list.length).to.equal(0)
+      assert.deepEqual(
+          nodeListWithEndLabel3.list, []);
+    });
+
+    it("getChildStateNodeListWithLabel chaining with endLabel and lastEndLabel", () => {
+      // maxListSize = 2
+      // lastEndLabel = null
+      const nodeListWithEndLabel1 = node.getChildStateNodeListWithEndLabel(2, null);
+      expect(nodeListWithEndLabel1.endLabel).to.equal('00001001')
+      expect(nodeListWithEndLabel1.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel1.list, [
+            {
+              serial: 0,
+              stateNode: stateNode,
+            },
+            {
+              serial: 3,
+              stateNode: childStateNode1,
+            },
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '00001001'
+      const nodeListWithEndLabel2 = node.getChildStateNodeListWithEndLabel(2, '00001001');
+      expect(nodeListWithEndLabel2.endLabel).to.equal('000020021021')
+      expect(nodeListWithEndLabel2.list.length).to.equal(2)
+      assert.deepEqual(
+          nodeListWithEndLabel2.list, [
+            {
+              serial: 4,
+              stateNode: childStateNode2,
+            },
+            {
+              serial: 2,
+              stateNode: childStateNode21,
+            },
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '000020021021'
+      const nodeListWithEndLabel3 = node.getChildStateNodeListWithEndLabel(2, '000020021021');
+      expect(nodeListWithEndLabel3.endLabel).to.equal('000020022022')
+      expect(nodeListWithEndLabel3.list.length).to.equal(1)
+      assert.deepEqual(
+          nodeListWithEndLabel3.list, [
+            {
+              serial: 1,
+              stateNode: childStateNode22,
+            },
+          ]);
+
+      // maxListSize = 2
+      // lastEndLabel = '000020022022'
+      const nodeListWithEndLabel4 = node.getChildStateNodeListWithEndLabel(2, '000020022022');
+      expect(nodeListWithEndLabel4.endLabel).to.equal(null)
+      expect(nodeListWithEndLabel4.list.length).to.equal(0)
+      assert.deepEqual(nodeListWithEndLabel4.list, []);
     });
 
     it("deleteRadixTreeVersion", () => {

--- a/test/unit/radix-tree.test.js
+++ b/test/unit/radix-tree.test.js
@@ -2905,6 +2905,30 @@ describe("radix-tree", () => {
         // Restore GET_RESP_MAX_SIBLINGS value.
         NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
       });
+
+      it("getChildStateLabelsWithEndLabel / getChildStateNodesWithEndLabel with isPartial = true and lastEndLabel", () => {
+        // Change GET_RESP_MAX_SIBLINGS value for testing.
+        const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
+
+        // lastEndLabel = '000bbb' (stateNode2)
+
+        const labelsWithEndLabel = tree.getChildStateLabelsWithEndLabel(true, '000bbb');
+        assert.deepEqual(labelsWithEndLabel.list, [
+          label22,
+          label21,
+        ]);
+        expect(labelsWithEndLabel.endLabel).to.equal('000bbb222');
+        const nodesWithEndLabel = tree.getChildStateNodesWithEndLabel(true, '000bbb');
+        assert.deepEqual(nodesWithEndLabel.list, [
+          stateNode22,
+          stateNode21,
+        ]);
+        expect(nodesWithEndLabel.endLabel).to.equal('000bbb222');
+
+        // Restore GET_RESP_MAX_SIBLINGS value.
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
+      });
     });
 
     describe("radix info", () => {

--- a/test/unit/radix-tree.test.js
+++ b/test/unit/radix-tree.test.js
@@ -4,6 +4,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 const RadixNode = require('../../db/radix-node');
 const StateNode = require('../../db/state-node');
+const { NodeConfigs } = require('../../common/constants');
 
 describe("radix-tree", () => {
 
@@ -2864,6 +2865,28 @@ describe("radix-tree", () => {
         assert.deepEqual(
             cloned.getChildStateNodes(),
             [ stateNode22, newStateNode21, stateNode1, stateNode2, newStateNode23 ]);
+      });
+
+      it("getChildStateLabels / getChildStateNodes with isPartial = true", () => {
+        const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = 3;
+        // Insertion order is kept
+        assert.deepEqual(tree.getChildStateLabels(true), [
+          // skip label22
+          label21,
+          label1,
+          label2
+        ]);
+        assert.deepEqual(
+            tree.getChildStateNodes(true), [
+              // skip stateNode22
+              stateNode21,
+              stateNode1,
+              stateNode2
+            ]);
+
+        NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
       });
     });
 

--- a/test/unit/radix-tree.test.js
+++ b/test/unit/radix-tree.test.js
@@ -2838,18 +2838,26 @@ describe("radix-tree", () => {
         cloned = tree.clone(version2);
       });
 
-      it("getChildStateLabels / getChildStateNodes", () => {
+      it("getChildStateLabelsWithEndLabel / getChildStateNodesWithEndLabel", () => {
         // Insertion order is kept
-        assert.deepEqual(tree.getChildStateLabels(), [ label22, label21, label1, label2 ]);
+        const labelsWithEndLabel = tree.getChildStateLabelsWithEndLabel();
+        assert.deepEqual(labelsWithEndLabel.list, [ label22, label21, label1, label2 ]);
+        expect(labelsWithEndLabel.endLabel).to.equal('000bbb222');
+        const nodesWithEndLabel = tree.getChildStateNodesWithEndLabel();
         assert.deepEqual(
-            tree.getChildStateNodes(), [ stateNode22, stateNode21, stateNode1, stateNode2 ]);
+            nodesWithEndLabel.list, [ stateNode22, stateNode21, stateNode1, stateNode2 ]);
+        expect(nodesWithEndLabel.endLabel).to.equal('000bbb222');
       });
 
-      it("getChildStateLabels / getChildStateNodes with cloned tree", () => {
+      it("getChildStateLabelsWithEndLabel / getChildStateNodesWithEndLabel with cloned tree", () => {
         // Insertion order is kept.
-        assert.deepEqual(cloned.getChildStateLabels(), [ label22, label21, label1, label2 ]);
+        const labelsWithEndLabelBefore = cloned.getChildStateLabelsWithEndLabel();
+        assert.deepEqual(labelsWithEndLabelBefore.list, [ label22, label21, label1, label2 ]);
+        expect(labelsWithEndLabelBefore.endLabel).to.equal('000bbb222');
+        const nodesWithEndLabelBefore = cloned.getChildStateNodesWithEndLabel();
         assert.deepEqual(
-            cloned.getChildStateNodes(), [ stateNode22, stateNode21, stateNode1, stateNode2 ]);
+            nodesWithEndLabelBefore.list, [ stateNode22, stateNode21, stateNode1, stateNode2 ]);
+        expect(nodesWithEndLabelBefore.endLabel).to.equal('000bbb222');
 
         const newStateNode21 = new StateNode(version2);
         newStateNode21.setLabel(label21);
@@ -2860,32 +2868,41 @@ describe("radix-tree", () => {
         cloned.set(label23, newStateNode23);
 
         // The order does NOT change.
+        const labelsWithEndLabelAfter = cloned.getChildStateLabelsWithEndLabel();
         assert.deepEqual(
-            cloned.getChildStateLabels(), [ label22, label21, label1, label2, label23 ]);
+            labelsWithEndLabelAfter.list, [ label22, label21, label1, label2, label23 ]);
+        expect(labelsWithEndLabelAfter.endLabel).to.equal('000bbb333');
+        const nodesWithEndLabelAfter = cloned.getChildStateNodesWithEndLabel();
         assert.deepEqual(
-            cloned.getChildStateNodes(),
+            nodesWithEndLabelAfter.list,
             [ stateNode22, newStateNode21, stateNode1, stateNode2, newStateNode23 ]);
+        expect(nodesWithEndLabelAfter.endLabel).to.equal('000bbb333');
       });
 
-      it("getChildStateLabels / getChildStateNodes with isPartial = true", () => {
+      it("getChildStateLabelsWithEndLabel / getChildStateNodesWithEndLabel with isPartial = true", () => {
+        // Change GET_RESP_MAX_SIBLINGS value for testing.
         const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
-
         NodeConfigs.GET_RESP_MAX_SIBLINGS = 3;
+
         // Insertion order is kept
-        assert.deepEqual(tree.getChildStateLabels(true), [
+        const labelsWithEndLabel = tree.getChildStateLabelsWithEndLabel(true);
+        assert.deepEqual(labelsWithEndLabel.list, [
           // skip label22
           label21,
           label1,
           label2
         ]);
-        assert.deepEqual(
-            tree.getChildStateNodes(true), [
-              // skip stateNode22
-              stateNode21,
-              stateNode1,
-              stateNode2
-            ]);
+        expect(labelsWithEndLabel.endLabel).to.equal('000bbb111');
+        const nodesWithEndLabel = tree.getChildStateNodesWithEndLabel(true);
+        assert.deepEqual(nodesWithEndLabel.list, [
+          // skip stateNode22
+          stateNode21,
+          stateNode1,
+          stateNode2
+        ]);
+        expect(nodesWithEndLabel.endLabel).to.equal('000bbb111');
 
+        // Restore GET_RESP_MAX_SIBLINGS value.
         NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
       });
     });
@@ -3419,7 +3436,7 @@ describe("radix-tree", () => {
         "#version": "ver",
       });
       assert.deepEqual(treeRebuilt.toRadixSnapshot(), snapshot);
-      assert.deepEqual(treeRebuilt.getChildStateLabels(), [
+      assert.deepEqual(treeRebuilt.getChildStateLabelsWithEndLabel().list, [
         "0x000aaa",
         "0x000bbb",
         "0x000bbb111",

--- a/test/unit/state-node.test.js
+++ b/test/unit/state-node.test.js
@@ -1274,7 +1274,7 @@ describe("state-node", () => {
       expect(parent1.getIsLeaf()).to.equal(true);
     });
 
-    it("getChildLabelsWithEndLabel / getChildNodesWithEndLabel w/ isPartial = true", () => {
+    it("getChildLabelsWithEndLabel / getChildNodesWithEndLabel with isPartial = true", () => {
       // Change GET_RESP_MAX_SIBLINGS value for testing.
       const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
       NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
@@ -1297,9 +1297,11 @@ describe("state-node", () => {
 
       parent1.setChild(label3, child3);
       const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true);
+      // skip label3
       assert.deepEqual(labelsWithEndLabel3.list, ['label1', 'label2']);
       expect(labelsWithEndLabel3.endLabel).to.equal('6c6162656c32');
       const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true);
+      // skip child3
       assert.deepEqual(nodesWithEndLabel3.list, [child1, child2]);
       expect(nodesWithEndLabel3.endLabel).to.equal('6c6162656c32');
 
@@ -1319,6 +1321,96 @@ describe("state-node", () => {
       const nodesWithEndLabel5 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel5.list, []);
       expect(nodesWithEndLabel5.endLabel).to.equal(null);
+
+      // Restore GET_RESP_MAX_SIBLINGS value.
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
+    });
+
+    it("getChildLabelsWithEndLabel / getChildNodesWithEndLabel with isPartial = true and lastEndLabel", () => {
+      // Change GET_RESP_MAX_SIBLINGS value for testing.
+      const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
+
+      // lastEndLabel = ''6c6162656c31' (child1)
+
+      const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(labelsWithEndLabel1.list, []);
+      expect(labelsWithEndLabel1.endLabel).to.equal(null);
+      const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(nodesWithEndLabel1.list, []);
+      expect(nodesWithEndLabel1.endLabel).to.equal(null);
+
+      parent1.setChild(label1, child1);
+      parent1.setChild(label2, child2);
+      const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(labelsWithEndLabel2.list, ['label2']);
+      expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c32');
+      const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(nodesWithEndLabel2.list, [child2]);
+      expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c32');
+
+      parent1.setChild(label3, child3);
+      const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
+      // skip label1
+      assert.deepEqual(labelsWithEndLabel3.list, ['label2', 'label3']);
+      expect(labelsWithEndLabel3.endLabel).to.equal('6c6162656c33');
+      const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
+      // skip child1
+      assert.deepEqual(nodesWithEndLabel3.list, [child2, child3]);
+      expect(nodesWithEndLabel3.endLabel).to.equal('6c6162656c33');
+
+      parent1.deleteChild(label2);
+      const labelsWithEndLabel4 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
+      // skip label1
+      assert.deepEqual(labelsWithEndLabel4.list, ['label3']);
+      expect(labelsWithEndLabel4.endLabel).to.equal('6c6162656c33');
+      const nodesWithEndLabel4 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
+      // skip child1
+      assert.deepEqual(nodesWithEndLabel4.list, [child3]);
+      expect(nodesWithEndLabel4.endLabel).to.equal('6c6162656c33');
+
+      parent1.deleteChild(label3);
+      parent1.deleteChild(label1);
+      const labelsWithEndLabel5 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(labelsWithEndLabel5.list, []);
+      expect(labelsWithEndLabel5.endLabel).to.equal(null);
+      const nodesWithEndLabel5 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
+      assert.deepEqual(nodesWithEndLabel5.list, []);
+      expect(nodesWithEndLabel5.endLabel).to.equal(null);
+
+      // Restore GET_RESP_MAX_SIBLINGS value.
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
+    });
+
+    it("getChildLabelsWithEndLabel / getChildNodesWithEndLabel with isPartial = true and lastEndLabel - chaining", () => {
+      // Change GET_RESP_MAX_SIBLINGS value for testing.
+      const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
+
+      parent1.setChild(label1, child1);
+      parent1.setChild(label2, child2);
+      parent1.setChild(label3, child3);
+
+      const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel1.list, ['label1', 'label2']);
+      expect(labelsWithEndLabel1.endLabel).to.equal('6c6162656c32');
+      const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel1.list, [child1, child2]);
+      expect(nodesWithEndLabel1.endLabel).to.equal('6c6162656c32');
+
+      const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c32');
+      assert.deepEqual(labelsWithEndLabel2.list, ['label3']);
+      expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c33');
+      const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true, '6c6162656c32');
+      assert.deepEqual(nodesWithEndLabel2.list, [child3]);
+      expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c33');
+
+      const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c33');
+      assert.deepEqual(labelsWithEndLabel3.list, []);
+      expect(labelsWithEndLabel3.endLabel).to.equal(null);
+      const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true, '6c6162656c33');
+      assert.deepEqual(nodesWithEndLabel3.list, []);
+      expect(nodesWithEndLabel3.endLabel).to.equal(null);
 
       // Restore GET_RESP_MAX_SIBLINGS value.
       NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;

--- a/test/unit/state-node.test.js
+++ b/test/unit/state-node.test.js
@@ -3,6 +3,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const assert = chai.assert;
 
+const { NodeConfigs } = require('../../common/constants');
 const CommonUtil = require('../../common/common-util');
 const RadixNode = require('../../db/radix-node');
 const RadixTree = require('../../db/radix-tree');
@@ -976,11 +977,13 @@ describe("state-node", () => {
   describe("child", () => {
     const label1 = 'label1';
     const label2 = 'label2';
+    const label3 = 'label3';
 
     let parent1;
     let parent2;
     let child1;
     let child2;
+    let child3;
 
     beforeEach(() => {
       parent1 = new StateNode();
@@ -991,6 +994,9 @@ describe("state-node", () => {
 
       child2 = new StateNode();
       child2.setValue('value2');
+
+      child3 = new StateNode();
+      child3.setValue('value3');
     });
 
     it("get / set / has / delete with single parent", () => {
@@ -1234,7 +1240,24 @@ describe("state-node", () => {
       expect(child2.getIsLeaf()).to.equal(true);
       expect(parent1.getIsLeaf()).to.equal(false);
 
+      parent1.setChild(label3, child3);
+      assert.deepEqual(parent1.getChildLabels(), ['label1', 'label2', 'label3']);
+      assert.deepEqual(parent1.getChildNodes(), [child1, child2, child3]);
+      expect(parent1.numChildren()).to.equal(3);
+      expect(child1.getIsLeaf()).to.equal(true);
+      expect(child2.getIsLeaf()).to.equal(true);
+      expect(child3.getIsLeaf()).to.equal(true);
+      expect(parent1.getIsLeaf()).to.equal(false);
+
       parent1.deleteChild(label2);
+      assert.deepEqual(parent1.getChildLabels(), ['label1', 'label3']);
+      assert.deepEqual(parent1.getChildNodes(), [child1, child3]);
+      expect(parent1.numChildren()).to.equal(2);
+      expect(child1.getIsLeaf()).to.equal(true);
+      expect(child2.getIsLeaf()).to.equal(true);
+      expect(parent1.getIsLeaf()).to.equal(false);
+
+      parent1.deleteChild(label3);
       assert.deepEqual(parent1.getChildLabels(), ['label1']);
       assert.deepEqual(parent1.getChildNodes(), [child1]);
       expect(parent1.numChildren()).to.equal(1);
@@ -1249,6 +1272,56 @@ describe("state-node", () => {
       expect(child1.getIsLeaf()).to.equal(true);
       expect(child2.getIsLeaf()).to.equal(true);
       expect(parent1.getIsLeaf()).to.equal(true);
+    });
+
+    it("getChildLabelsWithEndLabel / getChildNodesWithEndLabel w/ isPartial = true", () => {
+      // Change GET_RESP_MAX_SIBLINGS value for testing.
+      const originalGetRespMaxSiblings = NodeConfigs.GET_RESP_MAX_SIBLINGS;
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = 2;
+
+      const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel1.list, []);
+      expect(labelsWithEndLabel1.endLabel).to.equal(null);
+      const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel1.list, []);
+      expect(nodesWithEndLabel1.endLabel).to.equal(null);
+
+      parent1.setChild(label1, child1);
+      parent1.setChild(label2, child2);
+      const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel2.list, ['label1', 'label2']);
+      expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c32');
+      const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel2.list, [child1, child2]);
+      expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c32');
+
+      parent1.setChild(label3, child3);
+      const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel3.list, ['label1', 'label2']);
+      expect(labelsWithEndLabel3.endLabel).to.equal('6c6162656c32');
+      const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel3.list, [child1, child2]);
+      expect(nodesWithEndLabel3.endLabel).to.equal('6c6162656c32');
+
+      parent1.deleteChild(label2);
+      const labelsWithEndLabel4 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel4.list, ['label1', 'label3']);
+      expect(labelsWithEndLabel4.endLabel).to.equal('6c6162656c33');
+      const nodesWithEndLabel4 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel4.list, [child1, child3]);
+      expect(nodesWithEndLabel4.endLabel).to.equal('6c6162656c33');
+
+      parent1.deleteChild(label3);
+      parent1.deleteChild(label1);
+      const labelsWithEndLabel5 = parent1.getChildLabelsWithEndLabel(true);
+      assert.deepEqual(labelsWithEndLabel5.list, []);
+      expect(labelsWithEndLabel5.endLabel).to.equal(null);
+      const nodesWithEndLabel5 = parent1.getChildNodesWithEndLabel(true);
+      assert.deepEqual(nodesWithEndLabel5.list, []);
+      expect(nodesWithEndLabel5.endLabel).to.equal(null);
+
+      // Restore GET_RESP_MAX_SIBLINGS value.
+      NodeConfigs.GET_RESP_MAX_SIBLINGS = originalGetRespMaxSiblings;
     });
   });
 


### PR DESCRIPTION
Change summary:
- Add child node pagination with is_partial = true option (By this, we support chained retrieval of children)
- Set fromApi=true for GET operations as well
- Let resp sibling number limit be skipped with is_partial option
- Let resp bytes limit be skipped with is_partial or is_shallow options

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/600