### PR TITLE
Fix result formats of ain_validateAppName() and ain_checkProtocolVersion()

### DIFF
--- a/common/version-util.js
+++ b/common/version-util.js
@@ -50,6 +50,7 @@ class VersionUtil {
       res.status(200)
         .set('Content-Type', 'application/json')
         .send({
+          result: null,
           code: JsonRpcApiResultCode.PROTO_VERSION_NOT_SPECIFIED,
           message: 'Protocol version not specified.',
           protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION
@@ -59,6 +60,7 @@ class VersionUtil {
       res.status(200)
         .set('Content-Type', 'application/json')
         .send({
+          result: null,
           code: JsonRpcApiResultCode.PROTO_VERSION_INVALID,
           message: 'Invalid protocol version.',
           protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION
@@ -69,6 +71,7 @@ class VersionUtil {
       res.status(200)
         .set('Content-Type', 'application/json')
         .send({
+          result: null,
           code: JsonRpcApiResultCode.PROTO_VERSION_INCOMPATIBLE,
           message: 'Incompatible protocol version.',
           protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION

--- a/db/index.js
+++ b/db/index.js
@@ -885,10 +885,12 @@ class DB {
     return curAppValue === null;
   }
 
+  // TODO(platfowner): Remove is_valid once migration is completed.
   validateAppName(appName, blockNumber, stateLabelLengthLimit) {
     if (!isValidStateLabel(appName, stateLabelLengthLimit)) {
       return {
         is_valid: false,
+        result: false,
         code: JsonRpcApiResultCode.INVALID_APP_NAME_FOR_STATE_LABEL,
         message: `Invalid app name for state label: ${appName}`
       };
@@ -896,6 +898,7 @@ class DB {
     if (!isValidServiceName(appName, blockNumber)) {
       return {
         is_valid: false,
+        result: false,
         code: JsonRpcApiResultCode.INVALID_APP_NAME_FOR_SERVICE_NAME,
         message: `Invalid app name for service name: ${appName}`
       };
@@ -903,12 +906,14 @@ class DB {
     if (!this.isNonExistingApp(appName)) {
       return {
         is_valid: false,
+        result: false,
         code: JsonRpcApiResultCode.APP_NAME_ALREADY_IN_USE,
         message: `App name already in use: ${appName}`
       };
     }
     return {
       is_valid: true,
+      result: true,
       code: JsonRpcApiResultCode.SUCCESS
     };
   }

--- a/json_rpc/admin.js
+++ b/json_rpc/admin.js
@@ -30,6 +30,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_GET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_FORBIDDEN_REQUEST,
           message: 'Forbidden request.'
         }));
@@ -41,6 +42,7 @@ module.exports = function getAdminApis(node) {
       trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_GET, latency);
       if (NodeConfigs[param] === undefined) {
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] does not exist.`
         }));
@@ -56,6 +58,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_FORBIDDEN_REQUEST,
           message: 'Forbidden request.'
         }));
@@ -67,6 +70,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] does not exist.`
         }));
@@ -77,6 +81,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_VALUE_NOT_A_STRING_TYPE,
           message: `Value '${args.message.value}' is not a string.`
         }));
@@ -88,6 +93,7 @@ module.exports = function getAdminApis(node) {
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({
+        result: true,
         code: JsonRpcApiResultCode.SUCCESS,
         message: `Param [${param}] is now set as: ${JSON.stringify(NodeConfigs[param])}`
       }));
@@ -100,6 +106,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_FORBIDDEN_REQUEST,
           message: 'Forbidden request.'
         }));
@@ -111,6 +118,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] does not exist.`
         }));
@@ -121,6 +129,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] is not a whitelist`
         }));
@@ -131,6 +140,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_VALUE_NOT_A_STRING_TYPE,
           message: `Value '${args.message.value}' is not a string.`
         }));
@@ -145,6 +155,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_ALREADY_IN_WHITELIST,
           message: `(${args.message.value}) already in whitelist [${param}]: ${JSON.stringify(NodeConfigs[param])}`
         }));
@@ -159,6 +170,7 @@ module.exports = function getAdminApis(node) {
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({
+        result: true,
         code: JsonRpcApiResultCode.SUCCESS,
         message: `Added (${args.message.value}) to whitelist [${param}]: ${JSON.stringify(NodeConfigs[param])}`
       }));
@@ -171,6 +183,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_FORBIDDEN_REQUEST,
           message: 'Forbidden request.'
         }));
@@ -182,6 +195,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] does not exist.`
         }));
@@ -192,6 +206,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_PARAM_INVALID,
           message: `Param [${param}] is not a whitelist`
         }));
@@ -202,6 +217,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_VALUE_NOT_A_STRING_TYPE,
           message: `Value '${args.message.value}' is not a string.`
         }));
@@ -215,6 +231,7 @@ module.exports = function getAdminApis(node) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.ADMIN_NOT_IN_WHITELIST,
           message: `(${args.message.value}) not in whitelist [${param}]: ${JSON.stringify(NodeConfigs[param])}`
         }));
@@ -225,6 +242,7 @@ module.exports = function getAdminApis(node) {
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.ACCESS_CONTROL_SET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({
+        result: true,
         code: JsonRpcApiResultCode.SUCCESS,
         message: `Removed (${args.message.value}) from whitelist [${param}]: ${JSON.stringify(NodeConfigs[param])}`
       }));

--- a/json_rpc/app.js
+++ b/json_rpc/app.js
@@ -9,10 +9,10 @@ module.exports = function getAppApis(node) {
   return {
     [JSON_RPC_METHODS.AIN_VALIDATE_APP_NAME]: function(args, done) {
       const beginTime = Date.now();
-      const result = node.validateAppName(args.app_name);
+      const retVal = node.validateAppName(args.app_name);
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result }));
+      done(null, JsonRpcUtil.addProtocolVersion(retVal));
     },
   };
 };

--- a/json_rpc/transaction.js
+++ b/json_rpc/transaction.js
@@ -127,7 +127,7 @@ module.exports = function getTransactionApis(node, p2pServer) {
     [JSON_RPC_METHODS.AIN_SEND_SIGNED_TRANSACTION_BATCH]: function(args, done) {
       const beginTime = Date.now();
       const batchTxListSizeLimit = node.getBlockchainParam('resource/batch_tx_list_size_limit');
-      if (!args.tx_list || !CommonUtil.isArray(args.tx_list)) {
+      if (!CommonUtil.isArray(args.tx_list) || CommonUtil.isEmpty(args.tx_list)) {
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_SET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({

--- a/json_rpc/version.js
+++ b/json_rpc/version.js
@@ -26,6 +26,7 @@ module.exports = function getVersionApis(minProtocolVersion, maxProtocolVersion)
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.PROTO_VERSION_NOT_SPECIFIED,
           message: 'Protocol version not specified.'
         }));
@@ -33,6 +34,7 @@ module.exports = function getVersionApis(minProtocolVersion, maxProtocolVersion)
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.PROTO_VERSION_INVALID,
           message: 'Invalid protocol version.'
         }));
@@ -41,6 +43,7 @@ module.exports = function getVersionApis(minProtocolVersion, maxProtocolVersion)
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: false,
           code: JsonRpcApiResultCode.PROTO_VERSION_INCOMPATIBLE,
           message: 'Incompatible protocol version.'
         }));
@@ -48,8 +51,8 @@ module.exports = function getVersionApis(minProtocolVersion, maxProtocolVersion)
         const latency = Date.now() - beginTime;
         trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
         done(null, JsonRpcUtil.addProtocolVersion({
+          result: true,
           code: JsonRpcApiResultCode.SUCCESS,
-          result: 'Success'
         }));
       }
     },

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -1505,6 +1505,29 @@ describe('Blockchain Node', () => {
       });
     })
 
+    describe('json-rpc api: ain_validateAppName', () => {
+      it('returns true', () => {
+        const client = jayson.client.http(server1 + '/json-rpc');
+        const request = { app_name: 'app_name_valid0', protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
+        return client.request(JSON_RPC_METHODS.AIN_VALIDATE_APP_NAME, request)
+        .then(res => {
+          expect(res.result.is_valid).to.equal(true);
+          expect(res.result.code).to.equal(0);
+        })
+      });
+
+      it('returns false', () => {
+        const client = jayson.client.http(server1 + '/json-rpc');
+        const request = { app_name: 'app/path', protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION };
+        return client.request(JSON_RPC_METHODS.AIN_VALIDATE_APP_NAME, request)
+        .then(res => {
+          expect(res.result.is_valid).to.equal(false);
+          expect(res.result.code).to.equal(30601);
+          expect(res.result.message).to.equal('Invalid app name for state label: app/path');
+        })
+      });
+    });
+
     describe('json-rpc api: ain_getAddress', () => {
       it('returns the correct node address', () => {
         const expAddr = '0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204';

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -1463,8 +1463,8 @@ describe('Blockchain Node', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, { protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION })
         .then(res => {
+          expect(res.result.result).to.equal(true);
           expect(res.result.code).to.equal(0);
-          expect(res.result.result).to.equal("Success");
         });
       });
 
@@ -1472,6 +1472,7 @@ describe('Blockchain Node', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, {})
         .then(res => {
+          expect(res.result.result).to.equal(false);
           expect(res.result.code).to.equal(30101);
           expect(res.result.message).to.equal("Protocol version not specified.");
         });
@@ -1481,6 +1482,7 @@ describe('Blockchain Node', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, { protoVer: 'a.b.c' })
         .then(res => {
+          expect(res.result.result).to.equal(false);
           expect(res.result.code).to.equal(30102);
           expect(res.result.message).to.equal("Invalid protocol version.");
         });
@@ -1490,6 +1492,7 @@ describe('Blockchain Node', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, { protoVer: 0 })
         .then(res => {
+          expect(res.result.result).to.equal(false);
           expect(res.result.code).to.equal(30103);
           expect(res.result.message).to.equal("Incompatible protocol version.");
         });
@@ -1499,6 +1502,7 @@ describe('Blockchain Node', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
         return client.request(JSON_RPC_METHODS.AIN_CHECK_PROTOCOL_VERSION, { protoVer: '0.0.1' })
         .then(res => {
+          expect(res.result.result).to.equal(false);
           expect(res.result.code).to.equal(30103);
           expect(res.result.message).to.equal("Incompatible protocol version.");
         });

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -6430,6 +6430,7 @@ describe("Util methods", () => {
       const appName = 'app_name_valid0';
       assert.deepEqual(node.db.validateAppName(appName, 2, stateLabelLengthLimit), {
         "is_valid": true,
+        "result": true,
         "code": 0,
       });
     });
@@ -6438,6 +6439,7 @@ describe("Util methods", () => {
       const appName = 'app/path';
       assert.deepEqual(node.db.validateAppName(appName, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30601,
         "message": `Invalid app name for state label: ${appName}`,
       });
@@ -6450,6 +6452,7 @@ describe("Util methods", () => {
       }
       assert.deepEqual(node.db.validateAppName(appName, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30601,
         "message": `Invalid app name for state label: ${appName}`,
       });
@@ -6459,6 +6462,7 @@ describe("Util methods", () => {
       const appName = 'balance_total_sum';
       assert.deepEqual(node.db.validateAppName(appName, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30602,
         "message": `Invalid app name for service name: ${appName}`,
       });
@@ -6468,6 +6472,7 @@ describe("Util methods", () => {
       const appName = 'appName';
       assert.deepEqual(node.db.validateAppName(appName, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30602,
         "message": `Invalid app name for service name: ${appName}`,
       });
@@ -6475,6 +6480,7 @@ describe("Util methods", () => {
       const appName2 = 'app-name';
       assert.deepEqual(node.db.validateAppName(appName2, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30602,
         "message": `Invalid app name for service name: ${appName2}`,
       });
@@ -6482,6 +6488,7 @@ describe("Util methods", () => {
       const appName3 = '0app';
       assert.deepEqual(node.db.validateAppName(appName3, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30602,
         "message": `Invalid app name for service name: ${appName3}`,
       });
@@ -6490,6 +6497,7 @@ describe("Util methods", () => {
     it("app name in use", () => {
       assert.deepEqual(node.db.validateAppName(appNameInUse, 2, stateLabelLengthLimit), {
         "is_valid": false,
+        "result": false,
         "code": 30603,
         "message": `App name already in use: ${appNameInUse}`,
       });


### PR DESCRIPTION
Change summary:
- Fix result format of ain_validateAppName() json rpc API
- Let ain_checkProtocolVersion() json rpc API return boolean result
- Check empty tx_list in ain_sendSignedTransactionBatch() json rpc API
- Make json rpc APIs always return result

Related PRs:
- https://github.com/ainblockchain/ain-js/pull/82

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053