### PR TITLE
Increase tx_bytes_limit to 100k bytes from 10k bytes

### DIFF
--- a/blockchain-configs/base/timer_flags.json
+++ b/blockchain-configs/base/timer_flags.json
@@ -59,5 +59,9 @@
   "allow_up_to_6_decimal_transfer_value_only": {
     "enabled_block": 2,
     "has_bandage": true
+  },
+  "update_tx_bytes_limit": {
+    "enabled_block": 2,
+    "has_bandage": true
   }
 }

--- a/blockchain-configs/mainnet-prod/timer_flags.json
+++ b/blockchain-configs/mainnet-prod/timer_flags.json
@@ -58,5 +58,9 @@
   "allow_up_to_6_decimal_transfer_value_only": {
     "enabled_block": 3064900,
     "has_bandage": true
+  },
+  "update_tx_bytes_limit": {
+    "enabled_block": null,
+    "has_bandage": true
   }
 }

--- a/blockchain-configs/testnet-prod/timer_flags.json
+++ b/blockchain-configs/testnet-prod/timer_flags.json
@@ -62,5 +62,9 @@
   "allow_up_to_6_decimal_transfer_value_only": {
     "enabled_block": 3062600,
     "has_bandage": true
+  },
+  "update_tx_bytes_limit": {
+    "enabled_block": null,
+    "has_bandage": true
   }
 }

--- a/db/bandage-files/update_tx_bytes_limit.js
+++ b/db/bandage-files/update_tx_bytes_limit.js
@@ -1,0 +1,9 @@
+module.exports = {
+  data: [
+    {
+      path: ['values', 'blockchain_params', 'resource', 'tx_bytes_limit'],
+      value: 100000,
+      prevValue: 10000
+    }
+  ]
+};

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -6,6 +6,7 @@ const spawn = require("child_process").spawn;
 const syncRequest = require('sync-request');
 const rimraf = require("rimraf")
 const jayson = require('jayson/promise');
+const sizeof = require('object-sizeof');
 const ainUtil = require('@ainblockchain/ain-util');
 const { BlockchainConsts, BlockchainParams, NodeConfigs } = require('../../common/constants');
 const CommonUtil = require('../../common/common-util');
@@ -5079,7 +5080,8 @@ describe('Blockchain Node', () => {
 
       it('rejects a transaction that exceeds its size limit.', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
-        const longText = 'a'.repeat(BlockchainParams.resource.tx_bytes_limit / 2);
+        const txBytesLimit = 100000;  // BlockchainParams.resource.tx_bytes_limit;
+        const longText = 'a'.repeat(txBytesLimit / 2);
         const txBody = {
           operation: {
             type: 'SET_VALUE',
@@ -5100,7 +5102,7 @@ describe('Blockchain Node', () => {
           assert.deepEqual(res.result, {
             result: null,
             code: 30301,
-            message: `Transaction size exceeds its limit: ${BlockchainParams.resource.tx_bytes_limit} bytes.`,
+            message: `Transaction size exceeds its limit: ${txBytesLimit} bytes.`,
             protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION
           });
         })
@@ -5584,7 +5586,8 @@ describe('Blockchain Node', () => {
 
       it('rejects a batch transaction with a transaction that exceeds its size limit.', () => {
         const client = jayson.client.http(server1 + '/json-rpc');
-        const longText = 'a'.repeat(BlockchainParams.resource.tx_bytes_limit / 2);
+        const txBytesLimit = 100000;  // BlockchainParams.resource.tx_bytes_limit;
+        const longText = 'a'.repeat(txBytesLimit / 2);
         const txBody = {
           operation: {
             type: 'SET_VALUE',
@@ -5619,7 +5622,7 @@ describe('Blockchain Node', () => {
           assert.deepEqual(res.result, {
             result: null,
             code: 30403,
-            message: `Transaction[1]'s size exceededs its limit: ${BlockchainParams.resource.tx_bytes_limit} bytes.`,
+            message: `Transaction[1]'s size exceededs its limit: ${txBytesLimit} bytes.`,
             protoVer: BlockchainConsts.CURRENT_PROTOCOL_VERSION,
           });
         })


### PR DESCRIPTION
Change summary:
- Increase tx_bytes_limit to 100k bytes from 10k bytes
- Change tx_bytes_limit checking to use sizeof(args.tx_body) instead of sizeof(args)
- Add test cases for ordered nonces (-2)

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1277