### PR TITLE
Remove -R option from chmod command for ain_blockchain_data directory

### DIFF
--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -366,6 +366,7 @@ for node_index in `seq 0 $(( $NUM_NODES - 1 ))`; do
     START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
     printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD
+    sleep 5
     inject_account "$node_index"
 done
 

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -255,6 +255,7 @@ function deploy_node() {
     eval $START_NODE_CMD
 
     # 4. Inject node account
+    sleep 5
     if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
         local node_ip_addr=${IP_ADDR_LIST[${node_index}]}
         printf "\n* >> Initializing account for node $node_index ($node_target_addr) ********************\n\n"

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -447,6 +447,7 @@ while [ $node_index -le $END_NODE_IDX ]; do
     # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
     # printf "START_NODE_CMD=$START_NODE_CMD\n"
     eval $START_NODE_CMD
+    sleep 5
     inject_account "$node_index"
     ((node_index++))
     sleep 1

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -177,19 +177,15 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
-    else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
-    fi
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf 'Reusing existing data directory..\n'
-    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--no-chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -180,7 +180,7 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
         DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
@@ -189,7 +189,7 @@ else
     if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
         DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -343,20 +343,16 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     sudo rm -rf /home/ain_blockchain_data/chains
     sudo rm -rf /home/ain_blockchain_data/snapshots
     sudo rm -rf /home/ain_blockchain_data/logs
-    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
-    else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
-    fi
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf '\n'
     printf 'Reusing existing data directory..\n'
-    if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    if [[ $CHOWN_DATA_OPTION = "--no-chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -346,7 +346,7 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
         DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
@@ -356,7 +356,7 @@ else
     if [[ $CHOWN_DATA_OPTION = "--chown-data" ]]; then
         DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD


### PR DESCRIPTION
Change summary:
- Refactor -R option in chmod / chown commands for ain_blockchain_data directory
- Add time buffer before account injection to avoid ECONNREFUSED error

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1086
- https://github.com/ainblockchain/ain-blockchain/issues/1091