### PR TITLE
Remove CORS_WHITELIST commandline examples for node param tools

### DIFF
--- a/tools/api-access/addToWhitelistNodeParam.js
+++ b/tools/api-access/addToWhitelistNodeParam.js
@@ -61,7 +61,6 @@ function usage() {
   console.log('Example: node tools/api-access/addToWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 mnemonic');
   console.log('Example: node tools/api-access/addToWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore keystore_blockchain_node.json');
   console.log("Example: node tools/api-access/addToWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST '*' keystore keystore keystore_blockchain_node.json");
-  console.log('Example: node tools/api-access/addToWhitelistNodeParam.js http://localhost:8081 0 CORS_WHITELIST https://ainetwork.ai keystore keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/addToWhitelistNodeParam.js https://staging-api.ainetwork.ai 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/addToWhitelistNodeParam.js https://testnet-api.ainetwork.ai 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/addToWhitelistNodeParam.js https://mainnet-api.ainetwork.ai 1 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore keystore_blockchain_node.json\n');

--- a/tools/api-access/removeFromWhitelistNodeParam.js
+++ b/tools/api-access/removeFromWhitelistNodeParam.js
@@ -61,7 +61,6 @@ function usage() {
   console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 mnemonic');
   console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore_blockchain_node.json');
   console.log("Example: node tools/api-access/removeFromWhitelistNodeParam.js http://localhost:8081 0 DEV_CLIENT_API_IP_WHITELIST '*' keystore keystore_blockchain_node.json");
-  console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js http://localhost:8081 0 CORS_WHITELIST https://ainetwork.ai keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js https://staging-api.ainetwork.ai 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js https://testnet-api.ainetwork.ai 0 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore_blockchain_node.json');
   console.log('Example: node tools/api-access/removeFromWhitelistNodeParam.js https://mainnet-api.ainetwork.ai 1 DEV_CLIENT_API_IP_WHITELIST 127.0.0.1 keystore keystore_blockchain_node.json\n');


### PR DESCRIPTION
Change summary;
- Remove CORS_WHITELIST commandline examples for node param tools

Related issues: 
- https://github.com/ainblockchain/ain-blockchain/issues/1272
