### PR TITLE
Speed up deploy scripts by skipping data file owner changes

### DIFF
--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -2,7 +2,7 @@
 
 if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
     printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--kill-only|--skip-kill]\n"
-    printf "Example: bash deploy_blockchain_genesis_gcp.sh dev my_username 0 --setup --keystore --no-keep-code\n"
+    printf "Example: bash deploy_blockchain_genesis_gcp.sh dev gcp_user 0 --setup --keystore --no-keep-code\n"
     printf "\n"
     exit
 fi
@@ -242,14 +242,14 @@ fi
 # install node modules on GCP instances
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf "\n* >> Installing node modules for parent tracker (${TRACKER_TARGET_ADDR}) *********************************************************\n\n"
-    gcloud compute ssh $TRACKER_TARGET_ADDR --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone $TRACKER_ZONE
+    gcloud compute ssh $TRACKER_TARGET_ADDR --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone $TRACKER_ZONE
 
     for node_index in `seq 0 $(( $NUM_NODES - 1 ))`; do
         NODE_TARGET_ADDR=NODE_${node_index}_TARGET_ADDR
         NODE_ZONE=NODE_${node_index}_ZONE
 
         printf "\n* >> Installing node modules for parent node $node_index (${!NODE_TARGET_ADDR}) *********************************************************\n\n"
-        gcloud compute ssh ${!NODE_TARGET_ADDR} --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone ${!NODE_ZONE}
+        gcloud compute ssh ${!NODE_TARGET_ADDR} --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone ${!NODE_ZONE}
     done
 fi
 
@@ -319,7 +319,7 @@ printf "\n* >> Starting parent tracker (${TRACKER_TARGET_ADDR}) ****************
 printf "\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
-START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
+START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
 printf "START_TRACKER_CMD=$START_TRACKER_CMD\n"
 eval $START_TRACKER_CMD
 
@@ -356,7 +356,7 @@ for node_index in `seq 0 $(( $NUM_NODES - 1 ))`; do
     printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD
     inject_account "$node_index"
@@ -411,13 +411,13 @@ if [[ $NUM_SHARDS -gt 0 ]]; then
         # install node modules on GCP instances
         if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
             printf "\n* >> Installing node modules for shard_$i tracker (${SHARD_TRACKER_TARGET_ADDR}) *********************************************************\n\n"
-            gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone $TRACKER_ZONE
+            gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone $TRACKER_ZONE
             printf "\n* >> Installing node modules for shard_$i node 0 (${SHARD_NODE_0_TARGET_ADDR}) *********************************************************\n\n"
-            gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_0_ZONE
+            gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_0_ZONE
             printf "\n* >> Installing node modules for shard_$i node 1 (${SHARD_NODE_1_TARGET_ADDR}) *********************************************************\n\n"
-            gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_1_ZONE
+            gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_1_ZONE
             printf "\n* >> Installing node modules for shard_$i node 2 (${SHARD_NODE_2_TARGET_ADDR}) *********************************************************\n\n"
-            gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command "cd ./ain-blockchain; sudo yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_2_ZONE
+            gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command "cd ./ain-blockchain; yarn install --ignore-engines" --project $PROJECT_ID --zone $NODE_2_ZONE
         fi
 
         # ssh into each instance, install packages and start up the server

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
-    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--kill-only|--skip-kill]\n"
-    printf "Example: bash deploy_blockchain_genesis_gcp.sh dev gcp_user 0 --setup --keystore --no-keep-code\n"
+if [[ $# -lt 3 ]] || [[ $# -gt 9 ]]; then
+    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]\n"
+    printf "Example: bash deploy_blockchain_genesis_gcp.sh dev gcp_user 0 --setup --keystore --no-keep-code --no-chown-data\n"
     printf "\n"
     exit
 fi
@@ -59,6 +59,10 @@ function parse_options() {
         SYNC_MODE_OPTION="$option"
     elif [[ $option = '--fast-sync' ]]; then
         SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--kill-only' ]]; then
         if [[ "$KILL_OPTION" ]]; then
             printf "You cannot use both --skip-kill and --kill-only\n"
@@ -83,6 +87,7 @@ ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--chown-data"
 KILL_OPTION=""
 
 ARG_INDEX=4
@@ -95,6 +100,7 @@ printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 printf "KILL_OPTION=$KILL_OPTION\n"
 
 if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
@@ -350,13 +356,14 @@ for node_index in `seq 0 $(( $NUM_NODES - 1 ))`; do
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
     printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
     printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+    printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
     printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD
     inject_account "$node_index"
@@ -422,19 +429,19 @@ if [[ $NUM_SHARDS -gt 0 ]]; then
 
         # ssh into each instance, install packages and start up the server
         printf "\n* >> Starting shard_$i tracker (${SHARD_TRACKER_TARGET_ADDR}) *********************************************************\n\n"
-        START_TRACKER_CMD="gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
+        START_TRACKER_CMD="gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
         printf "START_TRACKER_CMD=$START_TRACKER_CMD\n"
         eval $START_TRACKER_CMD
         printf "\n* >> Starting shard_$i node 0 (${SHARD_NODE_0_TARGET_ADDR}) *********************************************************\n\n"
-        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_0_ZONE"
+        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $GCP_USER $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION $CHOWN_DATA_OPTION' --project $PROJECT_ID --zone $NODE_0_ZONE"
         printf "START_NODE_CMD=$START_NODE_CMD\n"
         eval $START_NODE_CMD
         printf "\n* >> Starting shard_$i node 1 (${SHARD_NODE_1_TARGET_ADDR}) *********************************************************\n\n"
-        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_1_ZONE"
+        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $GCP_USER $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION $CHOWN_DATA_OPTION' --project $PROJECT_ID --zone $NODE_1_ZONE"
         printf "START_NODE_CMD=$START_NODE_CMD\n"
         eval $START_NODE_CMD
         printf "\n* >> Starting shard_$i node 2 (${SHARD_NODE_2_TARGET_ADDR}) *********************************************************\n\n"
-        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $SEASON $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION' --project $PROJECT_ID --zone $NODE_2_ZONE"
+        START_NODE_CMD="gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command '$START_NODE_CMD_BASE $SEASON $GCP_USER $i 0 $KEEP_CODE_OPTION $KEEP_DATA_OPTION $CHOWN_DATA_OPTION' --project $PROJECT_ID --zone $NODE_2_ZONE"
         printf "START_NODE_CMD=$START_NODE_CMD\n"
         eval $START_NODE_CMD
     done

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ $# -lt 5 ]] || [[ $# -gt 11 ]]; then
-    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> <Begin Parent Node Index> <End Parent Node Index> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync]\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev gcp_user 0 -1 1 --setup --keystore --no-keep-code --full-sync\n"
+if [[ $# -lt 5 ]] || [[ $# -gt 12 ]]; then
+    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> <Begin Parent Node Index> <End Parent Node Index> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev gcp_user 0 -1 1 --setup --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "Note: <Begin Parent Node Index> = -1 is for tracker\n"
     printf "Note: <End Parent Node Index> is inclusive\n"
     printf "\n"
@@ -64,6 +64,10 @@ function parse_options() {
         SYNC_MODE_OPTION="$option"
     elif [[ $option = '--fast-sync' ]]; then
         SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
     else
         printf "Invalid option: $option\n"
         exit
@@ -76,6 +80,7 @@ ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--chown-data"
 
 ARG_INDEX=6
 while [ $ARG_INDEX -le $# ]; do
@@ -88,6 +93,7 @@ printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 
 if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
     printf "Must provide an ACCOUNT_INJECTION_OPTION\n"
@@ -237,13 +243,14 @@ function deploy_node() {
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
     printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
     printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+    printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
     printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone $node_zone"
+    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone $node_zone"
     printf "START_NODE_CMD=$START_NODE_CMD\n\n"
     eval $START_NODE_CMD
 

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -2,7 +2,7 @@
 
 if [[ $# -lt 5 ]] || [[ $# -gt 11 ]]; then
     printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <# of Shards> <Begin Parent Node Index> <End Parent Node Index> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync]\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev my_username 0 -1 1 --setup --keystore --no-keep-code --full-sync\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev gcp_user 0 -1 1 --setup --keystore --no-keep-code --full-sync\n"
     printf "Note: <Begin Parent Node Index> = -1 is for tracker\n"
     printf "Note: <End Parent Node Index> is inclusive\n"
     printf "\n"
@@ -180,7 +180,7 @@ function deploy_tracker() {
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 
     printf "\n"
-    START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
+    START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
     printf "START_TRACKER_CMD=$START_TRACKER_CMD\n\n"
     eval $START_TRACKER_CMD
 }
@@ -243,7 +243,7 @@ function deploy_node() {
     printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone $node_zone"
+    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone $node_zone"
     printf "START_NODE_CMD=$START_NODE_CMD\n\n"
     eval $START_NODE_CMD
 

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
-    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--kill-only|--skip-kill]\n"
-    printf "Example: bash deploy_blockchain_sandbox_gcp.sh gcp_user 10 99 --setup\n"
+if [[ $# -lt 3 ]] || [[ $# -gt 8 ]]; then
+    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]\n"
+    printf "Example: bash deploy_blockchain_sandbox_gcp.sh gcp_user 10 99 --setup --no-chown-data\n"
     printf "\n"
     exit
 fi
@@ -17,6 +17,7 @@ GCP_USER="$1"
 START_NODE_IDX="$2"
 END_NODE_IDX="$3"
 ACCOUNT_INJECTION_OPTION="--private-key" # always use the private keys
+
 printf "GCP_USER=$GCP_USER\n"
 printf "START_NODE_IDX=$START_NODE_IDX\n"
 printf "END_NODE_IDX=$END_NODE_IDX\n"
@@ -39,6 +40,10 @@ function parse_options() {
         KEEP_DATA_OPTION="$option"
     elif [[ $option = '--no-keep-data' ]]; then
         KEEP_DATA_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--kill-only' ]]; then
         if [[ "$KILL_OPTION" ]]; then
             printf "You cannot use both --skip-kill and --kill-only\n"
@@ -61,6 +66,7 @@ function parse_options() {
 SETUP_OPTION=""
 KEEP_CODE_OPTION="--no-keep-code"
 KEEP_DATA_OPTION="--no-keep-data"
+CHOWN_DATA_OPTION="--chown-data"
 KILL_OPTION=""
 
 ARG_INDEX=4
@@ -71,6 +77,7 @@ done
 printf "SETUP_OPTION=$SETUP_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 printf "KILL_OPTION=$KILL_OPTION\n"
 
 
@@ -407,6 +414,7 @@ printf "\n"
 printf "START_NODE_CMD_BASE=$START_NODE_CMD_BASE\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 
 node_index=$START_NODE_IDX
 while [ $node_index -le $END_NODE_IDX ]; do
@@ -429,12 +437,13 @@ while [ $node_index -le $END_NODE_IDX ]; do
 
     printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
     printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+    printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
     printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
     printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $CHOWN_DATA_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
     # printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -2,7 +2,7 @@
 
 if [[ $# -lt 3 ]] || [[ $# -gt 7 ]]; then
     printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <GCP Username> <# start node> <# end node> [--setup] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--kill-only|--skip-kill]\n"
-    printf "Example: bash deploy_blockchain_sandbox_gcp.sh my_username 10 99 --setup\n"
+    printf "Example: bash deploy_blockchain_sandbox_gcp.sh gcp_user 10 99 --setup\n"
     printf "\n"
     exit
 fi
@@ -434,7 +434,7 @@ while [ $node_index -le $END_NODE_IDX ]; do
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
 
     printf "\n"
-    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $ACCOUNT_INJECTION_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
     # printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD

--- a/deploy_monitoring_gcp.sh
+++ b/deploy_monitoring_gcp.sh
@@ -2,7 +2,7 @@
 
 if [[ "$#" -lt 2 ]]; then
     printf "Usage: bash deploy_monitoring_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username>  [--setup]\n"
-    printf "Example: bash deploy_monitoring_gcp.sh dev my_username\n"
+    printf "Example: bash deploy_monitoring_gcp.sh dev gcp_user \n"
     printf "\n"
     exit
 fi
@@ -61,4 +61,4 @@ fi
 
 # ssh into each instance, install packages and start up the server
 printf "\n\n############################\n# Running monitoring #\n############################\n\n"
-gcloud compute ssh $MONITORING_TARGET_ADDR --command "cd ./ain-blockchain; . setup_monitoring_gcp.sh ${SEASON} && . start_monitoring_gcp.sh" --project $PROJECT_ID --zone $MONITORING_ZONE
+gcloud compute ssh $MONITORING_TARGET_ADDR --command "cd ./ain-blockchain; . setup_monitoring_gcp.sh $SEASON $GCP_USER && . start_monitoring_gcp.sh" --project $PROJECT_ID --zone $MONITORING_ZONE

--- a/setup_monitoring_gcp.sh
+++ b/setup_monitoring_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ "$#" -lt 1 ]]; then
-    printf "Usage: bash setup_monitoring_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet]\n"
-    printf "Example: bash setup_monitoring_gcp.sh dev\n"
+if [[ "$#" -lt 2 ]]; then
+    printf "Usage: bash setup_monitoring_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username>\n"
+    printf "Example: bash setup_monitoring_gcp.sh dev gcp_user\n"
     printf "\n"
     exit
 fi
@@ -14,7 +14,11 @@ if [[ "$1" != 'dev' ]] && [[ "$1" != 'staging' ]] && [[ "$1" != 'sandbox' ]] && 
 fi
 
 SEASON="$1"
+GCP_USER="$2"
 
+printf "SEASON=$SEASON\n"
+printf "GCP_USER=$GCP_USER\n"
+printf "\n"
 
 printf 'Killing old jobs..\n'
 killall prometheus
@@ -26,7 +30,7 @@ sudo rm -rf /home/ain-blockchain
 cd ~
 sudo mv ain-blockchain /home
 sudo chmod -R 777 /home/ain-blockchain
-sudo chown -R root:root /home/ain-blockchain
+sudo chown -R $GCP_USER:$GCP_USER /home/ain-blockchain
 cd /home/ain-blockchain
 
 printf 'Installing Prometheus..\n'

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # NOTE(minsulee2): Since exit really exits terminals, those are replaced to return 1.
-if [[ $# -lt 3 ]] || [[ $# -gt 10 ]]; then
-    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
-    printf "Example: bash start_node_genesis_gcp.sh spring 0 0 --keystore --no-keep-code --full-sync\n"
+if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
+    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
+    printf "Example: bash start_node_genesis_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync\n"
     printf "\n"
     return 1
 fi
@@ -45,22 +45,25 @@ function parse_options() {
 
 # Parse options.
 SEASON="$1"
+GCP_USER="$2"
+
 number_re='^[0-9]+$'
-if ! [[ $2 =~ $number_re ]] ; then
-    printf "Invalid <Shard Index> argument: $2\n"
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <Shard Index> argument: $3\n"
     return 1
 fi
-SHARD_INDEX="$2"
-if ! [[ $3 =~ $number_re ]] ; then
-    printf "Invalid <Node Index> argument: $3\n"
+SHARD_INDEX="$3"
+
+if ! [[ $4 =~ $number_re ]] ; then
+    printf "Invalid <Node Index> argument: $4\n"
     return 1
 fi
 # NOTE(minsulee2): Sandbox has 100 nodes.
-if [[ "$3" -lt 0 ]] || [[ "$3" -gt 100 ]]; then
-    printf "Invalid <Node Index> argument: $3\n"
+if [[ "$4" -lt 0 ]] || [[ "$4" -gt 100 ]]; then
+    printf "Invalid <Node Index> argument: $4\n"
     return 1
 fi
-NODE_INDEX="$3"
+NODE_INDEX="$4"
 
 ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
@@ -71,13 +74,14 @@ UPDATE_FRONT_DB_OPTION=""
 REST_FUNC_OPTION=""
 EVENT_HANDLER_OPTION=""
 
-ARG_INDEX=4
+ARG_INDEX=5
 while [ $ARG_INDEX -le $# ]; do
   parse_options "${!ARG_INDEX}"
   ((ARG_INDEX++))
 done
 
 printf "SEASON=$SEASON\n"
+printf "GCP_USER=$GCP_USER\n"
 printf "SHARD_INDEX=$SHARD_INDEX\n"
 printf "NODE_INDEX=$NODE_INDEX\n"
 printf "\n"
@@ -149,7 +153,7 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new working directory..\n'
     sudo rm -rf /home/ain-blockchain*
-    CODE_CMD="cd ~; sudo mv ain-blockchain /home; sudo chmod -R 777 /home/ain-blockchain; sudo chown -R root:root /home/ain-blockchain; cd /home/ain-blockchain"
+    CODE_CMD="cd ~; sudo mv ain-blockchain /home; sudo chmod -R 777 /home/ain-blockchain; sudo chown -R $GCP_USER:$GCP_USER /home/ain-blockchain; cd /home/ain-blockchain"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 else
@@ -157,7 +161,7 @@ else
     printf 'Reusing existing working directory..\n'
     OLD_DIR_PATH=$(find /home/ain-blockchain* -maxdepth 0 -type d)
     printf "OLD_DIR_PATH=$OLD_DIR_PATH\n"
-    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R root:root $OLD_DIR_PATH"
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 fi
@@ -167,12 +171,12 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R root:root /home/ain_blockchain_data"
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf 'Reusing existing data directory..\n'
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R root:root /home/ain_blockchain_data"
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 fi

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # NOTE(minsulee2): Since exit really exits terminals, those are replaced to return 1.
-if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
-    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
-    printf "Example: bash start_node_genesis_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync\n"
+if [[ $# -lt 4 ]] || [[ $# -gt 12 ]]; then
+    printf "Usage: bash start_node_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func]\n"
+    printf "Example: bash start_node_genesis_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "\n"
     return 1
 fi
@@ -29,6 +29,10 @@ function parse_options() {
         SYNC_MODE_OPTION="$option"
     elif [[ $option = '--fast-sync' ]]; then
         SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--json-rpc' ]]; then
         JSON_RPC_OPTION="$option"
     elif [[ $option = '--update-front-db' ]]; then
@@ -69,6 +73,7 @@ ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--chown-data"
 JSON_RPC_OPTION=""
 UPDATE_FRONT_DB_OPTION=""
 REST_FUNC_OPTION=""
@@ -90,6 +95,7 @@ printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
 printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
 printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
@@ -171,12 +177,20 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    else
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+    fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf 'Reusing existing data directory..\n'
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    else
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+    fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 fi

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ $# -lt 3 ]] || [[ $# -gt 10 ]]; then
-    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
-    printf "Example: bash start_node_incremental_gcp.sh spring 0 0 --keystore --no-keep-code --full-sync\n"
+if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
+    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync\n"
     printf "\n"
     exit
 fi
@@ -44,21 +44,24 @@ function parse_options() {
 
 # Parse options.
 SEASON="$1"
+GCP_USER="$2"
+
 number_re='^[0-9]+$'
-if ! [[ $2 =~ $number_re ]] ; then
-    printf "Invalid <Shard Index> argument: $2\n"
-    exit
-fi
-SHARD_INDEX="$2"
 if ! [[ $3 =~ $number_re ]] ; then
-    printf "Invalid <Node Index> argument: $3\n"
+    printf "Invalid <Shard Index> argument: $3\n"
     exit
 fi
-if [[ "$3" -lt 0 ]] || [[ "$3" -gt 9 ]]; then
-    printf "Invalid <Node Index> argument: $3\n"
+SHARD_INDEX="$3"
+
+if ! [[ $4 =~ $number_re ]] ; then
+    printf "Invalid <Node Index> argument: $4\n"
     exit
 fi
-NODE_INDEX="$3"
+if [[ "$4" -lt 0 ]] || [[ "$4" -gt 9 ]]; then
+    printf "Invalid <Node Index> argument: $4\n"
+    exit
+fi
+NODE_INDEX="$4"
 
 ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
@@ -69,13 +72,14 @@ UPDATE_FRONT_DB_OPTION=""
 REST_FUNC_OPTION=""
 EVENT_HANDLER_OPTION=""
 
-ARG_INDEX=4
+ARG_INDEX=5
 while [ $ARG_INDEX -le $# ]; do
   parse_options "${!ARG_INDEX}"
   ((ARG_INDEX++))
 done
 
 printf "SEASON=$SEASON\n"
+printf "GCP_USER=$GCP_USER\n"
 printf "SHARD_INDEX=$SHARD_INDEX\n"
 printf "NODE_INDEX=$NODE_INDEX\n"
 printf "\n"
@@ -299,20 +303,20 @@ printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new working directory..\n'
-    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R root:root $NEW_DIR_PATH"
+    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $NEW_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 
     printf '\n'
     printf 'Installing node modules..\n'
     cd $NEW_DIR_PATH
-    INSTALL_CMD="sudo yarn install --ignore-engines"
+    INSTALL_CMD="yarn install --ignore-engines"
     printf "\nINSTALL_CMD=$INSTALL_CMD\n"
     eval $INSTALL_CMD
 else
     printf '\n'
     printf 'Reusing existing working directory..\n'
-    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R root:root $OLD_DIR_PATH"
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 fi
@@ -333,13 +337,13 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R root:root /home/ain_blockchain_data"
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf '\n'
     printf 'Reusing existing data directory..\n'
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R root:root /home/ain_blockchain_data"
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 fi

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
-    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--json-rpc] [--update-front-db] [--rest-func]\n"
-    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync\n"
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func]\n"
+    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "\n"
     exit
 fi
@@ -28,6 +28,10 @@ function parse_options() {
         SYNC_MODE_OPTION="$option"
     elif [[ $option = '--fast-sync' ]]; then
         SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--json-rpc' ]]; then
         JSON_RPC_OPTION="$option"
     elif [[ $option = '--update-front-db' ]]; then
@@ -67,6 +71,7 @@ ACCOUNT_INJECTION_OPTION="--private-key"
 KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--chown-data"
 JSON_RPC_OPTION=""
 UPDATE_FRONT_DB_OPTION=""
 REST_FUNC_OPTION=""
@@ -88,6 +93,7 @@ printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
 printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
 printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
 printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
 printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
@@ -337,13 +343,21 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    else
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+    fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf '\n'
     printf 'Reusing existing data directory..\n'
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    else
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+    fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 fi

--- a/start_tracker_genesis_gcp.sh
+++ b/start_tracker_genesis_gcp.sh
@@ -1,26 +1,28 @@
 #!/bin/bash
 
-if [[ $# -gt 1 ]]; then
-    printf "Usage: bash start_tracker_genesis_gcp.sh [--keep-code|--no-keep-code]\n"
-    printf "Example: bash start_tracker_genesis_gcp.sh --keep-code\n"
+if [[ $# -gt 2 ]]; then
+    printf "Usage: bash start_tracker_genesis_gcp.sh <GCP Username> [--keep-code|--no-keep-code]\n"
+    printf "Example: bash start_tracker_genesis_gcp.sh gcp_user --keep-code\n"
     printf "\n"
     exit
 fi
 printf "\n[[[[[ start_tracker_genesis_gcp.sh ]]]]]\n\n"
 
-KEEP_CODE_OPTION="--keep-code"
+GCP_USER="$1"
 
-if [[ $# = 1 ]]; then
-    if [[ $1 = '--keep-code' ]]; then
-        KEEP_CODE_OPTION=$1
-    elif [[ $1 = '--no-keep-code' ]]; then
-        KEEP_CODE_OPTION=$1
+KEEP_CODE_OPTION="--keep-code"
+if [[ $# = 2 ]]; then
+    if [[ $2 = '--keep-code' ]]; then
+        KEEP_CODE_OPTION=$2
+    elif [[ $2 = '--no-keep-code' ]]; then
+        KEEP_CODE_OPTION=$2
     else
-        printf "Invalid option: $1\n"
+        printf "Invalid option: $2\n"
         exit
     fi
 fi
 
+printf "GCP_USER=$GCP_USER\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 
 printf '\n'
@@ -32,13 +34,13 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Creating new working directory..\n'
     sudo rm -rf /home/ain-blockchain*
-    CODE_CMD="cd ~; sudo mv ain-blockchain /home; sudo chmod -R 777 /home/ain-blockchain; sudo chown -R root:root /home/ain-blockchain; cd /home/ain-blockchain"
+    CODE_CMD="cd ~; sudo mv ain-blockchain /home; sudo chmod -R 777 /home/ain-blockchain; sudo chown -R $GCP_USER:$GCP_USER /home/ain-blockchain; cd /home/ain-blockchain"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 
     printf '\n'
     printf 'Installing node modules..\n'
-    INSTALL_CMD="sudo yarn install --ignore-engines"
+    INSTALL_CMD="yarn install --ignore-engines"
     printf "\nINSTALL_CMD=$INSTALL_CMD\n"
     eval $INSTALL_CMD
 else
@@ -46,7 +48,7 @@ else
     printf 'Using old directory..\n'
     OLD_DIR_PATH=$(find /home/ain-blockchain* -maxdepth 0 -type d)
     printf "OLD_DIR_PATH=$OLD_DIR_PATH\n"
-    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R root:root $OLD_DIR_PATH"
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 fi

--- a/start_tracker_incremental_gcp.sh
+++ b/start_tracker_incremental_gcp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [[ "$#" -gt 1 ]]; then
-    printf "Usage: bash start_tracker_incremental_gcp.sh [--keep-code|--no-keep-code]\n"
-    printf "Example: bash start_tracker_incremental_gcp.sh --keep-code\n"
+if [[ "$#" -gt 2 ]]; then
+    printf "Usage: bash start_tracker_incremental_gcp.sh <GCP Username> [--keep-code|--no-keep-code]\n"
+    printf "Example: bash start_tracker_incremental_gcp.sh gcp_user --keep-code\n"
     printf "\n"
     exit
 fi
@@ -11,19 +11,22 @@ printf "\n[[[[[ start_tracker_incremental_gcp.sh ]]]]]\n\n"
 # 1. Configure env vars
 printf "\n#### [Step 1] Configure env vars ####\n\n"
 
+GCP_USER="$1"
+
 KEEP_CODE_OPTION="--keep-code"
 
-if [[ $# = 1 ]]; then
-    if [[ $1 = '--keep-code' ]]; then
-        KEEP_CODE_OPTION=$1
-    elif [[ $1 = '--no-keep-code' ]]; then
-        KEEP_CODE_OPTION=$1
+if [[ $# = 2 ]]; then
+    if [[ $2 = '--keep-code' ]]; then
+        KEEP_CODE_OPTION=$2
+    elif [[ $2 = '--no-keep-code' ]]; then
+        KEEP_CODE_OPTION=$2
     else
-        printf "Invalid option: $1\n"
+        printf "Invalid option: $2\n"
         exit
     fi
 fi
 
+printf "GCP_USER=$GCP_USER\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
 
 # 2. Get currently used directory & new directory
@@ -44,20 +47,20 @@ printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new data directory..\n'
-    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R root:root $NEW_DIR_PATH"
+    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $NEW_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 
     printf '\n'
     printf 'Installing node modules..\n'
     cd $NEW_DIR_PATH
-    INSTALL_CMD="sudo yarn install --ignore-engines"
+    INSTALL_CMD="yarn install --ignore-engines"
     printf "\nINSTALL_CMD=$INSTALL_CMD\n"
     eval $INSTALL_CMD
 else
     printf '\n'
     printf 'Reusing existing working directory..\n'
-    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R root:root $OLD_DIR_PATH"
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 fi


### PR DESCRIPTION
Change summary:
- Set GCP_USER as file owner in deploy scripts
- Add --chown-data / --no-chown-data option for data files

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1086