### PR TITLE
Support --kill-only option in incremental deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can override default port numbering system by setting `PORT` and `P2P_PORT` 
 ```
 gcloud init
 # For genesis deploy
-bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]
+bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-job|--kill-only]
 # For incremental deploy
 bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]
 ```
@@ -130,7 +130,7 @@ BLOCKCHAIN_CONFIGS_DIR=blockchain-configs/afan-shard MIN_NUM_VALIDATORS=1 DEBUG=
 ```
 gcloud init
 # For genesis deploy
-bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]
+bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-job|--kill-only]
 # For incremental deploy
 bash deploy_blockchain_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data]
 ```

--- a/copy_blockchain_data_gcp.sh
+++ b/copy_blockchain_data_gcp.sh
@@ -146,7 +146,7 @@ function upload_data() {
 
     # 2. Extract tgz file for node
     printf "\n\n<<< Extracting tgz file for node $node_index >>>\n\n"
-    TGZ_CMD="gcloud compute ssh $node_target_addr --command 'cd /home; sudo mkdir -p ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER ain_blockchain_data; sudo chmod 777 ain_blockchain_data; cd ain_blockchain_data; gzip -dc ~/ain_blockchain_data.tar.gz | tar xvf -' --project $PROJECT_ID --zone $node_zone"
+    TGZ_CMD="gcloud compute ssh $node_target_addr --command 'cd /home; sudo mkdir -p ain_blockchain_data; sudo chown $GCP_USER:$GCP_USER ain_blockchain_data; sudo chmod 777 ain_blockchain_data; cd ain_blockchain_data; sudo rm -rf chains snapshots; gzip -dc ~/ain_blockchain_data.tar.gz | tar xvf -' --project $PROJECT_ID --zone $node_zone"
     printf "TGZ_CMD=$TGZ_CMD\n\n"
     eval $TGZ_CMD
 

--- a/copy_blockchain_data_onprem.sh
+++ b/copy_blockchain_data_onprem.sh
@@ -115,7 +115,7 @@ function upload_data() {
 
     # 2. Extract tgz file for node
     printf "\n\n<<< Extracting tgz file for node $node_index >>>\n\n"
-    TGZ_CMD="ssh $node_target_addr 'sudo -S ls -la; cd /home; sudo mkdir -p ${SEASON}/ain_blockchain_data; sudo chown $ONPREM_USER:$ONPREM_USER ${SEASON} ${SEASON}/ain_blockchain_data; sudo chmod 777 ${SEASON} ${SEASON}/ain_blockchain_data; cd ${SEASON}/ain_blockchain_data; gzip -dc ~/ain_blockchain_data.tar.gz | tar xvf -'"
+    TGZ_CMD="ssh $node_target_addr 'sudo -S ls -la; cd /home; sudo mkdir -p ${SEASON}/ain_blockchain_data; sudo chown $ONPREM_USER:$ONPREM_USER ${SEASON} ${SEASON}/ain_blockchain_data; sudo chmod 777 ${SEASON} ${SEASON}/ain_blockchain_data; cd ${SEASON}/ain_blockchain_data; sudo rm -rf chains snapshots; gzip -dc ~/ain_blockchain_data.tar.gz | tar xvf -'"
     printf "TGZ_CMD=$TGZ_CMD\n\n"
     eval "echo ${node_login_pw} | sshpass -f <(printf '%s\n' ${node_login_pw}) ${TGZ_CMD}"
 

--- a/deploy_blockchain_genesis_gcp.sh
+++ b/deploy_blockchain_genesis_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 10 ]]; then
-    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]\n"
+    printf "Usage: bash deploy_blockchain_genesis_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-job|--kill-only]\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev 0 -1  4 --keystore --no-keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev 0  0  0 --keystore --keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_gcp.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
@@ -72,17 +72,9 @@ function parse_options() {
         CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--no-chown-data' ]]; then
         CHOWN_DATA_OPTION="$option"
-    elif [[ $option = '--kill-only' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-job' ]]; then
         KILL_OPTION="$option"
-    elif [[ $option = '--skip-kill' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-only' ]]; then
         KILL_OPTION="$option"
     else
         printf "Invalid options: $option\n"
@@ -97,7 +89,7 @@ KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
 CHOWN_DATA_OPTION="--no-chown-data"
-KILL_OPTION=""
+KILL_OPTION="--kill-job"
 
 ARG_INDEX=5
 while [ $ARG_INDEX -le $# ]; do
@@ -326,47 +318,43 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     fi
 fi
 
-if [[ $KILL_OPTION = "--skip-kill" ]]; then
-    printf "\nSkipping process kill...\n"
-else
-    # kill any processes still alive
-    printf "\nKilling tracker / blockchain node jobs...\n"
+# kill any processes still alive
+printf "\nKilling tracker / blockchain node jobs...\n"
 
-    # Tracker server is killed with PARENT_NODE_INDEX_BEGIN = -1
-    if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
-        printf "\n* >> Killing tracker job (${TRACKER_TARGET_ADDR}) *********************************************************\n\n"
-        gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $TRACKER_ZONE
-    fi
+# Tracker server is killed with PARENT_NODE_INDEX_BEGIN = -1
+if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
+    printf "\n* >> Killing tracker job (${TRACKER_TARGET_ADDR}) *********************************************************\n\n"
+    gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $TRACKER_ZONE
+fi
 
-    begin_index=$PARENT_NODE_INDEX_BEGIN
-    if [[ $begin_index -lt 0 ]]; then
-      begin_index=0
-    fi
-    if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -ge 0 ]]; then
-        for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
-            NODE_TARGET_ADDR=NODE_${node_index}_TARGET_ADDR
-            NODE_ZONE=NODE_${node_index}_ZONE
+begin_index=$PARENT_NODE_INDEX_BEGIN
+if [[ $begin_index -lt 0 ]]; then
+    begin_index=0
+fi
+if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -ge 0 ]]; then
+    for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
+        NODE_TARGET_ADDR=NODE_${node_index}_TARGET_ADDR
+        NODE_ZONE=NODE_${node_index}_ZONE
 
-            printf "\n* >> Killing node $node_index job (${!NODE_TARGET_ADDR}) *********************************************************\n\n"
-            gcloud compute ssh ${!NODE_TARGET_ADDR} --command "sudo killall node" --project $PROJECT_ID --zone ${!NODE_ZONE}
-        done
-    fi
+        printf "\n* >> Killing node $node_index job (${!NODE_TARGET_ADDR}) *********************************************************\n\n"
+        gcloud compute ssh ${!NODE_TARGET_ADDR} --command "sudo killall node" --project $PROJECT_ID --zone ${!NODE_ZONE}
+    done
+fi
 
-    if [[ $NUM_SHARDS -gt 0 ]]; then
-        for i in $(seq $NUM_SHARDS); do
-            printf "shard #$i\n"
+if [[ $NUM_SHARDS -gt 0 ]]; then
+    for i in $(seq $NUM_SHARDS); do
+        printf "shard #$i\n"
 
-            SHARD_TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-tracker-taiwan"
-            SHARD_NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-0-taiwan"
-            SHARD_NODE_1_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-1-oregon"
-            SHARD_NODE_2_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-2-singapore"
+        SHARD_TRACKER_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-tracker-taiwan"
+        SHARD_NODE_0_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-0-taiwan"
+        SHARD_NODE_1_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-1-oregon"
+        SHARD_NODE_2_TARGET_ADDR="${GCP_USER}@${SEASON}-shard-${i}-node-2-singapore"
 
-            gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $TRACKER_ZONE
-            gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_0_ZONE
-            gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_1_ZONE
-            gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_2_ZONE
-        done
-    fi
+        gcloud compute ssh $SHARD_TRACKER_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $TRACKER_ZONE
+        gcloud compute ssh $SHARD_NODE_0_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_0_ZONE
+        gcloud compute ssh $SHARD_NODE_1_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_1_ZONE
+        gcloud compute ssh $SHARD_NODE_2_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $NODE_2_ZONE
+    done
 fi
 
 # If --kill-only, do not proceed any further

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 10 ]]; then
-    printf "Usage: bash deploy_blockchain_genesis_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]\n"
+    printf "Usage: bash deploy_blockchain_genesis_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <# of Shards> <Parent Node Index Begin> <Parent Node Index End> [--setup] [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--kill-job|--kill-only]\n"
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0 -1  4 --keystore --no-keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0  0  0 --keystore --keep-code\n"
     printf "Example: bash deploy_blockchain_genesis_onprem.sh dev 0 -1 -1 --setup --keystore --no-keep-code\n"
@@ -62,17 +62,9 @@ function parse_options() {
         CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--no-chown-data' ]]; then
         CHOWN_DATA_OPTION="$option"
-    elif [[ $option = '--kill-only' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-job' ]]; then
         KILL_OPTION="$option"
-    elif [[ $option = '--skip-kill' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-only' ]]; then
         KILL_OPTION="$option"
     else
         printf "Invalid options: $option\n"
@@ -87,7 +79,7 @@ KEEP_CODE_OPTION="--keep-code"
 KEEP_DATA_OPTION="--keep-data"
 SYNC_MODE_OPTION="--fast-sync"
 CHOWN_DATA_OPTION="--no-chown-data"
-KILL_OPTION=""
+KILL_OPTION="--kill-job"
 
 ARG_INDEX=5
 while [ $ARG_INDEX -le $# ]; do
@@ -218,7 +210,7 @@ function inject_account() {
 }
 
 # deploy files
-#FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_gcp.sh start_tracker_incremental_gcp.sh"
+#FILES_FOR_TRACKER="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ logger/ tracker-server/ traffic/ package.json setup_blockchain_ubuntu_onprem.sh start_tracker_genesis_onprem.sh start_tracker_incremental_onprem.sh"
 FILES_FOR_NODE="blockchain/ blockchain-configs/ block-pool/ client/ common/ consensus/ db/ event-handler/ json_rpc/ logger/ node/ p2p/ tools/ traffic/ tx-pool/ package.json setup_blockchain_ubuntu_onprem.sh start_node_genesis_onprem.sh start_node_incremental_onprem.sh wait_until_node_sync.sh stop_local_blockchain.sh"
 
 printf "###############################################################################\n"
@@ -300,11 +292,8 @@ if [[ $KEEP_CODE_OPTION = "--no-keep-code" ]]; then
     fi
 fi
 
-if [[ $KILL_OPTION = "--skip-kill" ]]; then
-    printf "\n\nSkipping process kill...\n"
-else
-    # kill any processes still alive
-    printf "\n\nKilling tracker / blockchain node jobs...\n"
+# kill any processes still alive
+printf "\n\nKilling tracker / blockchain node jobs...\n"
 
 #    # Tracker server is killed with PARENT_NODE_INDEX_BEGIN = -1
 #    if [[ $PARENT_NODE_INDEX_BEGIN = -1 ]]; then
@@ -312,20 +301,19 @@ else
 #        gcloud compute ssh $TRACKER_TARGET_ADDR --command "sudo killall node" --project $PROJECT_ID --zone $TRACKER_ZONE
 #    fi
 
-    begin_index=$PARENT_NODE_INDEX_BEGIN
-    if [[ $begin_index -lt 0 ]]; then
-      begin_index=0
-    fi
-    if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -ge 0 ]]; then
-        for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
-            NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
-            NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
+begin_index=$PARENT_NODE_INDEX_BEGIN
+if [[ $begin_index -lt 0 ]]; then
+    begin_index=0
+fi
+if [[ $begin_index -le $PARENT_NODE_INDEX_END ]] && [[ $PARENT_NODE_INDEX_END -ge 0 ]]; then
+    for node_index in `seq $(( $begin_index )) $(( $PARENT_NODE_INDEX_END ))`; do
+        NODE_TARGET_ADDR="${ONPREM_USER}@${NODE_IP_LIST[${node_index}]}"
+        NODE_LOGIN_PW="${NODE_PW_LIST[${node_index}]}"
 
-            printf "\n* >> Killing node $node_index job (${NODE_TARGET_ADDR}) *********************************************************\n\n"
+        printf "\n* >> Killing node $node_index job (${NODE_TARGET_ADDR}) *********************************************************\n\n"
 
-            echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "sudo -S pkill -f client/${SEASON}-ain-blockchain-index.js"
-        done
-    fi
+        echo ${NODE_LOGIN_PW} | sshpass -f <(printf '%s\n' ${NODE_LOGIN_PW}) ssh ${NODE_TARGET_ADDR} "sudo -S pkill -f client/${SEASON}-ain-blockchain-index.js"
+    done
 fi
 
 # If --kill-only, do not proceed any further
@@ -340,7 +328,7 @@ else
     GO_TO_PROJECT_ROOT_CMD="cd \$(find /home/${SEASON}/ain-blockchain* -maxdepth 0 -type d)"
 fi
 
-#START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_genesis_gcp.sh"
+#START_TRACKER_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_tracker_genesis_onprem.sh"
 START_NODE_CMD_BASE="$GO_TO_PROJECT_ROOT_CMD && . start_node_genesis_onprem.sh"
 printf "\n"
 #printf "START_TRACKER_CMD_BASE=$START_TRACKER_CMD_BASE\n"

--- a/deploy_blockchain_genesis_onprem.sh
+++ b/deploy_blockchain_genesis_onprem.sh
@@ -92,6 +92,11 @@ if [[ $SETUP_OPTION = "--setup" ]] && [[ ! $KEEP_CODE_OPTION = "--no-keep-code" 
     exit
 fi
 
+if [[ $PARENT_NODE_INDEX_BEGIN -lt 0 ]]; then
+    printf "Please use deploy_blockchain_incremental_gcp.sh instead for the tracker job.\n"
+    exit
+fi
+
 printf "SETUP_OPTION=$SETUP_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"

--- a/deploy_blockchain_incremental_onprem.sh
+++ b/deploy_blockchain_incremental_onprem.sh
@@ -91,6 +91,11 @@ if [[ $SETUP_OPTION = "--setup" ]] && [[ ! $KEEP_CODE_OPTION = "--no-keep-code" 
     exit
 fi
 
+if [[ $PARENT_NODE_INDEX_BEGIN -lt 0 ]]; then
+    printf "Please use deploy_blockchain_incremental_gcp.sh instead for the tracker job.\n"
+    exit
+fi
+
 printf "SETUP_OPTION=$SETUP_OPTION\n"
 printf "ACCOUNT_INJECTION_OPTION=$ACCOUNT_INJECTION_OPTION\n"
 printf "KEEP_CODE_OPTION=$KEEP_CODE_OPTION\n"

--- a/deploy_blockchain_sandbox_gcp.sh
+++ b/deploy_blockchain_sandbox_gcp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 2 ]] || [[ $# -gt 7 ]]; then
-    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <# start node> <# end node> [--setup] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--chown-data|--no-chown-data] [--kill-only|--skip-kill]\n"
+    printf "Usage: bash deploy_blockchain_sandbox_gcp.sh <# start node> <# end node> [--setup] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--chown-data|--no-chown-data] [--kill-job|--kill-only]\n"
     printf "Example: bash deploy_blockchain_sandbox_gcp.sh 10 99 --setup --no-chown-data\n"
     printf "\n"
     exit
@@ -44,17 +44,9 @@ function parse_options() {
         CHOWN_DATA_OPTION="$option"
     elif [[ $option = '--no-chown-data' ]]; then
         CHOWN_DATA_OPTION="$option"
-    elif [[ $option = '--kill-only' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-job' ]]; then
         KILL_OPTION="$option"
-    elif [[ $option = '--skip-kill' ]]; then
-        if [[ "$KILL_OPTION" ]]; then
-            printf "You cannot use both --skip-kill and --kill-only\n"
-            exit
-        fi
+    elif [[ $option = '--kill-only' ]]; then
         KILL_OPTION="$option"
     else
         printf "Invalid options: $option\n"
@@ -67,7 +59,7 @@ SETUP_OPTION=""
 KEEP_CODE_OPTION="--no-keep-code"
 KEEP_DATA_OPTION="--no-keep-data"
 CHOWN_DATA_OPTION="--no-chown-data"
-KILL_OPTION=""
+KILL_OPTION="--kill-job"
 
 ARG_INDEX=3
 while [ $ARG_INDEX -le $# ]; do
@@ -326,29 +318,25 @@ spinner() {
     sleep .1
 }
 
-if [[ $KILL_OPTION = "--skip-kill" ]]; then
-    printf "\nSkipping process kill...\n"
-else
-    # kill any processes still alive
-    printf "\nKilling all blockchain nodes...\n"
-    index=$START_NODE_IDX
-    while [ $index -le $END_NODE_IDX ]; do
-        NODE_TARGET_ADDR=NODE_${index}_TARGET_ADDR
-        NODE_ZONE=NODE_${index}_ZONE
+# kill any processes still alive
+printf "\nKilling all blockchain nodes...\n"
+index=$START_NODE_IDX
+while [ $index -le $END_NODE_IDX ]; do
+    NODE_TARGET_ADDR=NODE_${index}_TARGET_ADDR
+    NODE_ZONE=NODE_${index}_ZONE
 
-        KILL_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command 'sudo killall node' --project $PROJECT_ID --zone ${!NODE_ZONE}"
-        # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
-        # printf "KILL_NODE_CMD=$KILL_NODE_CMD\n"
-        if [[ $index < "$(($NUM_NODES - 1))" ]]; then
-            eval $KILL_NODE_CMD &> /dev/null &
-        else
-            eval $KILL_NODE_CMD &> /dev/null
-        fi
-        ((index++))
-        spinner
-    done
-    printf "Kill all processes done.\n\n";
-fi
+    KILL_NODE_CMD="gcloud compute ssh ${!NODE_TARGET_ADDR} --command 'sudo killall node' --project $PROJECT_ID --zone ${!NODE_ZONE}"
+    # NOTE(minsulee2): Keep printf for extensibility experiment debugging purpose
+    # printf "KILL_NODE_CMD=$KILL_NODE_CMD\n"
+    if [[ $index < "$(($NUM_NODES - 1))" ]]; then
+        eval $KILL_NODE_CMD &> /dev/null &
+    else
+        eval $KILL_NODE_CMD &> /dev/null
+    fi
+    ((index++))
+    spinner
+done
+printf "Kill all processes done.\n\n";
 
 # If --kill-only, do not proceed any further
 if [[ $KILL_OPTION = "--kill-only" ]]; then

--- a/start_node_incremental_gcp.sh
+++ b/start_node_incremental_gcp.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 13 ]]; then
-    printf "Usage: bash start_node_incremental_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
-    printf "Example: bash start_node_incremental_onprem.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
+    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
+    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "\n"
     exit
 fi
-printf "\n[[[[[ start_node_incremental_onprem.sh ]]]]]\n\n"
+printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
 
 function parse_options() {
     local option="$1"
@@ -383,6 +383,6 @@ printf "\nSTART_CMD=$START_CMD\n"
 printf "START_CMD=$START_CMD\n" >> start_commands.txt
 eval $START_CMD
 
-# NOTE(platfowner): deploy_blockchain_incremental_onprem.sh waits until the new server gets healthy.
+# NOTE(platfowner): deploy_blockchain_incremental_gcp.sh waits until the new server gets healthy.
 
 printf "\n* << Node server [$SEASON $SHARD_INDEX $NODE_INDEX] successfully deployed! ***************************************\n\n"

--- a/start_node_incremental_onprem.sh
+++ b/start_node_incremental_onprem.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -lt 4 ]] || [[ $# -gt 13 ]]; then
-    printf "Usage: bash start_node_incremental_gcp.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
-    printf "Example: bash start_node_incremental_gcp.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
+    printf "Usage: bash start_node_incremental_onprem.sh [dev|staging|sandbox|exp|spring|summer|mainnet] <GCP Username> <Shard Index> <Node Index> [--keystore|--mnemonic|--private-key] [--keep-code|--no-keep-code] [--keep-data|--no-keep-data] [--full-sync|--fast-sync] [--chown-data|--no-chown-data] [--json-rpc] [--update-front-db] [--rest-func] [--event-handler]\n"
+    printf "Example: bash start_node_incremental_onprem.sh spring gcp_user 0 0 --keystore --no-keep-code --full-sync --no-chown-data\n"
     printf "\n"
     exit
 fi
@@ -15,7 +15,7 @@ printf "\n\n"
 # do sudo once with a dummy command
 echo $NODE_LOGIN_PW | sudo -S ls -la
 
-printf "\n[[[[[ start_node_incremental_gcp.sh ]]]]]\n\n"
+printf "\n[[[[[ start_node_incremental_onprem.sh ]]]]]\n\n"
 
 function parse_options() {
     local option="$1"
@@ -398,6 +398,6 @@ printf "\nSTART_CMD=$START_CMD\n"
 printf "START_CMD=$START_CMD\n" >> start_commands.txt
 eval $START_CMD
 
-# NOTE(platfowner): deploy_blockchain_incremental_gcp.sh waits until the new server gets healthy.
+# NOTE(platfowner): deploy_blockchain_incremental_onprem.sh waits until the new server gets healthy.
 
 printf "\n* << Node server [$SEASON $SHARD_INDEX $NODE_INDEX] successfully deployed! ***************************************\n\n"


### PR DESCRIPTION
Change summary:
- Support --kill-only option in incremental deploy scripts
- Deprecate --skip-kill option
- Remove old chains and snapshots in blockchain data upload 
- Do not allow tracker job starting in onprem deploy scripts

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1285