### PR TITLE
Internally separate error from result in get API results

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -118,7 +118,8 @@ app.get('/last_block_number', (req, res, next) => {
 
 app.get('/get_value', (req, res, next) => {
   const beginTime = Date.now();
-  const result = node.db.getValue(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const retVal = node.db.getValueWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const result = retVal.error !== undefined ? retVal.error : retVal.result;
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
@@ -132,7 +133,8 @@ app.get('/get_value', (req, res, next) => {
 
 app.get('/get_function', (req, res, next) => {
   const beginTime = Date.now();
-  const result = node.db.getFunction(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const retVal = node.db.getFunctionWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const result = retVal.error !== undefined ? retVal.error : retVal.result;
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
@@ -146,7 +148,8 @@ app.get('/get_function', (req, res, next) => {
 
 app.get('/get_rule', (req, res, next) => {
   const beginTime = Date.now();
-  const result = node.db.getRule(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const retVal = node.db.getRuleWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const result = retVal.error !== undefined ? retVal.error : retVal.result;
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
@@ -160,7 +163,8 @@ app.get('/get_rule', (req, res, next) => {
 
 app.get('/get_owner', (req, res, next) => {
   const beginTime = Date.now();
-  const result = node.db.getOwner(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const retVal = node.db.getOwnerWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
+  const result = retVal.error !== undefined ? retVal.error : retVal.result;
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
@@ -331,7 +335,8 @@ app.post('/eval_owner', (req, res, next) => {
 
 app.post('/get', (req, res, next) => {
   const beginTime = Date.now();
-  const result = node.db.get(req.body.op_list);
+  const retVal = node.db.getWithError(req.body.op_list);
+  const result = retVal.error !== undefined ? retVal.error : retVal.result;
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)

--- a/client/index.js
+++ b/client/index.js
@@ -119,13 +119,24 @@ app.get('/last_block_number', (req, res, next) => {
 app.get('/get_value', (req, res, next) => {
   const beginTime = Date.now();
   const retVal = node.db.getValueWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
-  const result = retVal.error !== undefined ? retVal.error : retVal.result;
+  let result;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    result = retVal;
+  } else {
+    result = retVal.error !== undefined ? retVal.error : retVal.result;
+  }
+  let code;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    code = result.error === undefined ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  } else {
+    code = result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  }
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({
-      code: result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE,
+      code,
       result
     })
     .end();
@@ -134,13 +145,24 @@ app.get('/get_value', (req, res, next) => {
 app.get('/get_function', (req, res, next) => {
   const beginTime = Date.now();
   const retVal = node.db.getFunctionWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
-  const result = retVal.error !== undefined ? retVal.error : retVal.result;
+  let result;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    result = retVal;
+  } else {
+    result = retVal.error !== undefined ? retVal.error : retVal.result;
+  }
+  let code;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    code = result.error === undefined ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  } else {
+    code = result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  }
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({
-      code: result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE,
+      code,
       result
     })
     .end();
@@ -149,13 +171,24 @@ app.get('/get_function', (req, res, next) => {
 app.get('/get_rule', (req, res, next) => {
   const beginTime = Date.now();
   const retVal = node.db.getRuleWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
-  const result = retVal.error !== undefined ? retVal.error : retVal.result;
+  let result;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    result = retVal;
+  } else {
+    result = retVal.error !== undefined ? retVal.error : retVal.result;
+  }
+  let code;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    code = result.error === undefined ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  } else {
+    code = result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  }
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({
-      code: result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE,
+      code,
       result
     })
     .end();
@@ -164,13 +197,24 @@ app.get('/get_rule', (req, res, next) => {
 app.get('/get_owner', (req, res, next) => {
   const beginTime = Date.now();
   const retVal = node.db.getOwnerWithError(req.query.ref, CommonUtil.toGetOptions(req.query, true));
-  const result = retVal.error !== undefined ? retVal.error : retVal.result;
+  let result;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    result = retVal;
+  } else {
+    result = retVal.error !== undefined ? retVal.error : retVal.result;
+  }
+  let code;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    code = result.error === undefined ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  } else {
+    code = result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  }
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({
-      code: result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE,
+      code,
       result
     })
     .end();
@@ -336,13 +380,24 @@ app.post('/eval_owner', (req, res, next) => {
 app.post('/get', (req, res, next) => {
   const beginTime = Date.now();
   const retVal = node.db.getWithError(req.body.op_list);
-  const result = retVal.error !== undefined ? retVal.error : retVal.result;
+  let result;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    result = retVal;
+  } else {
+    result = retVal.error !== undefined ? retVal.error : retVal.result;
+  }
+  let code;
+  if (DevFlags.enableErrorResultSeparationForGetApis) {
+    code = result.error === undefined ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  } else {
+    code = result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE;
+  }
   const latency = Date.now() - beginTime;
   trafficStatsManager.addEvent(TrafficEventTypes.CLIENT_API_GET, latency);
   res.status(200)
     .set('Content-Type', 'application/json')
     .send({
-      code: result !== null ? DevClientApiResultCode.SUCCESS : DevClientApiResultCode.FAILURE,
+      code,
       result
     })
     .end();

--- a/common/constants.js
+++ b/common/constants.js
@@ -23,6 +23,8 @@ const DevFlags = {
   // Enables p2p message tags checking.
   // TODO(liayoo): Add some security measures before turning this flag on.
   enableP2pMessageTagsChecking: false,
+  // Enables error-result separation for blockhain get APIs.
+  enableErrorResultSeparationForGetApis: false,
 
   // NOTE(liayoo): Below flags are added for performance optimization testing purposes.
   // Enables gas fee collection.

--- a/db/index.js
+++ b/db/index.js
@@ -497,25 +497,38 @@ class DB {
 
   static readFromStateRoot(stateRoot, rootLabel, refPath, options, shardingPath) {
     const isGlobal = options && options.isGlobal;
-    if (!stateRoot) return null;
+    if (!stateRoot) {
+      return {
+        result: null
+      };
+    }
     const parsedPath = CommonUtil.parsePath(refPath);
     const localPath = isGlobal ? DB.toLocalPath(parsedPath, shardingPath) : parsedPath;
     if (localPath === null) {
       // No matched local path.
-      return null;
+      return {
+        result: null
+      };
     }
     const fullPath = DB.getFullPath(localPath, rootLabel);
     const stateNode = DB.getRefForReadingFromStateRoot(stateRoot, fullPath);
     if (stateNode === null) {
-      return null;
+      return {
+        result: null
+      };
     }
     if (options && options.fromApi) {
       const limitChecked = DB.checkRespTreeLimits(stateNode, options);
       if (limitChecked !== true) {
-        return limitChecked;
+        return {
+          result: null,
+          error: limitChecked,
+        };
       }
     }
-    return stateNode.toStateSnapshot(options);
+    return {
+      result: stateNode.toStateSnapshot(options)
+    };
   }
 
   readDatabase(refPath, rootLabel, options) {
@@ -525,18 +538,34 @@ class DB {
   }
 
   getValue(valuePath, options) {
+    return this.getValueWithError(valuePath, options).result;
+  }
+
+  getValueWithError(valuePath, options) {
     return this.readDatabase(valuePath, PredefinedDbPaths.VALUES_ROOT, options);
   }
 
   getFunction(functionPath, options) {
+    return this.getFunctionWithError(functionPath, options).result;
+  }
+
+  getFunctionWithError(functionPath, options) {
     return this.readDatabase(functionPath, PredefinedDbPaths.FUNCTIONS_ROOT, options);
   }
 
   getRule(rulePath, options) {
+    return this.getRuleWithError(rulePath, options).result;
+  }
+
+  getRuleWithError(rulePath, options) {
     return this.readDatabase(rulePath, PredefinedDbPaths.RULES_ROOT, options);
   }
 
   getOwner(ownerPath, options) {
+    return this.getOwnerWithError(ownerPath, options).result;
+  }
+
+  getOwnerWithError(ownerPath, options) {
     return this.readDatabase(ownerPath, PredefinedDbPaths.OWNERS_ROOT, options);
   }
 
@@ -560,7 +589,7 @@ class DB {
 
   static getValueFromStateRoot(stateRoot, statePath, isShallow = false) {
     return DB.readFromStateRoot(
-        stateRoot, PredefinedDbPaths.VALUES_ROOT, statePath, { isShallow }, []);
+        stateRoot, PredefinedDbPaths.VALUES_ROOT, statePath, { isShallow }, []).result;
   }
 
   /**
@@ -752,18 +781,28 @@ class DB {
   // TODO(platfowner): Add tests for op.fid.
   // NOTE(liayoo): This function is only for external uses (APIs).
   get(opList) {
+    return this.getWithError(opList).result;
+  }
+
+  getWithError(opList) {
     if (!CommonUtil.isArray(opList)) {
       return {
-        code: JsonRpcApiResultCode.GET_INVALID_OP_LIST,
-        message: `Invalid op_list given`
+        result: null,
+        error: {
+          code: JsonRpcApiResultCode.GET_INVALID_OP_LIST,
+          message: `Invalid op_list given`
+        },
       };
     }
     if (CommonUtil.isNumber(NodeConfigs.GET_OP_LIST_SIZE_LIMIT) &&
       opList.length > NodeConfigs.GET_OP_LIST_SIZE_LIMIT) {
       return {
-        code: JsonRpcApiResultCode.GET_EXCEEDS_OP_LIST_SIZE_LIMIT,
-        message: `The request exceeds the max op_list size limit of the requested node: ` +
-            `${opList.length} > ${NodeConfigs.GET_OP_LIST_SIZE_LIMIT}`
+        result: null,
+        error: {
+          code: JsonRpcApiResultCode.GET_EXCEEDS_OP_LIST_SIZE_LIMIT,
+          message: `The request exceeds the max op_list size limit of the requested node: ` +
+              `${opList.length} > ${NodeConfigs.GET_OP_LIST_SIZE_LIMIT}`
+        }
       };
     }
     const resultList = [];
@@ -805,7 +844,9 @@ class DB {
             op.ref, op.permission, auth, CommonUtil.toMatchOrEvalOptions(op, true)));
       }
     }
-    return resultList;
+    return {
+      result: resultList,
+    };
   }
 
   static getAccountNonceAndTimestampFromStateRoot(stateRoot, address) {

--- a/db/index.js
+++ b/db/index.js
@@ -1377,6 +1377,7 @@ class DB {
         'resource/set_op_list_size_limit', blockNumber, this.stateRoot);
     if (blockNumber > 0 && opList.length > setOpListSizeLimit) {
       return {
+        result_list: null,
         code: JsonRpcApiResultCode.SET_EXCEEDS_OP_LIST_SIZE_LIMIT,
         message: `The transaction exceeds the max op_list size limit: ` +
             `${opList.length} > ${setOpListSizeLimit}`

--- a/json_rpc/database.js
+++ b/json_rpc/database.js
@@ -12,35 +12,41 @@ module.exports = function getDatabaseApis(node) {
   return {
     [JSON_RPC_METHODS.AIN_GET]: function(args, done) {
       const beginTime = Date.now();
+      let retVal;
       let result;
       let latency;
       switch (args.type) {
         case ReadDbOperations.GET_VALUE:
-          result = node.db.getValue(args.ref, CommonUtil.toGetOptions(args, true));
+          retVal = node.db.getValueWithError(args.ref, CommonUtil.toGetOptions(args, true));
+          result = retVal.error !== undefined ? retVal.error : retVal.result;
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_RULE:
-          result = node.db.getRule(args.ref, CommonUtil.toGetOptions(args, true));
+          retVal = node.db.getRuleWithError(args.ref, CommonUtil.toGetOptions(args, true));
+          result = retVal.error !== undefined ? retVal.error : retVal.result;
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_FUNCTION:
-          result = node.db.getFunction(args.ref, CommonUtil.toGetOptions(args, true));
+          retVal = node.db.getFunctionWithError(args.ref, CommonUtil.toGetOptions(args, true));
+          result = retVal.error !== undefined ? retVal.error : retVal.result;
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_OWNER:
-          result = node.db.getOwner(args.ref, CommonUtil.toGetOptions(args, true));
+          retVal = node.db.getOwnerWithError(args.ref, CommonUtil.toGetOptions(args, true));
+          result = retVal.error !== undefined ? retVal.error : retVal.result;
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET:
-          result = node.db.get(args.op_list);
+          retVal = node.db.getWithError(args.op_list);
+          result = retVal.error !== undefined ? retVal.error : retVal.result;
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));

--- a/json_rpc/database.js
+++ b/json_rpc/database.js
@@ -2,6 +2,7 @@ const {
   ReadDbOperations,
   TrafficEventTypes,
   trafficStatsManager,
+  DevFlags,
 } = require('../common/constants');
 const { JsonRpcApiResultCode } = require('../common/result-code');
 const CommonUtil = require('../common/common-util');
@@ -18,35 +19,55 @@ module.exports = function getDatabaseApis(node) {
       switch (args.type) {
         case ReadDbOperations.GET_VALUE:
           retVal = node.db.getValueWithError(args.ref, CommonUtil.toGetOptions(args, true));
-          result = retVal.error !== undefined ? retVal.error : retVal.result;
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            result = retVal;
+          } else {
+            result = retVal.error !== undefined ? retVal.error : retVal.result;
+          }
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_RULE:
           retVal = node.db.getRuleWithError(args.ref, CommonUtil.toGetOptions(args, true));
-          result = retVal.error !== undefined ? retVal.error : retVal.result;
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            result = retVal;
+          } else {
+            result = retVal.error !== undefined ? retVal.error : retVal.result;
+          }
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_FUNCTION:
           retVal = node.db.getFunctionWithError(args.ref, CommonUtil.toGetOptions(args, true));
-          result = retVal.error !== undefined ? retVal.error : retVal.result;
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            result = retVal;
+          } else {
+            result = retVal.error !== undefined ? retVal.error : retVal.result;
+          }
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET_OWNER:
           retVal = node.db.getOwnerWithError(args.ref, CommonUtil.toGetOptions(args, true));
-          result = retVal.error !== undefined ? retVal.error : retVal.result;
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            result = retVal;
+          } else {
+            result = retVal.error !== undefined ? retVal.error : retVal.result;
+          }
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
           return;
         case ReadDbOperations.GET:
           retVal = node.db.getWithError(args.op_list);
-          result = retVal.error !== undefined ? retVal.error : retVal.result;
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            result = retVal;
+          } else {
+            result = retVal.error !== undefined ? retVal.error : retVal.result;
+          }
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
           done(null, JsonRpcUtil.addProtocolVersion({ result }));
@@ -54,12 +75,24 @@ module.exports = function getDatabaseApis(node) {
         default:
           latency = Date.now() - beginTime;
           trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-          done(null, JsonRpcUtil.addProtocolVersion({
-            result: {
-              code: JsonRpcApiResultCode.GET_INVALID_OPERATION,
-              message: 'Invalid get operation'
-            }
-          }));
+          if (DevFlags.enableErrorResultSeparationForGetApis) {
+            done(null, JsonRpcUtil.addProtocolVersion({
+              result: {
+                result: null,
+                error: {
+                  code: JsonRpcApiResultCode.GET_INVALID_OPERATION,
+                  message: 'Invalid get operation'
+                }
+              }
+            }));
+          } else {
+            done(null, JsonRpcUtil.addProtocolVersion({
+              result: {
+                code: JsonRpcApiResultCode.GET_INVALID_OPERATION,
+                message: 'Invalid get operation'
+              }
+            }));
+          }
       }
     },
 


### PR DESCRIPTION
Change summary:
- Internally separate error from result in get API results
- Add enableErrorResultSeparationForGetApis dev flag

Note:
- With enableErrorResultSeparationForGetApis = false, the APIs are backward-compatible.

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053