### PR TITLE
Spin off Consensus APIs from Block APIs

### DIFF
--- a/json_rpc/account.js
+++ b/json_rpc/account.js
@@ -40,20 +40,5 @@ module.exports = function getAccountApis(node) {
       trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({ result }));
     },
-
-    [JSON_RPC_METHODS.AIN_GET_VALIDATOR_INFO]: function(args, done) {
-      const beginTime = Date.now();
-      const addr = args.address;
-      const isWhitelisted = node.db.getValue(PathUtil.getConsensusProposerWhitelistAddrPath(addr)) || false;
-      const stake = node.db.getValue(PathUtil.getServiceAccountBalancePath(addr)) || 0;
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({
-        result: {
-          isWhitelisted,
-          stake,
-        }
-      }));
-    },
   };
 };

--- a/json_rpc/block.js
+++ b/json_rpc/block.js
@@ -66,37 +66,10 @@ module.exports = function getBlockApis(node) {
       done(null, JsonRpcUtil.addProtocolVersion({ result: blockHeaders }));
     },
 
-    [JSON_RPC_METHODS.AIN_GET_PROPOSER_BY_HASH]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByHash(args.hash);
-      const result = block ? block.proposer : null;
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_PROPOSER_BY_NUMBER]: function(args, done) {
+    [JSON_RPC_METHODS.AIN_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER]: function(args, done) {
       const beginTime = Date.now();
       const block = node.bc.getBlockByNumber(args.number);
-      const result = block ? block.proposer : null;
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_VALIDATORS_BY_NUMBER]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByNumber(args.number);
-      const result = block ? block.validators : null;
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_VALIDATORS_BY_HASH]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByHash(args.hash);
-      const result = block ? block.validators : null;
+      const result = block ? block.transactions.length : null;
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({ result }));
@@ -105,15 +78,6 @@ module.exports = function getBlockApis(node) {
     [JSON_RPC_METHODS.AIN_GET_BLOCK_TRANSACTION_COUNT_BY_HASH]: function(args, done) {
       const beginTime = Date.now();
       const block = node.bc.getBlockByHash(args.hash);
-      const result = block ? block.transactions.length : null;
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByNumber(args.number);
       const result = block ? block.transactions.length : null;
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);

--- a/json_rpc/block.js
+++ b/json_rpc/block.js
@@ -2,19 +2,12 @@ const {
   TrafficEventTypes,
   trafficStatsManager,
 } = require('../common/constants');
+const CommonUtil = require('../common/common-util');
 const JsonRpcUtil = require('./json-rpc-util');
 const { JSON_RPC_METHODS } = require('./constants');
 
 module.exports = function getBlockApis(node) {
   return {
-    [JSON_RPC_METHODS.AIN_GET_BLOCK_LIST]: function(args, done) {
-      const beginTime = Date.now();
-      const blocks = node.bc.getBlockList(args.from, args.to);
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result: blocks }));
-    },
-
     [JSON_RPC_METHODS.AIN_GET_LAST_BLOCK]: function(args, done) {
       const beginTime = Date.now();
       const result = node.bc.lastBlock();
@@ -31,6 +24,36 @@ module.exports = function getBlockApis(node) {
       done(null, JsonRpcUtil.addProtocolVersion({ result }));
     },
 
+    [JSON_RPC_METHODS.AIN_GET_BLOCK_BY_NUMBER]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByNumber(args.number);
+      if (block && !CommonUtil.toBool(args.getFullTransactions)) {
+        block.transactions = JsonRpcUtil.extractTransactionHashes(block);
+      }
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result: block }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_BLOCK_BY_HASH]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByHash(args.hash);
+      if (block && !CommonUtil.toBool(args.getFullTransactions)) {
+        block.transactions = JsonRpcUtil.extractTransactionHashes(block);
+      }
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result: block }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_BLOCK_LIST]: function(args, done) {
+      const beginTime = Date.now();
+      const blocks = node.bc.getBlockList(args.from, args.to);
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result: blocks }));
+    },
+
     [JSON_RPC_METHODS.AIN_GET_BLOCK_HEADERS_LIST]: function(args, done) {
       const beginTime = Date.now();
       const blocks = node.bc.getBlockList(args.from, args.to);
@@ -41,32 +64,6 @@ module.exports = function getBlockApis(node) {
       const latency = Date.now() - beginTime;
       trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
       done(null, JsonRpcUtil.addProtocolVersion({ result: blockHeaders }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_BLOCK_BY_HASH]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByHash(args.hash);
-      if (block && !args.getFullTransactions) {
-        block.transactions = JsonRpcUtil.extractTransactionHashes(block);
-      }
-      const latency = Date.now() - beginTime;
-      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-      done(null, JsonRpcUtil.addProtocolVersion({ result: block }));
-    },
-
-    [JSON_RPC_METHODS.AIN_GET_BLOCK_BY_NUMBER]: function(args, done) {
-      const beginTime = Date.now();
-      const block = node.bc.getBlockByNumber(args.number);
-      if (!block || args.getFullTransactions) {
-        const latency = Date.now() - beginTime;
-        trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-        done(null, JsonRpcUtil.addProtocolVersion({ result: block }));
-      } else {
-        block.transactions = JsonRpcUtil.extractTransactionHashes(block);
-        const latency = Date.now() - beginTime;
-        trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
-        done(null, JsonRpcUtil.addProtocolVersion({ result: block }));
-      }
     },
 
     [JSON_RPC_METHODS.AIN_GET_PROPOSER_BY_HASH]: function(args, done) {

--- a/json_rpc/consensus.js
+++ b/json_rpc/consensus.js
@@ -1,0 +1,61 @@
+const {
+  TrafficEventTypes,
+  trafficStatsManager,
+} = require('../common/constants');
+const JsonRpcUtil = require('./json-rpc-util');
+const { JSON_RPC_METHODS } = require('./constants');
+
+module.exports = function getBlockApis(node) {
+  return {
+    [JSON_RPC_METHODS.AIN_GET_VALIDATOR_INFO]: function(args, done) {
+      const beginTime = Date.now();
+      const addr = args.address;
+      const isWhitelisted = node.db.getValue(PathUtil.getConsensusProposerWhitelistAddrPath(addr)) || false;
+      const stake = node.db.getValue(PathUtil.getServiceAccountBalancePath(addr)) || 0;
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({
+        result: {
+          isWhitelisted,
+          stake,
+        }
+      }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_VALIDATORS_BY_NUMBER]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByNumber(args.number);
+      const result = block ? block.validators : null;
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_VALIDATORS_BY_HASH]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByHash(args.hash);
+      const result = block ? block.validators : null;
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_PROPOSER_BY_NUMBER]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByNumber(args.number);
+      const result = block ? block.proposer : null;
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result }));
+    },
+
+    [JSON_RPC_METHODS.AIN_GET_PROPOSER_BY_HASH]: function(args, done) {
+      const beginTime = Date.now();
+      const block = node.bc.getBlockByHash(args.hash);
+      const result = block ? block.proposer : null;
+      const latency = Date.now() - beginTime;
+      trafficStatsManager.addEvent(TrafficEventTypes.JSON_RPC_GET, latency);
+      done(null, JsonRpcUtil.addProtocolVersion({ result }));
+    },
+  };
+};


### PR DESCRIPTION
Change summary:
- Spin off Consensus APIs from Block APIs
- Apply CommonUtil.toBool() to getFullTransactions parameter

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1235