### PR TITLE
Make ain_getTransactionByHash() return tx execution result

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -574,15 +574,17 @@ const WriteDbOperations = {
  */
 const TransactionStates = {
   FINALIZED: 'FINALIZED',
-  REVERTED: 'REVERTED', // Reverted means it's failed but included in a block
+  REVERTED: 'REVERTED',  // Failed but included in a block
   EXECUTED: 'EXECUTED',
-  FAILED: 'FAILED', // Failed means it's failed and is NOT included in a block
+  FAILED: 'FAILED',      // Failed and is NOT included in a block
+  IN_BLOCK: 'IN_BLOCK',  // Included in a block, NOT reverted.
   PENDING: 'PENDING',
   TIMED_OUT: 'TIMED_OUT',
 };
 
 function isTxInBlock(state) {
-  return state === TransactionStates.FINALIZED || state === TransactionStates.REVERTED;
+  return state === TransactionStates.FINALIZED || state === TransactionStates.IN_BLOCK
+      || state === TransactionStates.REVERTED;
 }
 
 function isEndState(state) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -577,7 +577,7 @@ const TransactionStates = {
   REVERTED: 'REVERTED',  // Failed but included in a block
   EXECUTED: 'EXECUTED',
   FAILED: 'FAILED',      // Failed and is NOT included in a block
-  IN_BLOCK: 'IN_BLOCK',  // Included in a block, NOT reverted.
+  IN_BLOCK: 'IN_BLOCK',  // Included in a block, NOT reverted nor finalized.
   PENDING: 'PENDING',
   TIMED_OUT: 'TIMED_OUT',
 };

--- a/consensus/index.js
+++ b/consensus/index.js
@@ -844,15 +844,20 @@ class Consensus {
     }
     for (let i = 0; i < transactions.length; i++) {
       const trackedAt = Date.now();
-      const txHash = transactions[i].hash;
+      const tx = transactions[i];
       const txResult = txsRes[i];
+      const tracked = node.tp.transactionTracker.get(tx.hash) || {};
+      const beforeState = _.get(tracked, 'state', null);
       const txState =
           CommonUtil.isFailedTx(txResult) ? TransactionStates.REVERTED : TransactionStates.IN_BLOCK;
-      node.tp.updateTransactionInfo(txHash, {
+      node.tp.updateTransactionInfo(tx.hash, {
         state: txState,
         exec_result: txResult,
         tracked_at: trackedAt,
       });
+      if (node.eh) {
+        node.eh.emitTxStateChanged(tx, beforeState, txState);
+      }
     }
   }
 

--- a/node/index.js
+++ b/node/index.js
@@ -851,7 +851,7 @@ class BlockchainNode {
           const latestDb = this.createTempDb(latestSnapshotStateVersion, `${StateVersions.LOAD}:${number}`, number);
           this.bp.addToHashToDbMap(block.hash, latestDb);
         } else {
-          Consensus.validateAndExecuteBlockOnDb(block, this, StateVersions.LOAD, proposalTx, true);
+          Consensus.validateAndExecuteBlockOnDb(block, this, StateVersions.LOAD, proposalTx, true, true);
           if (number === 0) {
             this.bc.addBlockToChainAndWriteToDisk(block, false);
             this.cloneAndFinalizeVersion(this.bp.hashToDb.get(block.hash).stateVersion, 0);
@@ -905,7 +905,7 @@ class BlockchainNode {
       const proposalTx = i < validBlocks.length - 1 ?
           ConsensusUtil.filterProposalFromVotes(validBlocks[i + 1].last_votes) : null;
       try {
-        Consensus.validateAndExecuteBlockOnDb(block, this, StateVersions.SEGMENT, proposalTx, true);
+        Consensus.validateAndExecuteBlockOnDb(block, this, StateVersions.SEGMENT, proposalTx, true, true);
         this.tryFinalizeChain();
       } catch (e) {
         logger.info(`[${LOG_HEADER}] Failed to add new block (${block.number} / ${block.hash}) to chain: ${e.stack}`);

--- a/node/index.js
+++ b/node/index.js
@@ -806,11 +806,11 @@ class BlockchainNode {
       //               will not be included in the tx pool, as they can't be included in a block
       //               anyway, and may be used for attacks on blockchain nodes.
       if (!isDryrun && !CommonUtil.txPrecheckFailed(result)) {
-        this.tp.addTransaction(executableTx);
+        this.tp.addTransaction(executableTx, result);
       }
     } else {
       if (!isDryrun) {
-        this.tp.addTransaction(executableTx, true);
+        this.tp.addTransaction(executableTx, result, true);
       }
     }
 

--- a/node/index.js
+++ b/node/index.js
@@ -1044,7 +1044,7 @@ class BlockchainNode {
         lastFinalizedBlock = blockToFinalize;
         logger.debug(`[${LOG_HEADER}] Finalized a block of number ${blockToFinalize.number} and ` +
             `hash ${blockToFinalize.hash}`);
-        this.tp.cleanUpForNewBlock(blockToFinalize);
+        this.tp.cleanUpForFinalizedBlock(blockToFinalize);
         if (!CommonUtil.isEmpty(blockToFinalize.evidence)) {
           Object.values(blockToFinalize.evidence).forEach((evidenceList) => {
             evidenceList.forEach((val) => {

--- a/test/integration/event_handler.test.js
+++ b/test/integration/event_handler.test.js
@@ -371,12 +371,15 @@ describe('Event Handler Test', function() {
             if (eventTriggeredCnt === 0) {
               expect(txState.before).to.equal(null);
               expect(txState.after).to.equal(TransactionStates.EXECUTED);
-              eventTriggeredCnt++;
-            } else {
+            } else if (eventTriggeredCnt === 1) {
               expect(txState.before).to.equal(TransactionStates.EXECUTED);
+              expect(txState.after).to.equal(TransactionStates.IN_BLOCK);
+            } else if (eventTriggeredCnt === 2) {
+              expect(txState.before).to.equal(TransactionStates.IN_BLOCK);
               expect(txState.after).to.equal(TransactionStates.FINALIZED);
               done();
             }
+            eventTriggeredCnt++;
           }
         });
         const txResult = setValue(serverList[EVENT_HANDLER_NODE_INDEX], targetPath, 'change')
@@ -402,15 +405,17 @@ describe('Event Handler Test', function() {
             if (eventTriggeredCnt < 2) {
               expect(txState.before).to.equal(null);
               expect(txState.after).to.equal(TransactionStates.EXECUTED);
-              eventTriggeredCnt++;
-            } else {
+            } else if (eventTriggeredCnt < 4) {
               expect(txState.before).to.equal(TransactionStates.EXECUTED);
+              expect(txState.after).to.equal(TransactionStates.IN_BLOCK);
+            } else if (eventTriggeredCnt < 6) {
+              expect(txState.before).to.equal(TransactionStates.IN_BLOCK);
               expect(txState.after).to.equal(TransactionStates.FINALIZED);
-              eventTriggeredCnt++;
-              if (eventTriggeredCnt === 4) {
+              if (eventTriggeredCnt === 5) {
                 done();
               }
             }
+            eventTriggeredCnt++;
           }
         });
         const txResult = setValue(serverList[EVENT_HANDLER_NODE_INDEX], targetPath, 'change')
@@ -443,12 +448,12 @@ describe('Event Handler Test', function() {
             if (eventTriggeredCnt === 0) {
               expect(txState.before).to.equal(null);
               expect(txState.after).to.equal(TransactionStates.PENDING);
-              eventTriggeredCnt++;
-            } else {
+            } else if (eventTriggeredCnt === 1) {
               expect(txState.before).to.equal(TransactionStates.PENDING);
               expect(txState.after).to.equal(TransactionStates.REVERTED);
               done();
             }
+            eventTriggeredCnt++;
           }
         });
         registerFilter(wsClient, filterId, BlockchainEventTypes.TX_STATE_CHANGED, config);

--- a/test/unit/tx-pool.test.js
+++ b/test/unit/tx-pool.test.js
@@ -64,11 +64,13 @@ describe('TransactionPool', () => {
     });
 
     it('add an executed transaction', () => {
-      node.tp.addTransaction(txToAdd, true);
+      const execResult = { code: 0 };
+      node.tp.addTransaction(txToAdd, execResult, true);
       const addedTx = node.tp.transactions.get(node.account.address).find((t) => t.hash === txToAdd.hash);
       assert.deepEqual(eraseTxCreatedAt(addedTx), eraseTxCreatedAt(txToAdd));
       const txInfo = node.getTransactionByHash(txToAdd.hash);
       expect(txInfo.state).to.equal(TransactionStates.EXECUTED);
+      assert.deepEqual(txInfo.exec_result, execResult);
     });
   });
 

--- a/test/unit/tx-pool.test.js
+++ b/test/unit/tx-pool.test.js
@@ -766,7 +766,7 @@ describe('TransactionPool', () => {
       nodes = [node2, node3, node4];
     });
 
-    it('cleanUpForNewBlock()', () => {
+    it('cleanUpForFinalizedBlock()', () => {
       const number = 1;
       const lastBlock = node.bc.genesisBlock;
       const transactions = node.tp.getValidTransactions();
@@ -789,7 +789,7 @@ describe('TransactionPool', () => {
         }));
         node.tp.addTransaction(newTransactions[node.account.address][i]);
       }
-      node.tp.cleanUpForNewBlock(block);
+      node.tp.cleanUpForFinalizedBlock(block);
       assert.deepEqual(newTransactions, Object.fromEntries(node.tp.transactions));
     });
 

--- a/tools/proof-hash/verifyBlock.js
+++ b/tools/proof-hash/verifyBlock.js
@@ -100,7 +100,7 @@ async function verifyBlock(snapshotFile, blockFileList) {
     // TODO(platfowner): Make the block execution code work.
     console.log(`\n* Executing block on db...`);
     try {
-      Consensus.validateAndExecuteBlockOnDb(block, node, 'verifyBlock', proposalTx);
+      Consensus.validateAndExecuteBlockOnDb(block, node, 'verifyBlock', proposalTx, false);
     } catch (e) {
       console.log(`Failed to validate and excute block ${block.number}: ${e}`);
       process.exit(0);

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -66,7 +66,7 @@ class TransactionPool {
     this.updateTxList(address, txListAfter);
   }
 
-  addTransaction(tx, isExecutedTx = false) {
+  addTransaction(tx, execResult = null, isExecutedTx = false) {
     const LOG_HEADER = 'addTransaction';
 
     // NOTE(platfowner): A transaction needs to be converted to an executable form
@@ -87,7 +87,7 @@ class TransactionPool {
       logger.error(`[${LOG_HEADER}] Already tracked transaction: ${JSON.stringify(tx)}`);
       return false;
     }
-    this.transactionTracker.set(tx.hash, {
+    const transactionInfo = {
       state: txState,
       number: -1,
       index: this.transactions.get(tx.address).length - 1,
@@ -98,7 +98,11 @@ class TransactionPool {
       tracked_at: tx.extra.created_at,
       executed_at: tx.extra.executed_at,
       finalized_at: -1,
-    });
+    };
+    if (execResult) {
+      transactionInfo.exec_result = execResult;
+    }
+    this.transactionTracker.set(tx.hash, transactionInfo);
     this.txCountTotal++;
     if (Transaction.isFreeTransaction(tx)) {
       this.freeTxCountTotal++;

--- a/tx-pool/index.js
+++ b/tx-pool/index.js
@@ -538,7 +538,7 @@ class TransactionPool {
     this.updateTxPoolWithTxHashSet(consensusTxs, {}, {});
   }
 
-  cleanUpForNewBlock(block) {
+  cleanUpForFinalizedBlock(block) {
     const finalizedAt = Date.now();
     // Get in-block transaction set.
     const inBlockTxs = new Set();


### PR DESCRIPTION
Change summary:
- Make ain_getTransactionByHash() return tx execution result
- Add IN_BLOCK transaction state
- Update the states of the transactions in blocks when they're executed

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1202