### PR TITLE
Add p2p ip address whitelisting

### DIFF
--- a/p2p/p2p-util.js
+++ b/p2p/p2p-util.js
@@ -178,6 +178,12 @@ class P2pUtil {
     return CommonUtil.isValidIpV4(ipAddress) || CommonUtil.isValidIpV6(ipAddress);
   }
 
+  // NOTE(platfowner): Need whitelisting due to the internal networking config of comcom hosting env.
+  static isWhitelistedIpAddress(ipAddress) {
+    const whitelistedIpAddressRegex = /192.168.\d+.2/gm;
+    return CommonUtil.isString(ipAddress) ? whitelistedIpAddressRegex.test(ipAddress) : false;
+  }
+
   /**
    * Returns true if the socket ip address is the same as the given p2p url ip address,
    * false otherwise.
@@ -187,9 +193,10 @@ class P2pUtil {
   static checkIpAddressFromPeerInfo(ipAddressFromSocket, ipAddressFromPeerInfo) {
     if (!P2pUtil.isValidIpAddress(ipAddressFromSocket) ||
         !P2pUtil.isValidIpAddress(ipAddressFromPeerInfo)) {
-        return false;
+      return false;
     } else {
-      return ip.isEqual(ipAddressFromSocket, ipAddressFromPeerInfo);
+      return ip.isEqual(ipAddressFromSocket, ipAddressFromPeerInfo)
+          || P2pUtil.isWhitelistedIpAddress(ipAddressFromSocket);
     }
   }
 

--- a/test/unit/p2p-util.test.js
+++ b/test/unit/p2p-util.test.js
@@ -376,12 +376,58 @@ describe("P2P Util", () => {
       expect(util.isValidIpAddress(url5)).to.be.false;
     });
 
-    it("returns true if valid ip address is set", () => {
+    it("returns true if valid ip address is given", () => {
       const ipV4 = '172.20.10.2';
       const ipV6 = '::ffff:172.20.10.2';
 
       expect(util.isValidIpAddress(ipV4)).to.be.true;
       expect(util.isValidIpAddress(ipV6)).to.be.true;
+    });
+  });
+
+  describe("isWhitelistedIpAddress", () => {
+    it("returns false if invalid ipAddress is given", () => {
+      const stringValue = 'stringValue';
+      const numberValue = 123456789;
+      const booleanValue = true;
+      const nullValue = null;
+      const undefinedValue = undefined;
+      const arrayValue = [];
+      const objectValue = {};
+      const url1 = 'ainetwork.ai';
+      const url2 = 'https://*.ainetwork.ai';
+      const url3 = 'http://172.16.0.36:8080';
+      const url4 = 'http://172.16.0.36';
+      const url5 = 'http://172.16.0.36:8080/json-rpc';
+      const ipAddr1 = '172.16.0.36';
+      const ipAddr2 = '::ffff:172.16.0.36';
+
+      expect(util.isWhitelistedIpAddress(stringValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(numberValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(booleanValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(nullValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(undefinedValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(arrayValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(objectValue)).to.be.false;
+      expect(util.isWhitelistedIpAddress(url1)).to.be.false;
+      expect(util.isWhitelistedIpAddress(url2)).to.be.false;
+      expect(util.isWhitelistedIpAddress(url3)).to.be.false;
+      expect(util.isWhitelistedIpAddress(url4)).to.be.false;
+      expect(util.isWhitelistedIpAddress(url5)).to.be.false;
+      expect(util.isWhitelistedIpAddress(ipAddr1)).to.be.false;
+      expect(util.isWhitelistedIpAddress(ipAddr2)).to.be.false;
+    });
+
+    it("returns true if whitelisted ip address is given", () => {
+      const ipV4Addr1 = '192.168.92.2';
+      const ipV4Addr2 = '192.168.93.2';
+      const ipV6Addr1 = '::ffff:192.168.92.2';
+      const ipV6Addr2 = '::ffff:192.168.93.2';
+
+      expect(util.isWhitelistedIpAddress(ipV4Addr1)).to.be.true;
+      expect(util.isWhitelistedIpAddress(ipV4Addr2)).to.be.true;
+      expect(util.isWhitelistedIpAddress(ipV6Addr1)).to.be.true;
+      expect(util.isWhitelistedIpAddress(ipV6Addr2)).to.be.true;
     });
   });
 
@@ -405,6 +451,20 @@ describe("P2P Util", () => {
       const ipV6 = '::ffff:172.20.10.2';
 
       expect(util.checkIpAddressFromPeerInfo(ipV4, ipV6)).to.be.true;
+    });
+
+    it("returns true for whitelisted ip addresses", () => {
+      const ip1 = '::ffff:192.168.92.2';
+      const ip2 = '101.202.37.2';
+
+      expect(util.checkIpAddressFromPeerInfo(ip1, ip2)).to.be.true;
+    });
+
+    it("returns false for non-whitelisted ip addresses", () => {
+      const ip1 = '::ffff:101.202.37.2';
+      const ip2 = '192.168.92.2';
+
+      expect(util.checkIpAddressFromPeerInfo(ip1, ip2)).to.be.false;
     });
   });
 


### PR DESCRIPTION
Change summary:
- Add p2p ip address whitelisting for on-premise nodes

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1285