### PR TITLE
Add incremental blockchain deploy scripts for onprem machines

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -97,7 +97,7 @@ app.get('/metrics', async (req, res, next) => {
     .end();
 });
 
-// Used in wait_until_node_sync_gcp.sh
+// Used in wait_until_node_sync.sh
 app.get('/last_block_number', (req, res, next) => {
   const beginTime = Date.now();
   const result = node.bc.lastBlockNumber();

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -225,7 +225,7 @@ function inject_account() {
 
 # deploy files
 FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_gcp.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync.sh stop_local_blockchain.sh"
 
 TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-tracker-taiwan"
 NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-node-0-taiwan"

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -446,9 +446,8 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
         printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
         printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
-        printf "\n"
         START_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone ${!NODE_ZONE}"
-        printf "START_NODE_CMD=$START_NODE_CMD\n"
+        printf "\nSTART_NODE_CMD=$START_NODE_CMD\n"
         eval $START_NODE_CMD
         sleep 5
         inject_account "$node_index"

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -219,7 +219,7 @@ function inject_account() {
 
 # deploy files
 #FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync.sh stop_local_blockchain.sh"
 
 printf "###############################################################################\n"
 printf "# Deploying parent blockchain #\n"

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -6,7 +6,7 @@ if [[ $# -lt 4 ]] || [[ $# -gt 10 ]]; then
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0  0  0 --keystore --keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0  0  0 --setup --keystore --no-keep-code\n"
-    printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
+    #printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
     printf "Note: <Parent Node Index End> is inclusive\n"
     printf "\n"
     exit

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -244,9 +244,9 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
             printf "\n* >> Deploying files for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-
             printf "FILES_FOR_NODE=${FILES_FOR_NODE}\n"
 
+            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh $NODE_TARGET_ADDR "sudo -S rm -rf ~/ain-blockchain; mkdir ~/ain-blockchain; chmod -R 777 ~/ain-blockchain"
             sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) scp -r $FILES_FOR_NODE ${NODE_TARGET_ADDR}:~/ain-blockchain/
         done
     fi

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -243,8 +243,8 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
-            printf "\n* >> Deploying files for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            printf "FILES_FOR_NODE=${FILES_FOR_NODE}\n"
+            printf "\n\n* >> Deploying files for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+            printf "FILES_FOR_NODE=${FILES_FOR_NODE}\n\n"
 
             echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh $NODE_TARGET_ADDR "sudo -S rm -rf ~/ain-blockchain; mkdir ~/ain-blockchain; chmod -R 777 ~/ain-blockchain"
             sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) scp -r $FILES_FOR_NODE ${NODE_TARGET_ADDR}:~/ain-blockchain/
@@ -269,7 +269,7 @@ if [[ $SETUP_OPTION = "--setup" ]]; then
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
-            printf "\n* >> Setting up parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+            printf "\n\n* >> Setting up parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
 
             echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh"
         done
@@ -293,7 +293,7 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
-            printf "\n* >> Installing node modules for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+            printf "\n\n* >> Installing node modules for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
 
             sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "cd ./ain-blockchain; yarn install --ignore-engines"
         done
@@ -301,10 +301,10 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
 fi
 
 if [[ $KILL_OPTION = "--skip-kill" ]]; then
-    printf "\nSkipping process kill...\n"
+    printf "\n\nSkipping process kill...\n"
 else
     # kill any processes still alive
-    printf "\nKilling tracker / blockchain node jobs...\n"
+    printf "\n\nKilling tracker / blockchain node jobs...\n"
 
 #    # Tracker server is killed with PARENT_NODE_INDEX_BEGIN = -1
 #    if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
@@ -333,7 +333,7 @@ if [[ $KILL_OPTION = "--kill-only" ]]; then
     exit
 fi
 
-printf "\nStarting blockchain servers...\n\n"
+printf "\n\nStarting blockchain servers...\n\n"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     GO_TO_PROJECT_ROOT_CMD="cd ./ain-blockchain"
 else
@@ -368,7 +368,7 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
         NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
         if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
-            printf "\n* >> Removing old data for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+            printf "\n\n* >> Removing old data for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
 
             CHAINS_DIR=/home/${SEASON}/ain_blockchain_data/chains
             SNAPSHOTS_DIR=/home/${SEASON}/ain_blockchain_data/snapshots
@@ -376,7 +376,7 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
             echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "sudo -S rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR"
         fi
 
-        printf "\n* >> Starting parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+        printf "\n\n* >> Starting parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
 
         if [[ $node_index -ge $JSON_RPC_NODE_INDEX_GE ]] && [[ $node_index -le $JSON_RPC_NODE_INDEX_LE ]]; then
             JSON_RPC_OPTION="--json-rpc"
@@ -405,9 +405,8 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
         printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
         printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
-        printf "\n"
         START_NODE_CMD="ssh ${NODE_TARGET_ADDR} '$START_NODE_CMD_BASE $SEASON $ONPREM_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION'"
-        printf "START_NODE_CMD=$START_NODE_CMD\n"
+        printf "\nSTART_NODE_CMD=$START_NODE_CMD\n"
         eval "echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ${START_NODE_CMD}"
         sleep 5
         inject_account "$node_index"

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -29,8 +29,6 @@ if [[ ! $2 =~ $number_re ]] ; then
     printf "Invalid <# of Shards> argument: $2\n"
     exit
 fi
-NUM_SHARDS=$2
-printf "NUM_SHARDS=$NUM_SHARDS\n"
 PARENT_NODE_INDEX_BEGIN=$3
 printf "PARENT_NODE_INDEX_BEGIN=$PARENT_NODE_INDEX_BEGIN\n"
 PARENT_NODE_INDEX_END=$4
@@ -327,7 +325,7 @@ else
             printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
             printf "\n* >> Killing node $node_index job (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "sudo -S killall node"
+            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "sudo -S pkill -f client/${SEASON}-ain-blockchain-index.js"
         done
     fi
 fi

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -221,7 +221,7 @@ function inject_account() {
 
 # deploy files
 #FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
 
 printf "###############################################################################\n"
 printf "# Deploying parent blockchain #\n"

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -242,11 +242,12 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
         for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
-            printf "\n"
-            printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
             printf "\n* >> Deploying files for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) scp -rv $FILES_FOR_NODE ${NODE_TARGET_ADDR}:~/ain-blockchain/
+
+            printf "FILES_FOR_NODE=${FILES_FOR_NODE}\n"
+
+            sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) scp -r $FILES_FOR_NODE ${NODE_TARGET_ADDR}:~/ain-blockchain/
         done
     fi
 fi
@@ -267,11 +268,10 @@ if [[ $SETUP_OPTION = "--setup" ]]; then
         for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
-            printf "\n"
-            printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
             printf "\n* >> Setting up parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh"
+
+            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh"
         done
     fi
 fi
@@ -292,11 +292,10 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
         for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
-            printf "\n"
-            printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
             printf "\n* >> Installing node modules for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "cd ./ain-blockchain; yarn install --ignore-engines"
+
+            sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "cd ./ain-blockchain; yarn install --ignore-engines"
         done
     fi
 fi
@@ -321,11 +320,10 @@ else
         for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
             NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
             NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
-            printf "\n"
-            printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
             printf "\n* >> Killing node $node_index job (${NODE_TARGET_ADDR}) *********************************************************\n\n"
-            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "sudo -S pkill -f client/${SEASON}-ain-blockchain-index.js"
+
+            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "sudo -S pkill -f client/${SEASON}-ain-blockchain-index.js"
         done
     fi
 fi
@@ -368,8 +366,6 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
     for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
         NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
         NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
-        printf "\n"
-        printf "NODE_TARGET_ADDR=${NODE_TARGET_ADDR}\n"
 
         if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
             printf "\n* >> Removing old data for parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
@@ -377,7 +373,7 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
             CHAINS_DIR=/home/${SEASON}/ain_blockchain_data/chains
             SNAPSHOTS_DIR=/home/${SEASON}/ain_blockchain_data/snapshots
             LOGS_DIR=/home/${SEASON}/ain_blockchain_data/logs
-            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh -v ${NODE_TARGET_ADDR} "sudo -S rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR"
+            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "sudo -S rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR"
         fi
 
         printf "\n* >> Starting parent node $node_index (${NODE_TARGET_ADDR}) *********************************************************\n\n"
@@ -410,7 +406,7 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
         printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
         printf "\n"
-        START_NODE_CMD="ssh -v ${NODE_TARGET_ADDR} '$START_NODE_CMD_BASE $SEASON $ONPREM_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION'"
+        START_NODE_CMD="ssh ${NODE_TARGET_ADDR} '$START_NODE_CMD_BASE $SEASON $ONPREM_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION'"
         printf "START_NODE_CMD=$START_NODE_CMD\n"
         eval "echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ${START_NODE_CMD}"
         sleep 5

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -172,7 +172,7 @@ elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
 fi
 
 FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_gcp.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync.sh stop_local_blockchain.sh"
 
 NUM_SHARD_NODES=3
 
@@ -326,7 +326,7 @@ function deploy_node() {
 
     # 5. Wait until node is synced
     printf "\n\n<<< Waiting until node $node_index is synced >>>\n\n"
-    WAIT_CMD="gcloud compute ssh $node_target_addr --command 'cd \$(find /home/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync_gcp.sh' --project $PROJECT_ID --zone $node_zone"
+    WAIT_CMD="gcloud compute ssh $node_target_addr --command 'cd \$(find /home/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync.sh' --project $PROJECT_ID --zone $node_zone"
     printf "WAIT_CMD=$WAIT_CMD\n\n"
     eval $WAIT_CMD
 }

--- a/deploy_blockchain_incremental_gcp.sh
+++ b/deploy_blockchain_incremental_gcp.sh
@@ -355,18 +355,8 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
 else
     GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d)"
 fi
-if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
-    # restart after removing chains, snapshots, and log files (but keep the keys)
-    CHAINS_DIR=/home/ain_blockchain_data/chains
-    SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
-    LOGS_DIR=/home/ain_blockchain_data/logs
-    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
-else
-    # restart with existing chains, snapshots, and log files
-    START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
-fi
+START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
 
 # Tracker server is deployed with PARENT_NODE_INDEX_BEGIN = -1
 if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -6,7 +6,7 @@ if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
     printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0  0  0 --keystore --keep-code\n"
     printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
     printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0  0  0 --setup --keystore --no-keep-code\n"
-    printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
+    #printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
     printf "Note: <Parent Node Index End> is inclusive\n"
     printf "\n"
     exit
@@ -171,7 +171,7 @@ elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
     IFS=$'\n' read -d '' -r -a MNEMONIC_LIST < ./testnet_mnemonics/$SEASON.txt
 fi
 
-FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
+#FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
 FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
 
 NUM_SHARD_NODES=3
@@ -190,40 +190,40 @@ NODE_ZONE_LIST=(
     "europe-west4-a" \
 )
 
-function deploy_tracker() {
-    printf "\n* >> Deploying files for tracker ********************************************************\n\n"
-
-    printf "TRACKER_TARGET_ADDR='$TRACKER_TARGET_ADDR'\n"
-    printf "TRACKER_ZONE='$TRACKER_ZONE'\n"
-
-    if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
-        # 1. Copy files for tracker
-        printf "\n\n[[[ Copying files for tracker ]]]\n\n"
-        gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo rm -rf ~/ain-blockchain; sudo mkdir ~/ain-blockchain; sudo chmod -R 777 ~/ain-blockchain" --project $PROJECT_ID --zone $TRACKER_ZONE
-        SCP_CMD="gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ain-blockchain --project $PROJECT_ID --zone $TRACKER_ZONE"
-        printf "SCP_CMD=$SCP_CMD\n\n"
-        eval $SCP_CMD
-    fi
-
-    # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
-    if [[ $SETUP_OPTION = "--setup" ]]; then
-        # 2. Set up tracker
-        printf "\n\n[[[ Setting up tracker ]]]\n\n"
-        SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
-        printf "SETUP_CMD=$SETUP_CMD\n\n"
-        eval $SETUP_CMD
-    fi
-
-    # 3. Start tracker
-    printf "\n\n[[[ Starting tracker ]]]\n\n"
-
-    printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
-
-    printf "\n"
-    START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
-    printf "START_TRACKER_CMD=$START_TRACKER_CMD\n\n"
-    eval $START_TRACKER_CMD
-}
+#function deploy_tracker() {
+#    printf "\n* >> Deploying files for tracker ********************************************************\n\n"
+#
+#    printf "TRACKER_TARGET_ADDR='$TRACKER_TARGET_ADDR'\n"
+#    printf "TRACKER_ZONE='$TRACKER_ZONE'\n"
+#
+#    if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+#        # 1. Copy files for tracker
+#        printf "\n\n[[[ Copying files for tracker ]]]\n\n"
+#        gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo rm -rf ~/ain-blockchain; sudo mkdir ~/ain-blockchain; sudo chmod -R 777 ~/ain-blockchain" --project $PROJECT_ID --zone $TRACKER_ZONE
+#        SCP_CMD="gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ain-blockchain --project $PROJECT_ID --zone $TRACKER_ZONE"
+#        printf "SCP_CMD=$SCP_CMD\n\n"
+#        eval $SCP_CMD
+#    fi
+#
+#    # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
+#    if [[ $SETUP_OPTION = "--setup" ]]; then
+#        # 2. Set up tracker
+#        printf "\n\n[[[ Setting up tracker ]]]\n\n"
+#        SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
+#        printf "SETUP_CMD=$SETUP_CMD\n\n"
+#        eval $SETUP_CMD
+#    fi
+#
+#    # 3. Start tracker
+#    printf "\n\n[[[ Starting tracker ]]]\n\n"
+#
+#    printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+#
+#    printf "\n"
+#    START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
+#    printf "START_TRACKER_CMD=$START_TRACKER_CMD\n\n"
+#    eval $START_TRACKER_CMD
+#}
 
 function deploy_node() {
     local node_index="$1"
@@ -360,18 +360,18 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     CHAINS_DIR=/home/ain_blockchain_data/chains
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
     LOGS_DIR=/home/ain_blockchain_data/logs
-    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    #START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
     START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_onprem.sh"
 else
     # restart with existing chains, snapshots, and log files
-    START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    #START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
     START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_onprem.sh"
 fi
 
-# Tracker server is deployed with PARENT_NODE_INDEX_BEGIN = -1
-if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
-    deploy_tracker
-fi
+## Tracker server is deployed with PARENT_NODE_INDEX_BEGIN = -1
+#if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
+#    deploy_tracker
+#fi
 begin_index=$PARENT_NODE_INDEX_BEGIN
 if [[ $begin_index -lt 0 ]]; then
   begin_index=0
@@ -380,24 +380,5 @@ if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -g
     for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
         deploy_node "$node_index"
         sleep 40
-    done
-fi
-
-if [[ $NUM_SHARDS -gt 0 ]]; then
-    for shard_index in $(seq $NUM_SHARDS); do
-        printf "###############################################################################\n"
-        printf "# Deploying shard $shard_index blockchain #\n"
-        printf "###############################################################################\n\n"
-
-        TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${shard_index}-tracker-taiwan"
-        NODE_TARGET_ADDR_LIST=( \
-            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-0-taiwan" \
-            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-1-oregon" \
-            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-2-singapore")
-
-        deploy_tracker "$NUM_SHARD_NODES"
-        for node_index in `seq 0 $(( ${NUM_SHARD_NODES} - 1 ))`; do
-            deploy_node "$node_index"
-        done
     done
 fi

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -215,38 +215,25 @@ function deploy_node() {
     # 1. Copy files for node (if necessary)
     if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
         printf "\n<<< Copying files for node $node_index ($node_target_addr) >>>\n\n"
-        printf "FILES_FOR_NODE=${FILES_FOR_NODE}\n\n"
 
         echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ssh $node_target_addr "sudo -S rm -rf ~/ain-blockchain; mkdir ~/ain-blockchain; chmod -R 777 ~/ain-blockchain"
         SCP_CMD="scp -r $FILES_FOR_NODE ${node_target_addr}:~/ain-blockchain"
-        printf "SCP_CMD=$SCP_CMD\n\n"
+        printf "\n\nSCP_CMD=$SCP_CMD\n\n"
         eval "sshpass -f <(printf '%s\n' ${node_login_pw}) ${SCP_CMD}"
     fi
 
     # 2. Set up node (if necessary)
     # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
     if [[ $SETUP_OPTION = "--setup" ]]; then
-        printf "\n<<< Setting up node $node_index ($node_target_addr) >>>\n\n"
+        printf "\n\n<<< Setting up node $node_index ($node_target_addr) >>>\n\n"
 
         SETUP_CMD="ssh $node_target_addr 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh'"
-        printf "SETUP_CMD=$SETUP_CMD\n\n"
+        printf "\nSETUP_CMD=$SETUP_CMD\n\n"
         eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${SETUP_CMD}"
     fi
 
-    # 3. Remove old data (if necessary)
-    if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
-        printf "\n<<< Removing old data from node $node_index ($node_target_addr) >>>\n\n"
-
-        # Remove chains, snapshots, and log files (but keep the keys)
-        CHAINS_DIR=/home/${SEASON}/ain_blockchain_data/chains
-        SNAPSHOTS_DIR=/home/${SEASON}/ain_blockchain_data/snapshots
-        LOGS_DIR=/home/${SEASON}/ain_blockchain_data/logs
-        RM_CMD="ssh $node_target_addr 'sudo -S rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR'"
-        eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${RM_CMD}"
-    fi
-
-    # 4. Start node
-    printf "\n<<< Starting node $node_index ($node_target_addr) >>>\n\n"
+    # 3. Start node
+    printf "\n\n<<< Starting node $node_index ($node_target_addr) >>>\n\n"
 
     if [[ $node_index -ge $JSON_RPC_NODE_INDEX_GE ]] && [[ $node_index -le $JSON_RPC_NODE_INDEX_LE ]]; then
         JSON_RPC_OPTION="--json-rpc"
@@ -277,14 +264,14 @@ function deploy_node() {
 
     printf "\n"
     START_NODE_CMD="ssh $node_target_addr '$START_NODE_CMD_BASE $SEASON $ONPREM_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION'"
-    printf "START_NODE_CMD=$START_NODE_CMD\n\n"
+    printf "\nSTART_NODE_CMD=$START_NODE_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${START_NODE_CMD}"
 
-    # 5. Inject node account
+    # 4. Inject node account
     sleep 5
     if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
         local node_url=${NODE_URL_LIST[${node_index}]}
-        printf "\n* >> Initializing account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "\n\n* >> Initializing account for node $node_index ($node_target_addr) ********************\n\n"
         printf "node_url='$node_url'\n"
 
         KEYSTORE_FILE_PATH="$KEYSTORE_DIR/keystore_node_$node_index.json"
@@ -296,7 +283,7 @@ function deploy_node() {
     elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
         local node_url=${NODE_URL_LIST[${node_index}]}
         local MNEMONIC=${MNEMONIC_LIST[${node_index}]}
-        printf "\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "\n\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
         printf "node_url='$node_url'\n"
 
         {
@@ -306,7 +293,7 @@ function deploy_node() {
         } | node inject_node_account.js $node_url $ACCOUNT_INJECTION_OPTION
     else
         local node_url=${NODE_URL_LIST[${node_index}]}
-        printf "\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "\n\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
         printf "node_url='$node_url'\n"
 
         local GENESIS_ACCOUNTS_PATH="blockchain-configs/base/genesis_accounts.json"
@@ -317,11 +304,11 @@ function deploy_node() {
         echo $PRIVATE_KEY | node inject_node_account.js $node_url $ACCOUNT_INJECTION_OPTION
     fi
 
-    # 6. Wait until node is synced
-    printf "\n<<< Waiting until node $node_index ($node_target_addr) is synced >>>\n\n"
+    # 5. Wait until node is synced
+    printf "\n\n<<< Waiting until node $node_index ($node_target_addr) is synced >>>\n\n"
 
     WAIT_CMD="ssh $node_target_addr 'cd \$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync_gcp.sh'"
-    printf "WAIT_CMD=$WAIT_CMD\n\n"
+    printf "\nWAIT_CMD=$WAIT_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${WAIT_CMD}"
 }
 

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -210,11 +210,11 @@ function deploy_node() {
     local node_target_addr="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
     local node_login_pw="${NODE_PW_LIST[${node_index}]}"
 
-    printf "\n* >> Deploying files for node $node_index ($node_target_addr) *********************************************************\n\n"
+    printf "\n\n* >> Deploying files for node $node_index ($node_target_addr) *********************************************************\n\n"
 
     # 1. Copy files for node (if necessary)
     if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
-        printf "\n<<< Copying files for node $node_index ($node_target_addr) >>>\n\n"
+        printf "\n\n<<< Copying files for node $node_index ($node_target_addr) >>>\n\n"
 
         echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ssh $node_target_addr "sudo -S rm -rf ~/ain-blockchain; mkdir ~/ain-blockchain; chmod -R 777 ~/ain-blockchain"
         SCP_CMD="scp -r $FILES_FOR_NODE ${node_target_addr}:~/ain-blockchain"
@@ -228,7 +228,7 @@ function deploy_node() {
         printf "\n\n<<< Setting up node $node_index ($node_target_addr) >>>\n\n"
 
         SETUP_CMD="ssh $node_target_addr 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh'"
-        printf "\nSETUP_CMD=$SETUP_CMD\n\n"
+        printf "\n\nSETUP_CMD=$SETUP_CMD\n\n"
         eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${SETUP_CMD}"
     fi
 
@@ -262,9 +262,8 @@ function deploy_node() {
     printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
     printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
 
-    printf "\n"
     START_NODE_CMD="ssh $node_target_addr '$START_NODE_CMD_BASE $SEASON $ONPREM_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION'"
-    printf "\nSTART_NODE_CMD=$START_NODE_CMD\n\n"
+    printf "\n\nSTART_NODE_CMD=$START_NODE_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${START_NODE_CMD}"
 
     # 4. Inject node account
@@ -308,7 +307,7 @@ function deploy_node() {
     printf "\n\n<<< Waiting until node $node_index ($node_target_addr) is synced >>>\n\n"
 
     WAIT_CMD="ssh $node_target_addr 'cd \$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync.sh'"
-    printf "\nWAIT_CMD=$WAIT_CMD\n\n"
+    printf "\n\nWAIT_CMD=$WAIT_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${WAIT_CMD}"
 }
 

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -1,0 +1,403 @@
+#!/bin/bash
+
+if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
+    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0 -1  4 --keystore --no-keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0  0  0 --keystore --keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0  0  0 --setup --keystore --no-keep-code\n"
+    printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
+    printf "Note: <Parent Node Index End> is inclusive\n"
+    printf "\n"
+    exit
+fi
+printf "\n[[[[[ deploy_blockchain_incremental_gcp.sh ]]]]]\n\n"
+
+if [[ "$1" = 'dev' ]] || [[ "$1" = 'staging' ]] || [[ "$1" = 'sandbox' ]] || [[ "$1" = 'exp' ]] || [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'mainnet' ]]; then
+    SEASON="$1"
+    if [[ "$1" = 'mainnet' ]]; then
+        PROJECT_ID="mainnet-prod-ground"
+    elif [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]]; then
+        PROJECT_ID="testnet-prod-ground"
+    else
+        PROJECT_ID="testnet-$1-ground"
+    fi
+else
+    printf "Invalid <Project/Season> argument: $1\n"
+    exit
+fi
+printf "SEASON=$SEASON\n"
+printf "PROJECT_ID=$PROJECT_ID\n"
+
+GCP_USER="runner"
+printf "GCP_USER=$GCP_USER\n"
+
+number_re='^[0-9]+$'
+if [[ ! $2 =~ $number_re ]] ; then
+    printf "Invalid <# of Shards> argument: $2\n"
+    exit
+fi
+NUM_SHARDS=$2
+printf "NUM_SHARDS=$NUM_SHARDS\n"
+PARENT_NODE_INDEX_BEGIN=$3
+printf "PARENT_NODE_INDEX_BEGIN=$PARENT_NODE_INDEX_BEGIN\n"
+PARENT_NODE_INDEX_END=$4
+printf "PARENT_NODE_INDEX_END=$PARENT_NODE_INDEX_END\n"
+printf "\n"
+
+function parse_options() {
+    local option="$1"
+    if [[ $option = '--setup' ]]; then
+        SETUP_OPTION="$option"
+    elif [[ $option = '--private-key' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--keystore' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--mnemonic' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--no-keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
+    elif [[ $option = '--no-keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
+    elif [[ $option = '--full-sync' ]]; then
+        SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--fast-sync' ]]; then
+        SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    else
+        printf "Invalid option: $option\n"
+        exit
+    fi
+}
+
+# Parse options.
+SETUP_OPTION=""
+ACCOUNT_INJECTION_OPTION="--private-key"
+KEEP_CODE_OPTION="--keep-code"
+KEEP_DATA_OPTION="--keep-data"
+SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--no-chown-data"
+
+ARG_INDEX=5
+while [ $ARG_INDEX -le $# ]; do
+  parse_options "${!ARG_INDEX}"
+  ((ARG_INDEX++))
+done
+
+if [[ $SETUP_OPTION = "--setup" ]] && [[ ! $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+    printf "You cannot use --setup without --no-keep-code\n"
+    exit
+fi
+
+printf "SETUP_OPTION=$SETUP_OPTION\n"
+printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
+printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
+
+# Json-RPC-enabled blockchain nodes
+JSON_RPC_NODE_INDEX_GE=0
+JSON_RPC_NODE_INDEX_LE=4
+# Rest-Function-enabled blockchain nodes
+REST_FUNC_NODE_INDEX_GE=0
+REST_FUNC_NODE_INDEX_LE=2
+# Event-Handler-enabled blockchain nodes
+EVENT_HANDLER_NODE_INDEX_GE=0
+EVENT_HANDLER_NODE_INDEX_LE=4
+
+printf "\n"
+printf "JSON_RPC_NODE_INDEX_GE=$JSON_RPC_NODE_INDEX_GE\n"
+printf "JSON_RPC_NODE_INDEX_LE=$JSON_RPC_NODE_INDEX_LE\n"
+printf "REST_FUNC_NODE_INDEX_GE=$REST_FUNC_NODE_INDEX_GE\n"
+printf "REST_FUNC_NODE_INDEX_LE=$REST_FUNC_NODE_INDEX_LE\n"
+printf "EVENT_HANDLER_NODE_INDEX_GE=$EVENT_HANDLER_NODE_INDEX_GE\n"
+printf "EVENT_HANDLER_NODE_INDEX_LE=$EVENT_HANDLER_NODE_INDEX_LE\n"
+
+if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
+    printf "Must provide an ACCOUNT_INJECTION_OPTION\n"
+    exit
+fi
+
+# Get confirmation.
+if [[ "$SEASON" = "mainnet" ]]; then
+    printf "\n"
+    printf "Do you want to proceed for $SEASON? Enter [mainnet]: "
+    read CONFIRM
+    printf "\n"
+    if [[ ! $CONFIRM = "mainnet" ]]
+    then
+        [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+    fi
+elif [[ "$SEASON" = "spring" ]] || [[ "$SEASON" = "summer" ]]; then
+    printf "\n"
+    printf "Do you want to proceed for $SEASON? Enter [testnet]: "
+    read CONFIRM
+    printf "\n"
+    if [[ ! $CONFIRM = "testnet" ]]; then
+        [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+    fi
+else
+    printf "\n"
+    read -p "Do you want to proceed for $SEASON? [y/N]: " -n 1 -r
+    printf "\n\n"
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+    fi
+fi
+
+# Read node urls
+IFS=$'\n' read -d '' -r -a NODE_URL_LIST < ./ip_addresses/$SEASON.txt
+if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
+    # Get keystore password
+    printf "Enter keystore password: "
+    read -s KEYSTORE_PW
+    printf "\n\n"
+    if [[ $SEASON = "mainnet" ]]; then
+        KEYSTORE_DIR="mainnet_prod_keys"
+    elif [[ $SEASON = "spring" ]] || [[ $SEASON = "summer" ]]; then
+        KEYSTORE_DIR="testnet_prod_keys"
+    else
+        KEYSTORE_DIR="testnet_dev_staging_keys"
+    fi
+elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
+    IFS=$'\n' read -d '' -r -a MNEMONIC_LIST < ./testnet_mnemonics/$SEASON.txt
+fi
+
+FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_gcp.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+
+NUM_SHARD_NODES=3
+
+TRACKER_ZONE="asia-east1-b"
+NODE_ZONE_LIST=(
+    "asia-east1-b" \
+    "us-west1-b" \
+    "asia-southeast1-b" \
+    "us-central1-a" \
+    "europe-west4-a" \
+    "asia-east1-b" \
+    "us-west1-b" \
+    "asia-southeast1-b" \
+    "us-central1-a" \
+    "europe-west4-a" \
+)
+
+function deploy_tracker() {
+    printf "\n* >> Deploying files for tracker ********************************************************\n\n"
+
+    printf "TRACKER_TARGET_ADDR='$TRACKER_TARGET_ADDR'\n"
+    printf "TRACKER_ZONE='$TRACKER_ZONE'\n"
+
+    if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+        # 1. Copy files for tracker
+        printf "\n\n[[[ Copying files for tracker ]]]\n\n"
+        gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo rm -rf ~/ain-blockchain; sudo mkdir ~/ain-blockchain; sudo chmod -R 777 ~/ain-blockchain" --project $PROJECT_ID --zone $TRACKER_ZONE
+        SCP_CMD="gcloud compute scp --recurse $FILES_FOR_TRACKER ${TRACKER_TARGET_ADDR}:~/ain-blockchain --project $PROJECT_ID --zone $TRACKER_ZONE"
+        printf "SCP_CMD=$SCP_CMD\n\n"
+        eval $SCP_CMD
+    fi
+
+    # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
+    if [[ $SETUP_OPTION = "--setup" ]]; then
+        # 2. Set up tracker
+        printf "\n\n[[[ Setting up tracker ]]]\n\n"
+        SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_gcp.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
+        printf "SETUP_CMD=$SETUP_CMD\n\n"
+        eval $SETUP_CMD
+    fi
+
+    # 3. Start tracker
+    printf "\n\n[[[ Starting tracker ]]]\n\n"
+
+    printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+
+    printf "\n"
+    START_TRACKER_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command '$START_TRACKER_CMD_BASE $GCP_USER $KEEP_CODE_OPTION' --project $PROJECT_ID --zone $TRACKER_ZONE"
+    printf "START_TRACKER_CMD=$START_TRACKER_CMD\n\n"
+    eval $START_TRACKER_CMD
+}
+
+function deploy_node() {
+    local node_index="$1"
+    local node_target_addr=${NODE_TARGET_ADDR_LIST[${node_index}]}
+    local node_zone=${NODE_ZONE_LIST[${node_index}]}
+
+    printf "\n* >> Deploying files for node $node_index ($node_target_addr) *********************************************************\n\n"
+
+    printf "node_target_addr='$node_target_addr'\n"
+    printf "node_zone='$node_zone'\n"
+
+    if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+        # 1. Copy files for node
+        printf "\n\n<<< Copying files for node $node_index >>>\n\n"
+        gcloud compute ssh $node_target_addr --command "sudo rm -rf ~/ain-blockchain; sudo mkdir ~/ain-blockchain; sudo chmod -R 777 ~/ain-blockchain" --project $PROJECT_ID --zone $node_zone
+        SCP_CMD="gcloud compute scp --recurse $FILES_FOR_NODE ${node_target_addr}:~/ain-blockchain --project $PROJECT_ID --zone $node_zone"
+        printf "SCP_CMD=$SCP_CMD\n\n"
+        eval $SCP_CMD
+    fi
+
+    # ssh into each instance, set up the ubuntu VM instance (ONLY NEEDED FOR THE FIRST TIME)
+    if [[ $SETUP_OPTION = "--setup" ]]; then
+        # 2. Set up node
+        printf "\n\n<<< Setting up node $node_index >>>\n\n"
+        SETUP_CMD="gcloud compute ssh $node_target_addr --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_gcp.sh' --project $PROJECT_ID --zone $node_zone"
+        printf "SETUP_CMD=$SETUP_CMD\n\n"
+        eval $SETUP_CMD
+    fi
+
+    # 3. Start node
+    printf "\n\n<<< Starting node $node_index >>>\n\n"
+
+    if [[ $node_index -ge $JSON_RPC_NODE_INDEX_GE ]] && [[ $node_index -le $JSON_RPC_NODE_INDEX_LE ]]; then
+        JSON_RPC_OPTION="--json-rpc"
+    else
+        JSON_RPC_OPTION=""
+    fi
+    UPDATE_FRONT_DB_OPTION="--update-front-db"
+    if [[ $node_index -ge $REST_FUNC_NODE_INDEX_GE ]] && [[ $node_index -le $REST_FUNC_NODE_INDEX_LE ]]; then
+        REST_FUNC_OPTION="--rest-func"
+    else
+        REST_FUNC_OPTION=""
+    fi
+    if [[ $node_index -ge $EVENT_HANDLER_NODE_INDEX_GE ]] && [[ $node_index -le $EVENT_HANDLER_NODE_INDEX_LE ]]; then
+        EVENT_HANDLER_OPTION="--event-handler"
+    else
+        EVENT_HANDLER_OPTION=""
+    fi
+
+    printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
+    printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+    printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+    printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+    printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
+    printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
+    printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
+    printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
+    printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
+
+    printf "\n"
+    START_NODE_CMD="gcloud compute ssh $node_target_addr --command '$START_NODE_CMD_BASE $SEASON $GCP_USER 0 $node_index $KEEP_CODE_OPTION $KEEP_DATA_OPTION $SYNC_MODE_OPTION $CHOWN_DATA_OPTION $ACCOUNT_INJECTION_OPTION $JSON_RPC_OPTION $UPDATE_FRONT_DB_OPTION $REST_FUNC_OPTION $EVENT_HANDLER_OPTION' --project $PROJECT_ID --zone $node_zone"
+    printf "START_NODE_CMD=$START_NODE_CMD\n\n"
+    eval $START_NODE_CMD
+
+    # 4. Inject node account
+    sleep 5
+    if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
+        local node_url=${NODE_URL_LIST[${node_index}]}
+        printf "\n* >> Initializing account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "node_url='$node_url'\n"
+
+        KEYSTORE_FILE_PATH="$KEYSTORE_DIR/keystore_node_$node_index.json"
+        {
+            echo $KEYSTORE_FILE_PATH
+            sleep 1
+            echo $KEYSTORE_PW
+        } | node inject_node_account.js $node_url $ACCOUNT_INJECTION_OPTION
+    elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
+        local node_url=${NODE_URL_LIST[${node_index}]}
+        local MNEMONIC=${MNEMONIC_LIST[${node_index}]}
+        printf "\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "node_url='$node_url'\n"
+
+        {
+            echo $MNEMONIC
+            sleep 1
+            echo 0
+        } | node inject_node_account.js $node_url $ACCOUNT_INJECTION_OPTION
+    else
+        local node_url=${NODE_URL_LIST[${node_index}]}
+        printf "\n* >> Injecting an account for node $node_index ($node_target_addr) ********************\n\n"
+        printf "node_url='$node_url'\n"
+        local GENESIS_ACCOUNTS_PATH="blockchain-configs/base/genesis_accounts.json"
+        if [[ "$SEASON" = "spring" ]] || [[ "$SEASON" = "summer" ]]; then
+            GENESIS_ACCOUNTS_PATH="blockchain-configs/testnet-prod/genesis_accounts.json"
+        fi
+        PRIVATE_KEY=$(cat $GENESIS_ACCOUNTS_PATH | jq -r '.others['$node_index'].private_key')
+        echo $PRIVATE_KEY | node inject_node_account.js $node_url $ACCOUNT_INJECTION_OPTION
+    fi
+
+    # 5. Wait until node is synced
+    printf "\n\n<<< Waiting until node $node_index is synced >>>\n\n"
+    WAIT_CMD="gcloud compute ssh $node_target_addr --command 'cd \$(find /home/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync_gcp.sh' --project $PROJECT_ID --zone $node_zone"
+    printf "WAIT_CMD=$WAIT_CMD\n\n"
+    eval $WAIT_CMD
+}
+
+printf "###############################################################################\n"
+printf "# Deploying parent blockchain #\n"
+printf "###############################################################################\n\n"
+
+TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-tracker-taiwan"
+NODE_TARGET_ADDR_LIST=(
+    "${GCP_USER}@${SEASON}-node-0-taiwan" \
+    "${GCP_USER}@${SEASON}-node-1-oregon" \
+    "${GCP_USER}@${SEASON}-node-2-singapore" \
+    "${GCP_USER}@${SEASON}-node-3-iowa" \
+    "${GCP_USER}@${SEASON}-node-4-netherlands" \
+    "${GCP_USER}@${SEASON}-node-5-taiwan" \
+    "${GCP_USER}@${SEASON}-node-6-oregon" \
+    "${GCP_USER}@${SEASON}-node-7-singapore" \
+    "${GCP_USER}@${SEASON}-node-8-iowa" \
+    "${GCP_USER}@${SEASON}-node-9-netherlands" \
+)
+
+printf "\nStarting blockchain servers...\n\n"
+if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+    GO_TO_PROJECT_ROOT_CMD="cd ./ain-blockchain"
+else
+    GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/ain-blockchain* -maxdepth 0 -type d)"
+fi
+if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
+    # restart after removing chains, snapshots, and log files (but keep the keys)
+    CHAINS_DIR=/home/ain_blockchain_data/chains
+    SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
+    LOGS_DIR=/home/ain_blockchain_data/logs
+    START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
+else
+    # restart with existing chains, snapshots, and log files
+    START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
+    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
+fi
+
+# Tracker server is deployed with PARENT_NODE_INDEX_BEGIN = -1
+if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
+    deploy_tracker
+fi
+begin_index=$PARENT_NODE_INDEX_BEGIN
+if [[ $begin_index -lt 0 ]]; then
+  begin_index=0
+fi
+if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -ge 0 ]]; then
+    for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
+        deploy_node "$node_index"
+        sleep 40
+    done
+fi
+
+if [[ $NUM_SHARDS -gt 0 ]]; then
+    for shard_index in $(seq $NUM_SHARDS); do
+        printf "###############################################################################\n"
+        printf "# Deploying shard $shard_index blockchain #\n"
+        printf "###############################################################################\n\n"
+
+        TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${shard_index}-tracker-taiwan"
+        NODE_TARGET_ADDR_LIST=( \
+            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-0-taiwan" \
+            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-1-oregon" \
+            "${GCP_USER}@${SEASON}-shard-${shard_index}-node-2-singapore")
+
+        deploy_tracker "$NUM_SHARD_NODES"
+        for node_index in `seq 0 $(( ${NUM_SHARD_NODES} - 1 ))`; do
+            deploy_node "$node_index"
+        done
+    done
+fi

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 11 ]]; then
-    printf "Usage: bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0 -1  4 --keystore --no-keep-code\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0  0  0 --keystore --keep-code\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
-    printf "Example: bash deploy_blockchain_incremental_gcp.sh dev 0  0  0 --setup --keystore --no-keep-code\n"
+    printf "Usage: bash deploy_blockchain_incremental_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]\n"
+    printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0 -1  4 --keystore --no-keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0  0  0 --keystore --keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
+    printf "Example: bash deploy_blockchain_incremental_onprem.sh dev 0  0  0 --setup --keystore --no-keep-code\n"
     printf "Note: <Parent Node Index Begin> = -1 is for tracker\n"
     printf "Note: <Parent Node Index End> is inclusive\n"
     printf "\n"
     exit
 fi
-printf "\n[[[[[ deploy_blockchain_incremental_gcp.sh ]]]]]\n\n"
+printf "\n[[[[[ deploy_blockchain_incremental_onprem.sh ]]]]]\n\n"
 
 if [[ "$1" = 'dev' ]] || [[ "$1" = 'staging' ]] || [[ "$1" = 'sandbox' ]] || [[ "$1" = 'exp' ]] || [[ "$1" = 'spring' ]] || [[ "$1" = 'summer' ]] || [[ "$1" = 'mainnet' ]]; then
     SEASON="$1"
@@ -171,8 +171,8 @@ elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
     IFS=$'\n' read -d '' -r -a MNEMONIC_LIST < ./testnet_mnemonics/$SEASON.txt
 fi
 
-FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_gcp.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
 
 NUM_SHARD_NODES=3
 
@@ -209,7 +209,7 @@ function deploy_tracker() {
     if [[ $SETUP_OPTION = "--setup" ]]; then
         # 2. Set up tracker
         printf "\n\n[[[ Setting up tracker ]]]\n\n"
-        SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_gcp.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
+        SETUP_CMD="gcloud compute ssh $TRACKER_TARGET_ADDR --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh' --project $PROJECT_ID --zone $TRACKER_ZONE"
         printf "SETUP_CMD=$SETUP_CMD\n\n"
         eval $SETUP_CMD
     fi
@@ -248,7 +248,7 @@ function deploy_node() {
     if [[ $SETUP_OPTION = "--setup" ]]; then
         # 2. Set up node
         printf "\n\n<<< Setting up node $node_index >>>\n\n"
-        SETUP_CMD="gcloud compute ssh $node_target_addr --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_gcp.sh' --project $PROJECT_ID --zone $node_zone"
+        SETUP_CMD="gcloud compute ssh $node_target_addr --command 'cd ./ain-blockchain; . setup_blockchain_ubuntu_onprem.sh' --project $PROJECT_ID --zone $node_zone"
         printf "SETUP_CMD=$SETUP_CMD\n\n"
         eval $SETUP_CMD
     fi
@@ -361,11 +361,11 @@ if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     SNAPSHOTS_DIR=/home/ain_blockchain_data/snapshots
     LOGS_DIR=/home/ain_blockchain_data/logs
     START_TRACKER_CMD_BASE="sudo rm -rf /home/ain_blockchain_data/ && $GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
+    START_NODE_CMD_BASE="sudo rm -rf $CHAINS_DIR $SNAPSHOTS_DIR $LOGS_DIR && $GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_onprem.sh"
 else
     # restart with existing chains, snapshots, and log files
     START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_incremental_gcp.sh"
-    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_gcp.sh"
+    START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_incremental_onprem.sh"
 fi
 
 # Tracker server is deployed with PARENT_NODE_INDEX_BEGIN = -1

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -168,7 +168,7 @@ if [[ ! $KILL_OPTION = '--kill-only' ]]; then
 fi
 
 #FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync_gcp.sh stop_local_blockchain.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync.sh stop_local_blockchain.sh"
 
 #function deploy_tracker() {
 #    printf "\n* >> Deploying files for tracker ********************************************************\n\n"
@@ -307,7 +307,7 @@ function deploy_node() {
     # 5. Wait until node is synced
     printf "\n\n<<< Waiting until node $node_index ($node_target_addr) is synced >>>\n\n"
 
-    WAIT_CMD="ssh $node_target_addr 'cd \$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync_gcp.sh'"
+    WAIT_CMD="ssh $node_target_addr 'cd \$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d); . wait_until_node_sync.sh'"
     printf "\nWAIT_CMD=$WAIT_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${WAIT_CMD}"
 }

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -314,7 +314,7 @@ NODE_98_ZONE="us-central1-a"
 NODE_99_ZONE="europe-west4-a"
 
 # deploy files
-FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync_gcp.sh"
+FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_gcp.sh start_node_genesis_gcp.sh start_node_incremental_gcp.sh wait_until_node_sync.sh"
 
 # Work in progress spinner
 spin="-\|/"

--- a/setup_blockchain_ubuntu_onprem.sh
+++ b/setup_blockchain_ubuntu_onprem.sh
@@ -66,3 +66,7 @@ sudo apt install -y jq
 
 printf 'jq --version\n'
 jq --version
+
+printf '\n[[ Installing killall.. ]]\n'
+sudo apt update
+sudo apt install -y psmisc

--- a/start_node_genesis_gcp.sh
+++ b/start_node_genesis_gcp.sh
@@ -163,9 +163,6 @@ else
     export ENABLE_EVENT_HANDLER=false
 fi
 
-printf '\n'
-printf 'Killing old jobs..\n'
-sudo killall node
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new working directory..\n'

--- a/start_node_genesis_onprem.sh
+++ b/start_node_genesis_onprem.sh
@@ -172,9 +172,6 @@ else
     export ENABLE_EVENT_HANDLER=false
 fi
 
-printf '\n'
-printf 'Killing old jobs..\n'
-sudo killall "client/${SEASON}-ain-blockchain-index.js"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new working directory..\n'

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 13 ]]; then
-    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
-    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
+    printf "Usage: bash start_node_incremental_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
+    printf "Example: bash start_node_incremental_onprem.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "\n"
     exit
 fi
-printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
+printf "\n[[[[[ start_node_incremental_onprem.sh ]]]]]\n\n"
 
 function parse_options() {
     local option="$1"
@@ -383,6 +383,6 @@ printf "\nSTART_CMD=$START_CMD\n"
 printf "START_CMD=$START_CMD\n" >> start_commands.txt
 eval $START_CMD
 
-# NOTE(platfowner): deploy_blockchain_incremental_gcp.sh waits until the new server gets healthy.
+# NOTE(platfowner): deploy_blockchain_incremental_onprem.sh waits until the new server gets healthy.
 
 printf "\n* << Node server [$SEASON $SHARD_INDEX $NODE_INDEX] successfully deployed! ***************************************\n\n"

--- a/start_node_incremental_onprem.sh
+++ b/start_node_incremental_onprem.sh
@@ -310,18 +310,17 @@ printf "NEW_DIR_PATH=$NEW_DIR_PATH\n"
 printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
-    printf 'Setting up new working directory..\n'
-    # NOTE(platfowner): Add $SEASON to the node job name to be selectively killed in restarts.
-    CODE_CMD="sudo mkdir -p /home/${SEASON}; sudo chmod -R 777 /home/${SEASON}; sudo chown -R $ONPREM_USER:$ONPREM_USER /home/${SEASON}; cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $ONPREM_USER:$ONPREM_USER $NEW_DIR_PATH; cd $NEW_DIR_PATH; mv client/index.js client/${SEASON}-ain-blockchain-index.js"
-    printf "\nCODE_CMD=$CODE_CMD\n"
-    eval $CODE_CMD
-
-    printf '\n'
     printf 'Installing node modules..\n'
-    cd $NEW_DIR_PATH
     INSTALL_CMD="yarn install --ignore-engines"
     printf "\nINSTALL_CMD=$INSTALL_CMD\n"
     eval $INSTALL_CMD
+
+    printf '\n'
+    printf 'Setting up new working directory..\n'
+    # NOTE(platfowner): Add $SEASON to the node job name to be selectively killed in restarts.
+    CODE_CMD="sudo mkdir -p /home/${SEASON}; sudo chmod -R 777 /home/${SEASON}; sudo chown -R $ONPREM_USER:$ONPREM_USER /home/${SEASON}; cd ~; sudo mv ain-blockchain $NEW_DIR_PATH; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $ONPREM_USER:$ONPREM_USER $NEW_DIR_PATH; cd $NEW_DIR_PATH; mv client/index.js client/${SEASON}-ain-blockchain-index.js"
+    printf "\nCODE_CMD=$CODE_CMD\n"
+    eval $CODE_CMD
 else
     printf '\n'
     printf 'Reusing existing working directory..\n'
@@ -381,6 +380,12 @@ export STAKE=100000
 printf "STAKE=$STAKE\n"
 export LOG_BANDAGE_INFO=true
 printf "LOG_BANDAGE_INFO=$LOG_BANDAGE_INFO\n"
+# on-premise nodes run with "comcom" hosting env
+export HOSTING_ENV="comcom"
+printf "HOSTING_ENV=$HOSTING_ENV\n"
+# on-premise nodes run with a blockchain data directory prefixed by ${SEASON}_
+export BLOCKCHAIN_DATA_DIR="/home/${SEASON}/ain_blockchain_data"
+printf "BLOCKCHAIN_DATA_DIR=$BLOCKCHAIN_DATA_DIR\n"
 
 if [[ "$SEASON" = "sandbox" ]]; then
     MAX_OLD_SPACE_SIZE_MB=11000

--- a/start_node_incremental_onprem.sh
+++ b/start_node_incremental_onprem.sh
@@ -6,6 +6,15 @@ if [[ $# -lt 4 ]] || [[ $# -gt 13 ]]; then
     printf "\n"
     exit
 fi
+
+# needed for on-premise nvidia machines
+# Get node login password
+printf "Enter node login password: "
+read -s NODE_LOGIN_PW
+printf "\n\n"
+# do sudo once with a dummy command
+echo $NODE_LOGIN_PW | sudo -S ls -la
+
 printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
 
 function parse_options() {
@@ -48,7 +57,7 @@ function parse_options() {
 
 # Parse options.
 SEASON="$1"
-GCP_USER="$2"
+ONPREM_USER="$2"
 
 number_re='^[0-9]+$'
 if ! [[ $3 =~ $number_re ]] ; then
@@ -84,7 +93,7 @@ while [ $ARG_INDEX -le $# ]; do
 done
 
 printf "SEASON=$SEASON\n"
-printf "GCP_USER=$GCP_USER\n"
+printf "ONPREM_USER=$ONPREM_USER\n"
 printf "SHARD_INDEX=$SHARD_INDEX\n"
 printf "NODE_INDEX=$NODE_INDEX\n"
 printf "\n"
@@ -287,14 +296,14 @@ fi
 # 2. Get currently used directory & new directory
 printf "\n#### [Step 2] Get currently used directory & new directory ####\n\n"
 
-OLD_DIR_PATH=$(find /home/ain-blockchain* -maxdepth 0 -type d)
+OLD_DIR_PATH=$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d)
 printf "OLD_DIR_PATH=$OLD_DIR_PATH\n"
 
 date=$(date '+%Y-%m-%dT%H-%M')
 printf "date=$date\n"
 NEW_DIR_NAME="ain-blockchain-$date"
 printf "NEW_DIR_NAME=$NEW_DIR_NAME\n"
-NEW_DIR_PATH="/home/$NEW_DIR_NAME"
+NEW_DIR_PATH="/home/${SEASON}/$NEW_DIR_NAME"
 printf "NEW_DIR_PATH=$NEW_DIR_PATH\n"
 
 # 3. Set up working directory & install modules
@@ -302,7 +311,8 @@ printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
 if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     printf '\n'
     printf 'Setting up new working directory..\n'
-    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $NEW_DIR_PATH"
+    # NOTE(platfowner): Add $SEASON to the node job name to be selectively killed in restarts.
+    CODE_CMD="sudo mkdir -p /home/${SEASON}; sudo chmod -R 777 /home/${SEASON}; sudo chown -R $ONPREM_USER:$ONPREM_USER /home/${SEASON}; cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $ONPREM_USER:$ONPREM_USER $NEW_DIR_PATH; cd $NEW_DIR_PATH; mv client/index.js client/${SEASON}-ain-blockchain-index.js"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 
@@ -315,7 +325,7 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
 else
     printf '\n'
     printf 'Reusing existing working directory..\n'
-    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $ONPREM_USER:$ONPREM_USER $OLD_DIR_PATH"
     printf "\nCODE_CMD=$CODE_CMD\n"
     eval $CODE_CMD
 fi
@@ -323,7 +333,7 @@ fi
 # 4. Kill old node server
 printf "\n#### [Step 4] Kill old node server ####\n\n"
 
-KILL_CMD="sudo killall node"
+KILL_CMD="sudo pkill -f client/${SEASON}-ain-blockchain-index.js"
 printf "KILL_CMD=$KILL_CMD\n\n"
 eval $KILL_CMD
 sleep 10
@@ -333,19 +343,19 @@ printf "\n#### [Step 5] Set up data directory ####\n\n"
 if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
     printf '\n'
     printf 'Setting up new data directory..\n'
-    sudo rm -rf /home/ain_blockchain_data/chains
-    sudo rm -rf /home/ain_blockchain_data/snapshots
-    sudo rm -rf /home/ain_blockchain_data/logs
-    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    sudo rm -rf /home/${SEASON}/ain_blockchain_data/chains
+    sudo rm -rf /home/${SEASON}/ain_blockchain_data/snapshots
+    sudo rm -rf /home/${SEASON}/ain_blockchain_data/logs
+    DATA_CMD="sudo mkdir -p /home/${SEASON}/ain_blockchain_data; sudo chmod -R 777 /home/${SEASON}/ain_blockchain_data; sudo chown -R $ONPREM_USER:$ONPREM_USER /home/${SEASON}/ain_blockchain_data"
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
 else
     printf '\n'
     printf 'Reusing existing data directory..\n'
     if [[ $CHOWN_DATA_OPTION = "--no-chown-data" ]]; then
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/${SEASON}/ain_blockchain_data; sudo chmod 777 /home/${SEASON}/ain_blockchain_data; sudo chown $ONPREM_USER:$ONPREM_USER /home/${SEASON}/ain_blockchain_data"
     else
-        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+        DATA_CMD="sudo mkdir -p /home/${SEASON}/ain_blockchain_data; sudo chmod -R 777 /home/${SEASON}/ain_blockchain_data; sudo chown -R $ONPREM_USER:$ONPREM_USER /home/${SEASON}/ain_blockchain_data"
     fi
     printf "\nDATA_CMD=$DATA_CMD\n"
     eval $DATA_CMD
@@ -378,7 +388,7 @@ else
     MAX_OLD_SPACE_SIZE_MB=55000
 fi
 
-START_CMD="nohup node --async-stack-traces --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB client/index.js >/dev/null 2>error_logs.txt &"
+START_CMD="nohup node --async-stack-traces --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB client/${SEASON}-ain-blockchain-index.js >/dev/null 2>error_logs.txt &"
 printf "\nSTART_CMD=$START_CMD\n"
 printf "START_CMD=$START_CMD\n" >> start_commands.txt
 eval $START_CMD

--- a/start_node_incremental_onprem.sh
+++ b/start_node_incremental_onprem.sh
@@ -1,0 +1,388 @@
+#!/bin/bash
+
+if [[ $# -lt 4 ]] || [[ $# -gt 13 ]]; then
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
+    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
+    printf "\n"
+    exit
+fi
+printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
+
+function parse_options() {
+    local option="$1"
+    if [[ $option = '--private-key' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--keystore' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--mnemonic' ]]; then
+        ACCOUNT_INJECTION_OPTION="$option"
+    elif [[ $option = '--keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--no-keep-code' ]]; then
+        KEEP_CODE_OPTION="$option"
+    elif [[ $option = '--keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
+    elif [[ $option = '--no-keep-data' ]]; then
+        KEEP_DATA_OPTION="$option"
+    elif [[ $option = '--full-sync' ]]; then
+        SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--fast-sync' ]]; then
+        SYNC_MODE_OPTION="$option"
+    elif [[ $option = '--chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--no-chown-data' ]]; then
+        CHOWN_DATA_OPTION="$option"
+    elif [[ $option = '--json-rpc' ]]; then
+        JSON_RPC_OPTION="$option"
+    elif [[ $option = '--update-front-db' ]]; then
+        UPDATE_FRONT_DB_OPTION="$option"
+    elif [[ $option = '--rest-func' ]]; then
+        REST_FUNC_OPTION="$option"
+    elif [[ $option = '--event-handler' ]]; then
+        EVENT_HANDLER_OPTION="$option"
+    else
+        printf "Invalid option: $option\n"
+        exit
+    fi
+}
+
+# Parse options.
+SEASON="$1"
+GCP_USER="$2"
+
+number_re='^[0-9]+$'
+if ! [[ $3 =~ $number_re ]] ; then
+    printf "Invalid <Shard Index> argument: $3\n"
+    exit
+fi
+SHARD_INDEX="$3"
+
+if ! [[ $4 =~ $number_re ]] ; then
+    printf "Invalid <Node Index> argument: $4\n"
+    exit
+fi
+if [[ "$4" -lt 0 ]] || [[ "$4" -gt 9 ]]; then
+    printf "Invalid <Node Index> argument: $4\n"
+    exit
+fi
+NODE_INDEX="$4"
+
+ACCOUNT_INJECTION_OPTION="--private-key"
+KEEP_CODE_OPTION="--keep-code"
+KEEP_DATA_OPTION="--keep-data"
+SYNC_MODE_OPTION="--fast-sync"
+CHOWN_DATA_OPTION="--no-chown-data"
+JSON_RPC_OPTION=""
+UPDATE_FRONT_DB_OPTION=""
+REST_FUNC_OPTION=""
+EVENT_HANDLER_OPTION=""
+
+ARG_INDEX=5
+while [ $ARG_INDEX -le $# ]; do
+  parse_options "${!ARG_INDEX}"
+  ((ARG_INDEX++))
+done
+
+printf "SEASON=$SEASON\n"
+printf "GCP_USER=$GCP_USER\n"
+printf "SHARD_INDEX=$SHARD_INDEX\n"
+printf "NODE_INDEX=$NODE_INDEX\n"
+printf "\n"
+
+printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
+printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"
+printf "KEEP_DATA_OPTION=$KEEP_DATA_OPTION\n"
+printf "SYNC_MODE_OPTION=$SYNC_MODE_OPTION\n"
+printf "CHOWN_DATA_OPTION=$CHOWN_DATA_OPTION\n"
+printf "JSON_RPC_OPTION=$JSON_RPC_OPTION\n"
+printf "UPDATE_FRONT_DB_OPTION=$UPDATE_FRONT_DB_OPTION\n"
+printf "REST_FUNC_OPTION=$REST_FUNC_OPTION\n"
+printf "EVENT_HANDLER_OPTION=$EVENT_HANDLER_OPTION\n"
+
+# Peer-whitelisting-enabled blockchain nodes
+# Peer whitelisting is disabled now with 5 core blockchain nodes on GCP.
+#PEER_WHITELIST_NODE_INDEX_GE=0
+#PEER_WHITELIST_NODE_INDEX_LE=4
+PEER_WHITELIST_NODE_INDEX_GE=-1
+PEER_WHITELIST_NODE_INDEX_LE=-1
+
+printf "\n"
+printf "PEER_WHITELIST_NODE_INDEX_GE=$PEER_WHITELIST_NODE_INDEX_GE\n"
+printf "PEER_WHITELIST_NODE_INDEX_LE=$PEER_WHITELIST_NODE_INDEX_LE\n"
+
+if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
+    printf "Must provide an ACCOUNT_INJECTION_OPTION\n"
+    exit
+fi
+
+# 1. Configure env vars (BLOCKCHAIN_CONFIGS_DIR, TRACKER_UPDATE_JSON_RPC_URL, ...)
+printf "\n#### [Step 1] Configure env vars ####\n\n"
+
+if [[ $SEASON = 'mainnet' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/mainnet-prod
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x000C63907F7Aeca56A72F5a4F7cd00EfFCF11c3A,0x001C3C9C4a5669eCD8b78946f6fa5549b33362F8,0x002C76f0aeA9Ba615428d9dF7fedEC6f8ed5369f,0x003C9d091584fEC96bC3bD8423c884680BEAaf4E,0x004C4328B6c2ABF7c4Df897a8124b36E3f00a2FC,0x005C99Db64845e5BF24cd152b22c932989479907,0x006C672861e9DBb09232307c17Be6554BC90687c,0x007C36bf5D0F77836eE138EEAc8df7051b43209b,0x008C287187a5626D0a25DbD67327B36AC55B998E,0x009C66DBce144003f8C4B859fFFce78F80fDD639"
+    fi
+elif [[ $SEASON = 'summer' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-prod
+    export TRACKER_UPDATE_JSON_RPC_URL="http://35.194.172.106:8080/json-rpc"
+    export PEER_CANDIDATE_JSON_RPC_URL="http://35.194.169.78:8080/json-rpc"
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x000AF024FEDb636294867bEff390bCE6ef9C5fc4,0x001Ac309EFFFF6d307CbC2d09C811aCD7dD8A35d,0x002A273ECd3aAEc4d8748f4E06eAdE3b34d83211,0x003AD6FdB06684175e7D95EcC36758B014517E4b,0x004A2550661c8a306207C9dabb279d5701fFD66e,0x005A3c55EcE1A593b761D408B6E6BC778E0a638B,0x006Af719E197bC81BBb75d2fec7Ea217D1750bAe,0x007Ac58EAc5F0D0bDd10Af8b90799BcF849c2E74,0x008AeBc041B7ceABc53A4cf393ccF16c10c29dba,0x009A97c0cF07fdbbcdA1197aE11792258b6EcedD"
+    fi
+elif [[ $SEASON = 'spring' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-prod
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x000AF024FEDb636294867bEff390bCE6ef9C5fc4,0x001Ac309EFFFF6d307CbC2d09C811aCD7dD8A35d,0x002A273ECd3aAEc4d8748f4E06eAdE3b34d83211,0x003AD6FdB06684175e7D95EcC36758B014517E4b,0x004A2550661c8a306207C9dabb279d5701fFD66e,0x005A3c55EcE1A593b761D408B6E6BC778E0a638B,0x006Af719E197bC81BBb75d2fec7Ea217D1750bAe,0x007Ac58EAc5F0D0bDd10Af8b90799BcF849c2E74,0x008AeBc041B7ceABc53A4cf393ccF16c10c29dba,0x009A97c0cF07fdbbcdA1197aE11792258b6EcedD"
+    fi
+elif [[ "$SEASON" = "sandbox" ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-sandbox
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x00ADEc28B6a845a085e03591bE7550dd68673C1C,0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204,0x02A2A1DF4f630d760c82BE07F18e5065d103Fa00,0x03AAb7b6f16A92A1dfe018Fe34ee420eb098B98A,0x04A456C92A880cd59D7145C457475515a6f6E0f2,0x05A1247A7400f0C2A893611adD1505743552c631,0x06AD9C8F611f1e9d9CACD4738167A51aA2e80a1A,0x07A43138CC760C85A5B1F115aa60eADEaa0bf417,0x08Aed7AF9354435c38d52143EE50ac839D20696b,0x09A0d53FDf1c36A131938eb379b98910e55EEfe1"
+    fi
+    # NOTE(platfowner): For non-api-servers, the value in the blockchain configs
+    # (https://sandbox-api.ainetwork.ai/json-rpc) is used.
+elif [[ $SEASON = 'staging' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-staging
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x00ADEc28B6a845a085e03591bE7550dd68673C1C,0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204,0x02A2A1DF4f630d760c82BE07F18e5065d103Fa00,0x03AAb7b6f16A92A1dfe018Fe34ee420eb098B98A,0x04A456C92A880cd59D7145C457475515a6f6E0f2,0x05A1247A7400f0C2A893611adD1505743552c631,0x06AD9C8F611f1e9d9CACD4738167A51aA2e80a1A,0x07A43138CC760C85A5B1F115aa60eADEaa0bf417,0x08Aed7AF9354435c38d52143EE50ac839D20696b,0x09A0d53FDf1c36A131938eb379b98910e55EEfe1"
+    fi
+    # NOTE(platfowner): For non-api-servers, the value in the blockchain configs
+    # (https://staging-api.ainetwork.ai/json-rpc) is used.
+elif [[ $SEASON = 'exp' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-exp
+    if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+        export PEER_WHITELIST="0x00ADEc28B6a845a085e03591bE7550dd68673C1C,0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204,0x02A2A1DF4f630d760c82BE07F18e5065d103Fa00,0x03AAb7b6f16A92A1dfe018Fe34ee420eb098B98A,0x04A456C92A880cd59D7145C457475515a6f6E0f2,0x05A1247A7400f0C2A893611adD1505743552c631,0x06AD9C8F611f1e9d9CACD4738167A51aA2e80a1A,0x07A43138CC760C85A5B1F115aa60eADEaa0bf417,0x08Aed7AF9354435c38d52143EE50ac839D20696b,0x09A0d53FDf1c36A131938eb379b98910e55EEfe1"
+    fi
+    # NOTE(platfowner): For non-api-servers, the value in the blockchain configs
+    # (https://exp-api.ainetwork.ai/json-rpc) is used.
+elif [[ $SEASON = 'dev' ]]; then
+    export BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/testnet-dev
+    if [[ $SHARD_INDEX = 0 ]]; then
+        if [[ $NODE_INDEX -ge $PEER_WHITELIST_NODE_INDEX_GE ]] && [[ $NODE_INDEX -le $PEER_WHITELIST_NODE_INDEX_LE ]]; then
+            export PEER_WHITELIST="0x00ADEc28B6a845a085e03591bE7550dd68673C1C,0x01A0980d2D4e418c7F27e1ef539d01A5b5E93204,0x02A2A1DF4f630d760c82BE07F18e5065d103Fa00,0x03AAb7b6f16A92A1dfe018Fe34ee420eb098B98A,0x04A456C92A880cd59D7145C457475515a6f6E0f2,0x05A1247A7400f0C2A893611adD1505743552c631,0x06AD9C8F611f1e9d9CACD4738167A51aA2e80a1A,0x07A43138CC760C85A5B1F115aa60eADEaa0bf417,0x08Aed7AF9354435c38d52143EE50ac839D20696b,0x09A0d53FDf1c36A131938eb379b98910e55EEfe1"
+        fi
+        # NOTE(platfowner): For non-api-servers, the value in the blockchain configs
+        # (https://dev-api.ainetwork.ai/json-rpc) is used.
+    elif [[ $SHARD_INDEX = 1 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.187.153.22:8080/json-rpc"  # dev-shard-1-tracker-ip
+    elif [[ $SHARD_INDEX = 2 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.203.104:8080/json-rpc"  # dev-shard-2-tracker-ip
+    elif [[ $SHARD_INDEX = 3 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.189.174.17:8080/json-rpc"  # dev-shard-3-tracker-ip
+    elif [[ $SHARD_INDEX = 4 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.221.164.158:8080/json-rpc"  # dev-shard-4-tracker-ip
+    elif [[ $SHARD_INDEX = 5 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.234.46.65:8080/json-rpc"  # dev-shard-5-tracker-ip
+    elif [[ $SHARD_INDEX = 6 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.221.210.171:8080/json-rpc"  # dev-shard-6-tracker-ip
+    elif [[ $SHARD_INDEX = 7 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.222.121:8080/json-rpc"  # dev-shard-7-tracker-ip
+    elif [[ $SHARD_INDEX = 8 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.221.200.95:8080/json-rpc"  # dev-shard-8-tracker-ip
+    elif [[ $SHARD_INDEX = 9 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.216.199:8080/json-rpc"  # dev-shard-9-tracker-ip
+    elif [[ $SHARD_INDEX = 10 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.161.85:8080/json-rpc"  # dev-shard-10-tracker-ip
+    elif [[ $SHARD_INDEX = 11 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.194.239.169:8080/json-rpc"  # dev-shard-11-tracker-ip
+    elif [[ $SHARD_INDEX = 12 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.185.156.22:8080/json-rpc"  # dev-shard-12-tracker-ip
+    elif [[ $SHARD_INDEX = 13 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.229.247.143:8080/json-rpc"  # dev-shard-13-tracker-ip
+    elif [[ $SHARD_INDEX = 14 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.229.226.47:8080/json-rpc"  # dev-shard-14-tracker-ip
+    elif [[ $SHARD_INDEX = 15 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.234.61.23:8080/json-rpc"  # dev-shard-15-tracker-ip
+    elif [[ $SHARD_INDEX = 16 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.66.41:8080/json-rpc"  # dev-shard-16-tracker-ip
+    elif [[ $SHARD_INDEX = 17 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.229.143.18:8080/json-rpc"  # dev-shard-17-tracker-ip
+    elif [[ $SHARD_INDEX = 18 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.234.58.137:8080/json-rpc"  # dev-shard-18-tracker-ip
+    elif [[ $SHARD_INDEX = 19 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://34.80.249.104:8080/json-rpc"  # dev-shard-19-tracker-ip
+    elif [[ $SHARD_INDEX = 20 ]]; then
+        export TRACKER_UPDATE_JSON_RPC_URL="http://35.201.248.92:8080/json-rpc"  # dev-shard-20-tracker-ip
+    else
+        printf "Invalid <Shard Index> argument: $SHARD_INDEX\n"
+        exit
+    fi
+    if [[ $SHARD_INDEX -gt 0 ]]; then
+        # Create a blockchain_params.json
+        export BLOCKCHAIN_CONFIGS_DIR="blockchain-configs/shard_$SHARD_INDEX"
+        mkdir -p "./$BLOCKCHAIN_CONFIGS_DIR"
+        node > "./$BLOCKCHAIN_CONFIGS_DIR/blockchain_params.json" <<EOF
+        const data = require('./$BLOCKCHAIN_CONFIGS_DIR/blockchain_params.json');
+        data.blockchain.TRACKER_UPDATE_JSON_RPC_URL = '$TRACKER_UPDATE_JSON_RPC_URL';
+        console.log(JSON.stringify(data, null, 2));
+EOF
+    fi
+else
+    printf "Invalid <Project/Season> argument: $SEASON\n"
+    exit
+fi
+
+printf "TRACKER_UPDATE_JSON_RPC_URL=$TRACKER_UPDATE_JSON_RPC_URL\n"
+printf "BLOCKCHAIN_CONFIGS_DIR=$BLOCKCHAIN_CONFIGS_DIR\n"
+printf "PEER_CANDIDATE_JSON_RPC_URL=$PEER_CANDIDATE_JSON_RPC_URL\n"
+printf "PEER_WHITELIST=$PEER_WHITELIST\n"
+
+# NOTE(liayoo): Currently this script supports [--keystore|--mnemonic] option only for the parent chain.
+if [[ $ACCOUNT_INJECTION_OPTION != "--private_key" ]] && [[ "$SHARD_INDEX" -gt 0 ]]; then
+    printf 'Invalid account injection option\n'
+    return 1
+fi
+
+if [[ "$ACCOUNT_INJECTION_OPTION" = "" ]]; then
+    printf "Must provide an ACCOUNT_INJECTION_OPTION\n"
+    return 1
+fi
+
+if [[ $ACCOUNT_INJECTION_OPTION = "--keystore" ]]; then
+    export ACCOUNT_INJECTION_OPTION=keystore
+elif [[ $ACCOUNT_INJECTION_OPTION = "--mnemonic" ]]; then
+    export ACCOUNT_INJECTION_OPTION=mnemonic
+else
+    export ACCOUNT_INJECTION_OPTION=private_key
+fi
+if [[ $SYNC_MODE_OPTION = "--full-sync" ]]; then
+    export SYNC_MODE=full
+else
+    export SYNC_MODE=fast
+fi
+if [[ $SEASON = "staging" ]]; then
+    # for performance test pipeline
+    export ENABLE_EXPRESS_RATE_LIMIT=false
+else
+    export ENABLE_EXPRESS_RATE_LIMIT=true
+fi
+if [[ $JSON_RPC_OPTION ]]; then
+    export ENABLE_JSON_RPC_API=true
+else
+    export ENABLE_JSON_RPC_API=false
+fi
+if [[ $UPDATE_FRONT_DB_OPTION ]]; then
+    export UPDATE_NEW_FINAL_FRONT_DB_WITH_TX_POOL=true
+else
+    export UPDATE_NEW_FINAL_FRONT_DB_WITH_TX_POOL=false
+fi
+if [[ $REST_FUNC_OPTION ]]; then
+    export ENABLE_REST_FUNCTION_CALL=true
+else
+    export ENABLE_REST_FUNCTION_CALL=false
+fi
+if [[ $EVENT_HANDLER_OPTION ]]; then
+    export ENABLE_EVENT_HANDLER=true
+else
+    export ENABLE_EVENT_HANDLER=false
+fi
+
+# NOTE(liayoo): Currently this script supports [--keystore|--mnemonic] option only for the parent chain.
+if [[ $ACCOUNT_INJECTION_OPTION != "private_key" ]] && [[ "$SHARD_INDEX" -gt 0 ]]; then
+    printf 'Invalid account injection option\n'
+    exit
+fi
+
+# 2. Get currently used directory & new directory
+printf "\n#### [Step 2] Get currently used directory & new directory ####\n\n"
+
+OLD_DIR_PATH=$(find /home/ain-blockchain* -maxdepth 0 -type d)
+printf "OLD_DIR_PATH=$OLD_DIR_PATH\n"
+
+date=$(date '+%Y-%m-%dT%H-%M')
+printf "date=$date\n"
+NEW_DIR_NAME="ain-blockchain-$date"
+printf "NEW_DIR_NAME=$NEW_DIR_NAME\n"
+NEW_DIR_PATH="/home/$NEW_DIR_NAME"
+printf "NEW_DIR_PATH=$NEW_DIR_PATH\n"
+
+# 3. Set up working directory & install modules
+printf "\n#### [Step 3] Set up working directory & install modules ####\n\n"
+if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+    printf '\n'
+    printf 'Setting up new working directory..\n'
+    CODE_CMD="cd ~; sudo mv ain-blockchain $NEW_DIR_NAME; sudo mv $NEW_DIR_NAME /home; sudo chmod -R 777 $NEW_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $NEW_DIR_PATH"
+    printf "\nCODE_CMD=$CODE_CMD\n"
+    eval $CODE_CMD
+
+    printf '\n'
+    printf 'Installing node modules..\n'
+    cd $NEW_DIR_PATH
+    INSTALL_CMD="yarn install --ignore-engines"
+    printf "\nINSTALL_CMD=$INSTALL_CMD\n"
+    eval $INSTALL_CMD
+else
+    printf '\n'
+    printf 'Reusing existing working directory..\n'
+    CODE_CMD="sudo chmod -R 777 $OLD_DIR_PATH; sudo chown -R $GCP_USER:$GCP_USER $OLD_DIR_PATH"
+    printf "\nCODE_CMD=$CODE_CMD\n"
+    eval $CODE_CMD
+fi
+
+# 4. Kill old node server
+printf "\n#### [Step 4] Kill old node server ####\n\n"
+
+KILL_CMD="sudo killall node"
+printf "KILL_CMD=$KILL_CMD\n\n"
+eval $KILL_CMD
+sleep 10
+
+# 5. Set up data directory
+printf "\n#### [Step 5] Set up data directory ####\n\n"
+if [[ $KEEP_DATA_OPTION = "--no-keep-data" ]]; then
+    printf '\n'
+    printf 'Setting up new data directory..\n'
+    sudo rm -rf /home/ain_blockchain_data/chains
+    sudo rm -rf /home/ain_blockchain_data/snapshots
+    sudo rm -rf /home/ain_blockchain_data/logs
+    DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    printf "\nDATA_CMD=$DATA_CMD\n"
+    eval $DATA_CMD
+else
+    printf '\n'
+    printf 'Reusing existing data directory..\n'
+    if [[ $CHOWN_DATA_OPTION = "--no-chown-data" ]]; then
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod 777 /home/ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    else
+        DATA_CMD="sudo mkdir -p /home/ain_blockchain_data; sudo chmod -R 777 /home/ain_blockchain_data; sudo chown -R $GCP_USER:$GCP_USER /home/ain_blockchain_data"
+    fi
+    printf "\nDATA_CMD=$DATA_CMD\n"
+    eval $DATA_CMD
+fi
+
+# 6. Remove old working directory keeping the chain data
+printf "\n#### [Step 6] Remove old working directory if necessary ####\n\n"
+if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
+    printf '\n'
+    printf 'Removing old working directory..\n'
+    RM_CMD="sudo rm -rf $OLD_DIR_PATH"
+    printf "\nRM_CMD=$RM_CMD\n"
+    eval $RM_CMD
+else
+    printf '\n'
+    printf 'Keeping existing working directory..\n'
+fi
+
+# 7. Start a new node server
+printf "\n#### [Step 7] Start new node server ####\n\n"
+
+export STAKE=100000
+printf "STAKE=$STAKE\n"
+export LOG_BANDAGE_INFO=true
+printf "LOG_BANDAGE_INFO=$LOG_BANDAGE_INFO\n"
+
+if [[ "$SEASON" = "sandbox" ]]; then
+    MAX_OLD_SPACE_SIZE_MB=11000
+else
+    MAX_OLD_SPACE_SIZE_MB=55000
+fi
+
+START_CMD="nohup node --async-stack-traces --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB client/index.js >/dev/null 2>error_logs.txt &"
+printf "\nSTART_CMD=$START_CMD\n"
+printf "START_CMD=$START_CMD\n" >> start_commands.txt
+eval $START_CMD
+
+# NOTE(platfowner): deploy_blockchain_incremental_gcp.sh waits until the new server gets healthy.
+
+printf "\n* << Node server [$SEASON $SHARD_INDEX $NODE_INDEX] successfully deployed! ***************************************\n\n"

--- a/wait_until_node_sync.sh
+++ b/wait_until_node_sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-printf "\n[[[[[ wait_until_node_sync_gcp.sh ]]]]]\n\n"
+printf "\n[[[[[ wait_until_node_sync.sh ]]]]]\n\n"
 
 printf "\n#### Wait until the new node server catches up ####\n\n"
 


### PR DESCRIPTION
Change summary:
- Add incremental blockchain deploy scripts for onprem machines
- Use pkill instead of killall for onprem jobs
- Install killall explicitly for higher ubuntu versions
- Remove duplicated parts for job killing
- Remove duplicated parts of data removal 
- Rename: wait_until_node_sync.sh

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1285