### PR TITLE
Fix broken integration test

### DIFF
--- a/p2p/index.js
+++ b/p2p/index.js
@@ -390,17 +390,20 @@ class P2pClient {
   }
 
   async discoverNewPeers() {
-    this.peerConnectionStartedAt = Date.now();
-    if (!this.isConnectingToPeerCandidates) {
-      this.isConnectingToPeerCandidates = true;
-      const nextPeerCandidateJsonRpcUrlList = this.assignRandomPeerCandidates();
-      for (const jsonRpcUrl of nextPeerCandidateJsonRpcUrlList) {
-        const maxNumberOfNewPeers = this.getMaxNumberOfNewPeers();
-        if (maxNumberOfNewPeers === 0) {
-          break;
+    try {
+      this.peerConnectionStartedAt = Date.now();
+      if (!this.isConnectingToPeerCandidates) {
+        this.isConnectingToPeerCandidates = true;
+        const nextPeerCandidateJsonRpcUrlList = this.assignRandomPeerCandidates();
+        for (const jsonRpcUrl of nextPeerCandidateJsonRpcUrlList) {
+          const maxNumberOfNewPeers = this.getMaxNumberOfNewPeers();
+          if (maxNumberOfNewPeers === 0) {
+            break;
+          }
+          await this.tryToQueryAndConnectNewPeer(jsonRpcUrl);
         }
-        await this.tryToQueryAndConnectNewPeer(jsonRpcUrl);
       }
+    } finally {
       this.isConnectingToPeerCandidates = false;
     }
   }

--- a/test/integration/sharding.test.js
+++ b/test/integration/sharding.test.js
@@ -457,6 +457,7 @@ describe('Sharding', () => {
         server1_proc.kill();
         await waitForNewBlocks(server2, sharding.reporting_period * 3);
         console.log(`        --> Restarting server[0]...`);
+        ENV_VARIABLES[2].PEER_CANDIDATE_JSON_RPC_URL = "http://localhost:9002/json-rpc";
         server1_proc = startServer(APP_SERVER, 'server1', ENV_VARIABLES[2]);
         await waitUntilNodeSyncs(server1);
         await waitForNewShardingReports(parentServer, sharding.sharding_path);


### PR DESCRIPTION
Since we now remove peerCandidate if they are not be reached, the first boot node needs to connect with setting up `PEER_CANDIDATE_JSON_RPC_URL`.

Related issue:  #1072 