### PR TITLE
Delete dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "develop"
-    labels:
-      - "dependencies"


### PR DESCRIPTION
According to the [Github official documentation](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts#detection-of-insecure-dependencies), dependabot's security scan is executed only for the default branch.
With dependabot.yml, I couldn't make the security scan run in the develop branch, so I removed the dependabot.yml file.