### PR TITLE
Return child node serial when is_partial = true

### DIFF
--- a/db/radix-tree.js
+++ b/db/radix-tree.js
@@ -383,6 +383,7 @@ class RadixTree {
     const labelList = nodesWithEndLabel.list.map(entry => entry.getLabel());
     return {
       list: labelList,
+      serialList: nodesWithEndLabel.serialList,
       endLabel: nodesWithEndLabel.endLabel,
     };
   }
@@ -391,11 +392,18 @@ class RadixTree {
     const maxListSize = isPartial ? NodeConfigs.GET_RESP_MAX_SIBLINGS : null;
     const nodeListWithEndLabel =
         this.root.getChildStateNodeListWithEndLabel(maxListSize, lastEndLabel);
-    const sortedNodeList = nodeListWithEndLabel.list
-        .sort((a, b) => a.serial - b.serial)
-        .map(entry => entry.stateNode);
+    const sorted = CommonUtil.isString(lastEndLabel) ?
+        nodeListWithEndLabel.list : // Skip sorting
+        nodeListWithEndLabel.list.sort((a, b) => a.serial - b.serial);
+    const stateNodeList = [];
+    const serialList = [];
+    for (const entry of sorted) {
+      stateNodeList.push(entry.stateNode);
+      serialList.push(entry.serial);
+    }
     return {
-      list: sortedNodeList,
+      list: stateNodeList,
+      serialList,
       endLabel: nodeListWithEndLabel.endLabel,
     };
   }

--- a/db/state-node.js
+++ b/db/state-node.js
@@ -126,7 +126,6 @@ class StateNode {
   /**
    * Converts this sub-tree to a js object.
    */
-  // TODO(platfowner): Return node serials with the end label for partial results merging.
   toStateSnapshot(options) {
     const isShallow = options && options.isShallow;
     const isPartial = options && options.isPartial;
@@ -143,7 +142,8 @@ class StateNode {
     if (isPartial) {
       obj[`${StateLabelProperties.END_LABEL}`] = childLabelsWithEndLabel.endLabel;
     }
-    for (const label of childLabelsWithEndLabel.list) {
+    for (let i = 0; i < childLabelsWithEndLabel.list.length; i++) {
+      const label = childLabelsWithEndLabel.list[i];
       const childNode = this.getChild(label);
       if (childNode.getIsLeaf()) {
         obj[label] = childNode.toStateSnapshot(options);
@@ -164,6 +164,10 @@ class StateNode {
         obj[label] = (isShallow || isPartial) ?
             { [`${StateLabelProperties.STATE_PROOF_HASH}`]: childNode.getProofHash() } :
             childNode.toStateSnapshot(options);
+        if (isPartial) {
+          const serial = childLabelsWithEndLabel.serialList[i];
+          obj[label][`${StateLabelProperties.SERIAL}`] = serial;
+        }
       }
     }
     if (includeVersion) {

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -839,6 +839,86 @@ describe('Blockchain Node', () => {
         });
       });
 
+      it('returns the correct value with is_shallow = true', () => {
+        const expected = 100;
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
+          protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/test/test_value/some/path",
+          is_shallow: true  // w/ is_shallow = true
+        })
+        .then(res => {
+          expect(res.result.result).to.equal(expected);
+        });
+      });
+
+      it('returns the correct value with is_partial = true', () => {
+        const expected = 100;
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
+          protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/test/test_value/some/path",
+          is_partial: true  // w/ is_partial = true
+        })
+        .then(res => {
+          expect(res.result.result).to.equal(expected);
+        });
+      });
+
+      it('returns the correct object value', () => {
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
+          protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/test/test_value"
+        })
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "some": {
+              "path": 100
+            }
+          });
+        });
+      });
+
+      it('returns the correct object value with is_shallow = true', () => {
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
+          protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/test/test_value",
+          is_shallow: true  // w/ is_shallow = true
+        })
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "some": {
+              "#state_ph": "0x1f8ea4b70d822143cd8545d3c248ac33f14c60053c86d2b44ee6bb9381c21d62"
+            }
+          });
+        });
+      });
+
+      it('returns the correct object value with is_partial = true', () => {
+        const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
+        return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
+          protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
+          type: 'GET_VALUE',
+          ref: "/apps/test/test_value",
+          is_partial: true  // w/ is_partial = true
+        })
+        .then(res => {
+          assert.deepEqual(res.result.result, {
+            "#end_label": "736f6d65",
+            "some": {
+              "#serial": 2,
+              "#state_ph": "0x1f8ea4b70d822143cd8545d3c248ac33f14c60053c86d2b44ee6bb9381c21d62",
+            }
+          });
+        });
+      });
+
       it('returns error when invalid op_list is given', () => {
         const jsonRpcClient = jayson.client.http(server2 + '/json-rpc');
         return jsonRpcClient.request(JSON_RPC_METHODS.AIN_GET, {
@@ -881,8 +961,8 @@ describe('Blockchain Node', () => {
         });
       });
 
-      // the same as the previous test case but is_shallow option
-      it('returns a correct value with is_shallow option', async () => {
+      // the same as the previous test case but is_shallow = true
+      it('returns a correct value with is_shallow = true', async () => {
         const bigTree = {};
         for (let i = 0; i < 10; i++) {
           bigTree[i] = {};
@@ -902,7 +982,7 @@ describe('Blockchain Node', () => {
           protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
           type: 'GET_VALUE',
           ref: "/apps/test/test_value/some/path",
-          is_shallow: true  // w/ is_shallow option
+          is_shallow: true  // w/ is_shallow = true
         })
         .then(res => {
           expect(res.result.result.code).to.equal(undefined);
@@ -935,8 +1015,8 @@ describe('Blockchain Node', () => {
         });
       });
 
-      // the same as the previous test case but is_partial option
-      it('returns a correct value with is_partial option', async () => {
+      // the same as the previous test case but is_partial = true
+      it('returns a correct value with is_partial = true', async () => {
         const wideTree = {};
         for (let i = 0; i < 1000; i++) {
           wideTree[i] = 'a';
@@ -953,7 +1033,7 @@ describe('Blockchain Node', () => {
           protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
           type: 'GET_VALUE',
           ref: "/apps/test/test_value/some/path",
-          is_partial: true  // w/ is_partial option
+          is_partial: true  // w/ is_partial = true
         })
         .then(res => {
           expect(res.result.result['#end_label']).to.equal('393938');

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -342,26 +342,32 @@ describe("DB operations", () => {
       it('getValue to retrieve value near top of database with isPartial = true and lastEndLabel', () => {
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
           'ai': {
-            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
+            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec",
+            "#serial": 2,
           },
           'increment': {
-            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8",
+            "#serial": 5,
           },
           'decrement': {
-            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8",
+            "#serial": 7,
           },
           'nested': {
-            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f"
+            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f",
+            "#serial": 9,
           },
           'shards': {
-            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223",
+            "#serial": 11,
           },
           "#end_label": "736861726473"
         })
         // lastEndLabel = "736861726472" ("736861726473" - 1)
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "736861726472" }), {
           'shards': {
-            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223",
+            "#serial": 11,
           },
           "#end_label": "736861726473"
         })
@@ -377,25 +383,30 @@ describe("DB operations", () => {
 
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true }), {
           "ai": {
-            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec"
+            "#state_ph": "0x4c6895fec04b40d425d1542b7cfb2f78b0e8cd2dc4d35d0106100f1ecc168cec",
+            "#serial": 2,
           },
           "decrement": {
-            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8",
+            "#serial": 7,
           },
           "#end_label": "64656372656d656e74"
         })
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "64656372656d656e74" }), {
           "increment": {
-            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8"
+            "#state_ph": "0x11d1aa4946a3e44e3d467d4da85617d56aecd2559fdd6d9e5dd8fb6b5ded71b8",
+            "#serial": 5,
           },
           "nested": {
-            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f"
+            "#state_ph": "0x8763e301c728729e38c1f5500a2af7163783bdf0948a7baf7bc87b35f33b347f",
+            "#serial": 9,
           },
           "#end_label": "6e6573746564"
         })
         assert.deepEqual(node.db.getValue('/apps/test', { isPartial: true, lastEndLabel: "6e6573746564" }), {
           "shards": {
-            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223"
+            "#state_ph": "0xbe0fbf9fec28b21de391ebb202517a420f47ee199aece85153e8fb4d9453f223",
+            "#serial": 11,
           },
           "#end_label": "736861726473"
         })
@@ -1037,6 +1048,7 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true }), {
           "some": {
             "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5",
+            "#serial": 2,
           },
           "#end_label": "736f6d65"
         });
@@ -1044,6 +1056,7 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getFunction('/apps/test/test_function', { isPartial: true, lastEndLabel: "736f6d64" }), {
           "some": {
             "#state_ph": "0x637e4fb9edc3f569e3a4bced647d706bf33742bca14b1aae3ca01fd5b44120d5",
+            "#serial": 2,
           },
           "#end_label": "736f6d65"
         });
@@ -1314,17 +1327,20 @@ describe("DB operations", () => {
       it('getRule to retrieve existing rule config with isPartial = true and lastEndLabel', () => {
         assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true }), {
           "some": {
-            "#state_ph": "0x2be40be7d05dfe5a88319f6aa0f1a7eb61691f8f5fae8c7c993f10892cd29038"
+            "#state_ph": "0x2be40be7d05dfe5a88319f6aa0f1a7eb61691f8f5fae8c7c993f10892cd29038",
+            "#serial": 2,
           },
           "syntax": {
-            "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732"
+            "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732",
+            "#serial": 5,
           },
           "#end_label": "73796e746178"
         });
         // lastEndLabel = "73796e746177" ("73796e746178" - 1)
         assert.deepEqual(node.db.getRule('/apps/test/test_rule', { isPartial: true, lastEndLabel: "73796e746177" }), {
           "syntax": {
-            "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732"
+            "#state_ph": "0x9bf58fc0d77ba1ec1271522dbaab398ebe0e8ea002bb43f6bd860b665e53b732",
+            "#serial": 5,
           },
           "#end_label": "73796e746178"
         });
@@ -1874,6 +1890,7 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true }), {
           "some": {
             "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80",
+            "#serial": 2,
           },
           "#end_label": "736f6d65"
         })
@@ -1881,6 +1898,7 @@ describe("DB operations", () => {
         assert.deepEqual(node.db.getOwner("/apps/test/test_owner", { isPartial: true, lastEndLabel: "736f6d64" }), {
           "some": {
             "#state_ph": "0x6127bafe410040319f8d36b1ec0491e16db32d2d0be00f8fc28015c564582b80",
+            "#serial": 2,
           },
           "#end_label": "736f6d65"
         })

--- a/test/unit/radix-tree.test.js
+++ b/test/unit/radix-tree.test.js
@@ -2915,14 +2915,14 @@ describe("radix-tree", () => {
 
         const labelsWithEndLabel = tree.getChildStateLabelsWithEndLabel(true, '000bbb');
         assert.deepEqual(labelsWithEndLabel.list, [
-          label22,
           label21,
+          label22,
         ]);
         expect(labelsWithEndLabel.endLabel).to.equal('000bbb222');
         const nodesWithEndLabel = tree.getChildStateNodesWithEndLabel(true, '000bbb');
         assert.deepEqual(nodesWithEndLabel.list, [
-          stateNode22,
           stateNode21,
+          stateNode22,
         ]);
         expect(nodesWithEndLabel.endLabel).to.equal('000bbb222');
 

--- a/test/unit/state-node.test.js
+++ b/test/unit/state-node.test.js
@@ -1281,45 +1281,55 @@ describe("state-node", () => {
 
       const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true);
       assert.deepEqual(labelsWithEndLabel1.list, []);
+      assert.deepEqual(labelsWithEndLabel1.serialList, []);
       expect(labelsWithEndLabel1.endLabel).to.equal(null);
       const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel1.list, []);
+      assert.deepEqual(nodesWithEndLabel1.serialList, []);
       expect(nodesWithEndLabel1.endLabel).to.equal(null);
 
       parent1.setChild(label1, child1);
       parent1.setChild(label2, child2);
       const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true);
       assert.deepEqual(labelsWithEndLabel2.list, ['label1', 'label2']);
+      assert.deepEqual(labelsWithEndLabel2.serialList, [2, 5]);
       expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c32');
       const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel2.list, [child1, child2]);
+      assert.deepEqual(nodesWithEndLabel2.serialList, [2, 5]);
       expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c32');
 
       parent1.setChild(label3, child3);
       const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true);
       // skip label3
       assert.deepEqual(labelsWithEndLabel3.list, ['label1', 'label2']);
+      assert.deepEqual(labelsWithEndLabel3.serialList, [2, 5]);
       expect(labelsWithEndLabel3.endLabel).to.equal('6c6162656c32');
       const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true);
       // skip child3
       assert.deepEqual(nodesWithEndLabel3.list, [child1, child2]);
+      assert.deepEqual(nodesWithEndLabel3.serialList, [2, 5]);
       expect(nodesWithEndLabel3.endLabel).to.equal('6c6162656c32');
 
       parent1.deleteChild(label2);
       const labelsWithEndLabel4 = parent1.getChildLabelsWithEndLabel(true);
       assert.deepEqual(labelsWithEndLabel4.list, ['label1', 'label3']);
+      assert.deepEqual(labelsWithEndLabel4.serialList, [2, 7]);
       expect(labelsWithEndLabel4.endLabel).to.equal('6c6162656c33');
       const nodesWithEndLabel4 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel4.list, [child1, child3]);
+      assert.deepEqual(nodesWithEndLabel4.serialList, [2, 7]);
       expect(nodesWithEndLabel4.endLabel).to.equal('6c6162656c33');
 
       parent1.deleteChild(label3);
       parent1.deleteChild(label1);
       const labelsWithEndLabel5 = parent1.getChildLabelsWithEndLabel(true);
       assert.deepEqual(labelsWithEndLabel5.list, []);
+      assert.deepEqual(labelsWithEndLabel5.serialList, []);
       expect(labelsWithEndLabel5.endLabel).to.equal(null);
       const nodesWithEndLabel5 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel5.list, []);
+      assert.deepEqual(nodesWithEndLabel5.serialList, []);
       expect(nodesWithEndLabel5.endLabel).to.equal(null);
 
       // Restore GET_RESP_MAX_SIBLINGS value.
@@ -1335,47 +1345,57 @@ describe("state-node", () => {
 
       const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(labelsWithEndLabel1.list, []);
+      assert.deepEqual(labelsWithEndLabel1.serialList, []);
       expect(labelsWithEndLabel1.endLabel).to.equal(null);
       const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(nodesWithEndLabel1.list, []);
+      assert.deepEqual(nodesWithEndLabel1.serialList, []);
       expect(nodesWithEndLabel1.endLabel).to.equal(null);
 
       parent1.setChild(label1, child1);
       parent1.setChild(label2, child2);
       const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(labelsWithEndLabel2.list, ['label2']);
+      assert.deepEqual(labelsWithEndLabel2.serialList, [5]);
       expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c32');
       const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(nodesWithEndLabel2.list, [child2]);
+      assert.deepEqual(nodesWithEndLabel2.serialList, [5]);
       expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c32');
 
       parent1.setChild(label3, child3);
       const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
       // skip label1
       assert.deepEqual(labelsWithEndLabel3.list, ['label2', 'label3']);
+      assert.deepEqual(labelsWithEndLabel3.serialList, [5, 7]);
       expect(labelsWithEndLabel3.endLabel).to.equal('6c6162656c33');
       const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
       // skip child1
       assert.deepEqual(nodesWithEndLabel3.list, [child2, child3]);
+      assert.deepEqual(nodesWithEndLabel3.serialList, [5, 7]);
       expect(nodesWithEndLabel3.endLabel).to.equal('6c6162656c33');
 
       parent1.deleteChild(label2);
       const labelsWithEndLabel4 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
       // skip label1
       assert.deepEqual(labelsWithEndLabel4.list, ['label3']);
+      assert.deepEqual(labelsWithEndLabel4.serialList, [7]);
       expect(labelsWithEndLabel4.endLabel).to.equal('6c6162656c33');
       const nodesWithEndLabel4 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
       // skip child1
       assert.deepEqual(nodesWithEndLabel4.list, [child3]);
+      assert.deepEqual(nodesWithEndLabel4.serialList, [7]);
       expect(nodesWithEndLabel4.endLabel).to.equal('6c6162656c33');
 
       parent1.deleteChild(label3);
       parent1.deleteChild(label1);
       const labelsWithEndLabel5 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(labelsWithEndLabel5.list, []);
+      assert.deepEqual(labelsWithEndLabel5.serialList, []);
       expect(labelsWithEndLabel5.endLabel).to.equal(null);
       const nodesWithEndLabel5 = parent1.getChildNodesWithEndLabel(true, '6c6162656c31');
       assert.deepEqual(nodesWithEndLabel5.list, []);
+      assert.deepEqual(nodesWithEndLabel5.serialList, []);
       expect(nodesWithEndLabel5.endLabel).to.equal(null);
 
       // Restore GET_RESP_MAX_SIBLINGS value.
@@ -1393,23 +1413,29 @@ describe("state-node", () => {
 
       const labelsWithEndLabel1 = parent1.getChildLabelsWithEndLabel(true);
       assert.deepEqual(labelsWithEndLabel1.list, ['label1', 'label2']);
+      assert.deepEqual(labelsWithEndLabel1.serialList, [2, 5]);
       expect(labelsWithEndLabel1.endLabel).to.equal('6c6162656c32');
       const nodesWithEndLabel1 = parent1.getChildNodesWithEndLabel(true);
       assert.deepEqual(nodesWithEndLabel1.list, [child1, child2]);
+      assert.deepEqual(nodesWithEndLabel1.serialList, [2, 5]);
       expect(nodesWithEndLabel1.endLabel).to.equal('6c6162656c32');
 
       const labelsWithEndLabel2 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c32');
       assert.deepEqual(labelsWithEndLabel2.list, ['label3']);
+      assert.deepEqual(labelsWithEndLabel2.serialList, [7]);
       expect(labelsWithEndLabel2.endLabel).to.equal('6c6162656c33');
       const nodesWithEndLabel2 = parent1.getChildNodesWithEndLabel(true, '6c6162656c32');
       assert.deepEqual(nodesWithEndLabel2.list, [child3]);
+      assert.deepEqual(nodesWithEndLabel2.serialList, [7]);
       expect(nodesWithEndLabel2.endLabel).to.equal('6c6162656c33');
 
       const labelsWithEndLabel3 = parent1.getChildLabelsWithEndLabel(true, '6c6162656c33');
       assert.deepEqual(labelsWithEndLabel3.list, []);
+      assert.deepEqual(labelsWithEndLabel3.serialList, []);
       expect(labelsWithEndLabel3.endLabel).to.equal(null);
       const nodesWithEndLabel3 = parent1.getChildNodesWithEndLabel(true, '6c6162656c33');
       assert.deepEqual(nodesWithEndLabel3.list, []);
+      assert.deepEqual(nodesWithEndLabel3.serialList, []);
       expect(nodesWithEndLabel3.endLabel).to.equal(null);
 
       // Restore GET_RESP_MAX_SIBLINGS value.


### PR DESCRIPTION
Change summary:
- Return child node 'serial' when is_partial = true
- Do not sort partial results

Background:
- When there are too many children, users need to use child node pagination with is_partial = true option to get the full child list
- To get the right ordering of the children (= insertion order), users can sort the full list of the child nodes from the pagination by their 'serial' values 

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/600